### PR TITLE
MarshalLoader to match dumper

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -75,7 +75,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.runtime.encoding.EncodingCapable;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.specialized.RubyArrayOneObject;
 import org.jruby.specialized.RubyArraySpecialized;
@@ -5298,7 +5298,7 @@ float_loop:
         }
     }
 
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyArray array, Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyArray array, MarshalDumper output) {
         output.registerLinkTarget(array);
 
         int length = array.realLength;

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -49,7 +49,7 @@ import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CachingCallSite;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
@@ -1179,7 +1179,7 @@ public class RubyBignum extends RubyInteger {
         }
     }
 
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyBignum bignum, Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyBignum bignum, MarshalDumper output) {
         output.registerLinkTarget(bignum);
 
         int b = bignum.value.signum() >= 0 ? '+' : '-';

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -92,7 +92,7 @@ import org.jruby.runtime.callsite.RespondToCallSite;
 import org.jruby.runtime.ivars.VariableAccessor;
 import org.jruby.runtime.ivars.VariableAccessorField;
 import org.jruby.runtime.ivars.VariableTableManager;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.ClassDefiningClassLoader;
@@ -1512,7 +1512,7 @@ public class RubyClass extends RubyModule {
         getMarshal().marshalTo(runtime, obj, this, marshalStream);
     }
 
-    public final void marshal(ThreadContext context, RubyOutputStream out, Object obj, Dumper marshalStream) {
+    public final void marshal(ThreadContext context, RubyOutputStream out, Object obj, MarshalDumper marshalStream) {
         getMarshal().marshalTo(context, out, obj, this, marshalStream);
     }
 
@@ -1534,9 +1534,9 @@ public class RubyClass extends RubyModule {
         output.writeString(org.jruby.runtime.marshal.MarshalStream.getPathFromClass(clazz));
     }
 
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyClass clazz, Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyClass clazz, MarshalDumper output) {
         output.registerLinkTarget(clazz);
-        output.writeString(out, Dumper.getPathFromClass(context, clazz).idString());
+        output.writeString(out, MarshalDumper.getPathFromClass(context, clazz).idString());
     }
 
     @Deprecated(since = "10.0", forRemoval = true)
@@ -1564,7 +1564,7 @@ public class RubyClass extends RubyModule {
         }
 
         @Override
-        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, Dumper marshalStream) {
+        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, MarshalDumper marshalStream) {
             IRubyObject object = (IRubyObject) obj;
 
             marshalStream.registerLinkTarget(object);
@@ -2855,7 +2855,7 @@ public class RubyClass extends RubyModule {
             }
         }
 
-        public void dump(Dumper stream, ThreadContext context, RubyOutputStream out, IRubyObject object) {
+        public void dump(MarshalDumper stream, ThreadContext context, RubyOutputStream out, IRubyObject object) {
             switch (type) {
                 case DEFAULT:
                     stream.writeDirectly(context, out, object);
@@ -2941,7 +2941,7 @@ public class RubyClass extends RubyModule {
         tuple.dump(stream, target);
     }
 
-    public void smartDump(ThreadContext context, RubyOutputStream out, Dumper stream, IRubyObject target) {
+    public void smartDump(ThreadContext context, RubyOutputStream out, MarshalDumper stream, IRubyObject target) {
         MarshalTuple tuple;
         if ((tuple = cachedDumpMarshal).generation == generation) {
         } else {

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -93,7 +93,7 @@ import org.jruby.runtime.ivars.VariableAccessor;
 import org.jruby.runtime.ivars.VariableAccessorField;
 import org.jruby.runtime.ivars.VariableTableManager;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.ClassDefiningClassLoader;
 import org.jruby.util.CodegenUtils;
@@ -101,6 +101,7 @@ import org.jruby.util.JavaNameMangler;
 import org.jruby.util.Loader;
 import org.jruby.util.OneShotClassLoader;
 import org.jruby.util.StringSupport;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -1515,8 +1516,14 @@ public class RubyClass extends RubyModule {
         getMarshal().marshalTo(context, out, obj, this, marshalStream);
     }
 
-    public final Object unmarshal(UnmarshalStream unmarshalStream) throws IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public final Object unmarshal(org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
         return getMarshal().unmarshalFrom(runtime, this, unmarshalStream);
+    }
+
+    public final Object unmarshal(ThreadContext context, RubyInputStream in, MarshalLoader loader) {
+        return getMarshal().unmarshalFrom(context, in, this, loader);
     }
 
     @Deprecated(since = "10.0", forRemoval = true)
@@ -1532,9 +1539,16 @@ public class RubyClass extends RubyModule {
         output.writeString(out, Dumper.getPathFromClass(context, clazz).idString());
     }
 
-    public static RubyClass unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubyClass unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         String name = RubyString.byteListToString(input.unmarshalString());
-        return UnmarshalStream.getClassFromPath(input.getRuntime(), name);
+        return org.jruby.runtime.marshal.UnmarshalStream.getClassFromPath(input.getRuntime(), name);
+    }
+
+    public static RubyClass unmarshalFrom(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        String name = RubyString.byteListToString(input.unmarshalString(context, in));
+        return MarshalLoader.getClassFromPath(context, name);
     }
 
     protected static final ObjectMarshal DEFAULT_OBJECT_MARSHAL = new ObjectMarshal() {
@@ -1558,10 +1572,21 @@ public class RubyClass extends RubyModule {
         }
 
         @Override
-        public Object unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream input) throws IOException {
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
+        public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             IRubyObject result = input.entry(type.allocate(runtime.getCurrentContext()));
 
             input.ivar(null, result, null);
+
+            return result;
+        }
+
+        @Override
+        public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader input) {
+            IRubyObject result = input.entry(type.allocate(context));
+
+            input.ivar(context, in, null, result, null);
 
             return result;
         }

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -42,10 +42,11 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
 import org.jruby.util.TypeConverter;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import java.io.IOException;
@@ -1179,9 +1180,21 @@ public class RubyComplex extends RubyNumeric {
         }
 
         @Override
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type,
-                                    UnmarshalStream unmarshalStream) throws IOException {
+                                    org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
             RubyComplex c = (RubyComplex)RubyClass.DEFAULT_OBJECT_MARSHAL.unmarshalFrom(runtime, type, unmarshalStream);
+            c.real = c.removeInstanceVariable("@real");
+            c.image = c.removeInstanceVariable("@image");
+            c.setFrozen(true);
+
+            return c;
+        }
+
+        @Override
+        public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader loader) {
+            RubyComplex c = (RubyComplex)RubyClass.DEFAULT_OBJECT_MARSHAL.unmarshalFrom(context, in, type, loader);
             c.real = c.removeInstanceVariable("@real");
             c.image = c.removeInstanceVariable("@image");
             c.setFrozen(true);

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -41,7 +41,7 @@ import org.jruby.runtime.ObjectMarshal;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
@@ -1175,7 +1175,7 @@ public class RubyComplex extends RubyNumeric {
         }
 
         @Override
-        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, Dumper marshalStream) {
+        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, MarshalDumper marshalStream) {
             //do nothing
         }
 

--- a/core/src/main/java/org/jruby/RubyData.java
+++ b/core/src/main/java/org/jruby/RubyData.java
@@ -12,7 +12,7 @@ import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.ivars.VariableAccessor;
 import org.jruby.runtime.ivars.VariableTableManager;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
@@ -338,7 +338,7 @@ public class RubyData {
     }
 
     // TODO: Mostly copied from RubyStruct; unify.
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, IRubyObject data, Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, IRubyObject data, MarshalDumper output) {
         output.registerLinkTarget(data);
         output.dumpDefaultObjectHeader(context, out, 'S', data.getMetaClass());
 

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -50,7 +50,7 @@ import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
@@ -188,7 +188,7 @@ public class RubyException extends RubyObject {
 
         @Override
         public void marshalTo(ThreadContext context, RubyOutputStream out, RubyException exc, RubyClass type,
-                              Dumper marshalStream) {
+                              MarshalDumper marshalStream) {
             marshalStream.registerLinkTarget(exc);
             marshalStream.dumpVariables(context, out, exc, 2, (marshal, c, o, v, receiver) -> {
                 receiver.receive(marshal, c, o, "mesg", v.getMessage());

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -51,7 +51,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import java.io.IOException;
@@ -196,11 +197,25 @@ public class RubyException extends RubyObject {
         }
 
         @Override
-        public RubyException unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream input) throws IOException {
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
+        public RubyException unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             var context = runtime.getCurrentContext();
             RubyException exc = (RubyException) input.entry(type.allocate(context));
 
             input.ivar(null, exc, null);
+
+            exc.setMessage((IRubyObject) exc.removeInternalVariable("mesg"));
+            exc.set_backtrace(context, (IRubyObject) exc.removeInternalVariable("bt"));
+
+            return exc;
+        }
+
+        @Override
+        public RubyException unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader input) {
+            RubyException exc = (RubyException) input.entry(type.allocate(context));
+
+            input.ivar(context, in, null, exc, null);
 
             exc.setMessage((IRubyObject) exc.removeInternalVariable("mesg"));
             exc.set_backtrace(context, (IRubyObject) exc.removeInternalVariable("bt"));

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -53,11 +53,12 @@ import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CachingCallSite;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.ConvertBytes;
 import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
+import org.jruby.util.io.RubyInputStream;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
@@ -1406,8 +1407,14 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         throw typeError(getRuntime().getCurrentContext(), "", this, " is not a symbol");
     }
 
-    public static RubyFixnum unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubyFixnum unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         return input.getRuntime().newFixnum(input.unmarshalInt());
+    }
+
+    public static RubyFixnum unmarshalFrom(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        return asFixnum(context, input.unmarshalInt(context, in));
     }
 
     private void checkZeroDivisionError(ThreadContext context, IRubyObject other) {

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -55,7 +55,7 @@ import org.jruby.runtime.JavaSites.FloatSites;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.ConvertDouble;
@@ -1144,7 +1144,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         output.writeString(aFloat.marshalDump(context));
     }
 
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyFloat aFloat, Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyFloat aFloat, MarshalDumper output) {
         output.registerLinkTarget(aFloat);
         output.writeString(out, aFloat.marshalDump(context));
     }

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -56,11 +56,12 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.ConvertDouble;
 import org.jruby.util.Numeric;
 import org.jruby.util.Sprintf;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import static org.jruby.api.Convert.*;
@@ -1148,7 +1149,9 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         output.writeString(out, aFloat.marshalDump(context));
     }
 
-    public static RubyFloat unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubyFloat unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         ByteList value = input.unmarshalString();
 
         if (value.equals(NAN_BYTELIST)) {
@@ -1159,6 +1162,20 @@ public class RubyFloat extends RubyNumeric implements Appendable {
             return RubyFloat.newFloat(input.getRuntime(), Double.POSITIVE_INFINITY);
         } else {
             return RubyFloat.newFloat(input.getRuntime(), ConvertDouble.byteListToDouble(value, false));
+        }
+    }
+
+    public static RubyFloat unmarshalFrom(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        ByteList value = input.unmarshalString(context, in);
+
+        if (value.equals(NAN_BYTELIST)) {
+            return RubyFloat.newFloat(context.runtime, RubyFloat.NAN);
+        } else if (value.equals(NEGATIVE_INFINITY_BYTELIST)) {
+            return RubyFloat.newFloat(context.runtime, Double.NEGATIVE_INFINITY);
+        } else if (value.equals(INFINITY_BYTELIST)) {
+            return RubyFloat.newFloat(context.runtime, Double.POSITIVE_INFINITY);
+        } else {
+            return RubyFloat.newFloat(context.runtime, ConvertDouble.byteListToDouble(value, false));
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -59,7 +59,7 @@ import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CachingCallSite;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.RecursiveComparator;
@@ -2525,14 +2525,14 @@ public class RubyHash extends RubyObject implements Map {
         if (hash.ifNone != UNDEF) output.dumpObject(hash.ifNone);
     }
 
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, final RubyHash hash, final Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, final RubyHash hash, final MarshalDumper output) {
         output.registerLinkTarget(hash);
         int hashSize = hash.size();
         output.writeInt(out, hashSize);
         try {
-            hash.visitLimited(context, new VisitorWithState<Dumper>() {
+            hash.visitLimited(context, new VisitorWithState<MarshalDumper>() {
                 @Override
-                public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Dumper state) {
+                public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, MarshalDumper state) {
                     state.dumpObject(context, out, key);
                     state.dumpObject(context, out, value);
                 }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -60,10 +60,11 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.RecursiveComparator;
 import org.jruby.util.TypeConverter;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import java.io.IOException;
@@ -2557,7 +2558,9 @@ public class RubyHash extends RubyObject implements Map {
         }
     };
 
-    public static RubyHash unmarshalFrom(UnmarshalStream input, boolean defaultValue) throws IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubyHash unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input, boolean defaultValue) throws IOException {
         RubyHash result = (RubyHash) input.entry(newHash(input.getRuntime()));
         int size = input.unmarshalInt();
 
@@ -2566,6 +2569,18 @@ public class RubyHash extends RubyObject implements Map {
         }
 
         if (defaultValue) result.default_value_set(input.unmarshalObject());
+        return result;
+    }
+
+    public static RubyHash unmarshalFrom(ThreadContext context, RubyInputStream in, MarshalLoader input, boolean defaultValue) {
+        RubyHash result = (RubyHash) input.entry(Create.newHash(context));
+        int size = input.unmarshalInt(context, in);
+
+        for (int i = 0; i < size; i++) {
+            result.fastASetCheckString(context.runtime, input.unmarshalObject(context, in), input.unmarshalObject(context, in));
+        }
+
+        if (defaultValue) result.default_value_set(input.unmarshalObject(context, in));
         return result;
     }
 

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -34,8 +34,6 @@
 package org.jruby;
 
 import java.io.ByteArrayInputStream;
-import java.io.EOFException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.jruby.anno.JRubyMethod;
@@ -45,11 +43,12 @@ import org.jruby.ast.util.ArgsUtil;
 import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 
 import org.jruby.util.ByteList;
 import org.jruby.util.IOInputStream;
 import org.jruby.util.IOOutputStream;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 import org.jruby.util.io.TransparentByteArrayOutputStream;
 
@@ -146,26 +145,21 @@ public class RubyMarshal {
         }
 
         final IRubyObject str = in.checkStringType();
-        try {
-            InputStream rawInput;
-            if (str != context.nil) {
-                ByteList bytes = ((RubyString) str).getByteList();
-                rawInput = new ByteArrayInputStream(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
-            } else if (sites(context).respond_to_getc.respondsTo(context, in, in) &&
-                        sites(context).respond_to_read.respondsTo(context, in, in)) {
-                rawInput = inputStream(context, in);
-            } else {
-                throw typeError(context, "instance of IO needed");
-            }
-
-            return new UnmarshalStream(context.runtime, rawInput, freeze, proc).unmarshalObject();
-        } catch (EOFException e) {
-            if (str != context.nil) throw argumentError(context, "marshal data too short");
-
-            throw context.runtime.newEOFError();
-        } catch (IOException ioe) {
-            throw context.runtime.newIOErrorFromException(ioe);
+        InputStream rawInput;
+        if (str != context.nil) {
+            ByteList bytes = ((RubyString) str).getByteList();
+            rawInput = new ByteArrayInputStream(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
+        } else if (sites(context).respond_to_getc.respondsTo(context, in, in) &&
+                    sites(context).respond_to_read.respondsTo(context, in, in)) {
+            rawInput = inputStream(context, in);
+        } else {
+            throw typeError(context, "instance of IO needed");
         }
+
+        MarshalLoader loader = new MarshalLoader(context, freeze, proc);
+        RubyInputStream rubyIn = new RubyInputStream(context.runtime, rawInput);
+        loader.start(context, rubyIn);
+        return loader.unmarshalObject(context, rubyIn);
     }
 
     private static InputStream inputStream(ThreadContext context, IRubyObject in) {

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -42,7 +42,7 @@ import org.jruby.anno.JRubyModule;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 
 import org.jruby.util.ByteList;
@@ -173,7 +173,7 @@ public class RubyMarshal {
     }
 
     private static void dumpToStream(ThreadContext context, IRubyObject object, OutputStream rawOutput, int depthLimit) {
-        Dumper output = new Dumper(depthLimit);
+        MarshalDumper output = new MarshalDumper(depthLimit);
         RubyOutputStream out = new RubyOutputStream(context.runtime, rawOutput);
 
         output.start(out);

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -120,7 +120,7 @@ import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.load.LoadService;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.runtime.opto.Invalidator;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.runtime.profile.MethodEnhancer;
@@ -130,6 +130,7 @@ import org.jruby.util.ClassProvider;
 import org.jruby.util.IdUtil;
 import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -4280,10 +4281,18 @@ public class RubyModule extends RubyObject {
         output.writeString(out, Dumper.getPathFromClass(context, module).idString());
     }
 
-    public static RubyModule unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubyModule unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         String name = RubyString.byteListToString(input.unmarshalString());
 
-        return UnmarshalStream.getModuleFromPath(input.getRuntime(), name);
+        return org.jruby.runtime.marshal.UnmarshalStream.getModuleFromPath(input.getRuntime(), name);
+    }
+
+    public static RubyModule unmarshalFrom(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        String name = RubyString.byteListToString(input.unmarshalString(context, in));
+
+        return MarshalLoader.getModuleFromPath(context, name);
     }
 
     /* Module class methods */

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -119,7 +119,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.load.LoadService;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.runtime.opto.Invalidator;
 import org.jruby.runtime.opto.OptoFactory;
@@ -4276,9 +4276,9 @@ public class RubyModule extends RubyObject {
         output.writeString(org.jruby.runtime.marshal.MarshalStream.getPathFromClass(module));
     }
 
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyModule module, Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyModule module, MarshalDumper output) {
         output.registerLinkTarget(module);
-        output.writeString(out, Dumper.getPathFromClass(context, module).idString());
+        output.writeString(out, MarshalDumper.getPathFromClass(context, module).idString());
     }
 
     @Deprecated(since = "10.0", forRemoval = true)

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -59,7 +59,7 @@ import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.runtime.marshal.CoreObjectType;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ShellLauncher;
 import org.jruby.util.TypeConverter;
@@ -186,7 +186,7 @@ public class RubyProcess {
 
         @Override
         public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type,
-                              Dumper marshalStream) {
+                              MarshalDumper marshalStream) {
             RubyStatus status = (RubyStatus) obj;
 
             marshalStream.registerLinkTarget(status);

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -77,9 +77,10 @@ import org.jruby.runtime.callsite.RespondToCallSite;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.Numeric;
 import org.jruby.util.TypeConverter;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import static org.jruby.RubyEnumerator.SizeFn;
@@ -1335,11 +1336,33 @@ public class RubyRange extends RubyObject {
         }
 
         @Override
-        public Object unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream input) throws IOException {
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
+        public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             var context = runtime.getCurrentContext();
             RubyRange range = (RubyRange) input.entry(type.allocate(context));
 
             input.ivar(null, range, null);
+
+            IRubyObject excl = (IRubyObject) range.removeInternalVariable("excl");
+            IRubyObject begin = (IRubyObject) range.removeInternalVariable("begin");
+            IRubyObject end = (IRubyObject) range.removeInternalVariable("end");
+
+            // try old names as well
+            if (begin == null) begin = (IRubyObject) range.removeInternalVariable("begini");
+            if (end == null) end = (IRubyObject) range.removeInternalVariable("endi");
+
+            if (begin == null || end == null || excl == null) throw argumentError(context, "bad value for range");
+
+            range.init(context, begin, end, excl.isTrue());
+            return range;
+        }
+
+        @Override
+        public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader input) {
+            RubyRange range = (RubyRange) input.entry(type.allocate(context));
+
+            input.ivar(context, in, null, range, null);
 
             IRubyObject excl = (IRubyObject) range.removeInternalVariable("excl");
             IRubyObject begin = (IRubyObject) range.removeInternalVariable("begin");

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -76,7 +76,7 @@ import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.callsite.RespondToCallSite;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.invokedynamic.MethodNames;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.Numeric;
 import org.jruby.util.TypeConverter;
@@ -1323,7 +1323,7 @@ public class RubyRange extends RubyObject {
 
         @Override
         public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type,
-                              Dumper marshalStream) {
+                              MarshalDumper marshalStream) {
             RubyRange range = (RubyRange) obj;
 
             marshalStream.registerLinkTarget(range);

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -46,10 +46,11 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
 import org.jruby.util.TypeConverter;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import static org.jruby.api.Convert.asBoolean;
@@ -1425,11 +1426,32 @@ public class RubyRational extends RubyNumeric {
         }
 
         @Override
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type,
-                                    UnmarshalStream unmarshalStream) throws IOException {
+                                    org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
             ThreadContext context = runtime.getCurrentContext();
 
             RubyRational r = (RubyRational) RubyClass.DEFAULT_OBJECT_MARSHAL.unmarshalFrom(runtime, type, unmarshalStream);
+
+            RubyInteger num = intCheck(context, r.removeInstanceVariable("@numerator"));
+            RubyInteger den = intCheck(context, r.removeInstanceVariable("@denominator"));
+
+            // MRI: nurat_canonicalize, negation part
+            if (canonicalizeShouldNegate(context, den)) {
+                num = num.negate(context);
+                den = den.negate(context);
+            }
+
+            r.num = num;
+            r.den = den;
+
+            return r;
+        }
+
+        @Override
+        public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader loader) {
+            RubyRational r = (RubyRational) RubyClass.DEFAULT_OBJECT_MARSHAL.unmarshalFrom(context, in, type, loader);
 
             RubyInteger num = intCheck(context, r.removeInstanceVariable("@numerator"));
             RubyInteger den = intCheck(context, r.removeInstanceVariable("@denominator"));

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -45,7 +45,7 @@ import org.jruby.runtime.ObjectMarshal;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
@@ -1421,7 +1421,7 @@ public class RubyRational extends RubyNumeric {
             throw typeError(runtime.getCurrentContext(), "marshal_dump should be used instead for Rational");
         }
         @Override
-        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, Dumper marshalStream) {
+        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, MarshalDumper marshalStream) {
             throw typeError(context, "marshal_dump should be used instead for Rational");
         }
 

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -61,7 +61,7 @@ import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.encoding.EncodingCapable;
 import org.jruby.runtime.encoding.MarshalEncoding;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.util.ByteList;
 import org.jruby.util.KCode;
 import org.jruby.util.RegexpOptions;
@@ -1929,7 +1929,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         output.writeByte(options);
     }
 
-    public static void marshalTo(ThreadContext context, RubyRegexp regexp, Dumper output, RubyOutputStream out) {
+    public static void marshalTo(ThreadContext context, RubyRegexp regexp, MarshalDumper output, RubyOutputStream out) {
         output.registerLinkTarget(regexp);
         output.writeString(out, regexp.str);
 

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -62,7 +62,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.encoding.EncodingCapable;
 import org.jruby.runtime.encoding.MarshalEncoding;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.KCode;
 import org.jruby.util.RegexpOptions;
@@ -1910,8 +1909,9 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return check ? str.convertToString() : str.checkStringType();
     }
 
-    @Deprecated
-    public static RubyRegexp unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubyRegexp unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         return newRegexp(input.getRuntime(), input.unmarshalString(), RegexpOptions.fromJoniOptions(input.readSignedByte()));
     }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -79,7 +79,7 @@ import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.encoding.EncodingCapable;
 import org.jruby.runtime.encoding.MarshalEncoding;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.CodeRangeSupport;
 import org.jruby.util.CodeRangeable;
@@ -93,6 +93,7 @@ import org.jruby.util.Sprintf;
 import org.jruby.util.StringSupport;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.io.EncodingUtils;
+import org.jruby.util.io.RubyInputStream;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -124,6 +125,7 @@ import static org.jruby.api.Create.dupString;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newArrayNoCopy;
 import static org.jruby.api.Create.newEmptyArray;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.indexError;
@@ -6663,8 +6665,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 first : RubyRational.newRationalNoReduce(context, asFixnum(context, 0), asFixnum(context, 1));
     }
 
-    public static RubyString unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubyString unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         return newString(input.getRuntime(), input.unmarshalString());
+    }
+
+    public static RubyString unmarshalFrom(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        return Create.newString(context, input.unmarshalString(context, in));
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -52,7 +52,7 @@ import org.jruby.runtime.JavaSites.StructSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.RecursiveComparator;
@@ -982,7 +982,7 @@ public class RubyStruct extends RubyObject {
         }
     }
 
-    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyStruct struct, Dumper output) {
+    public static void marshalTo(ThreadContext context, RubyOutputStream out, RubyStruct struct, MarshalDumper output) {
         output.registerLinkTarget(struct);
         output.dumpDefaultObjectHeader(context, out, 'S', struct.getMetaClass());
 

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -53,9 +53,10 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ByteList;
 import org.jruby.util.RecursiveComparator;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
@@ -995,7 +996,9 @@ public class RubyStruct extends RubyObject {
         }
     }
 
-    public static IRubyObject unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static IRubyObject unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         final Ruby runtime = input.getRuntime();
         var context = runtime.getCurrentContext();
 
@@ -1003,10 +1006,6 @@ public class RubyStruct extends RubyObject {
         RubyClass rbClass = pathToClass(context, className.asJavaString());
         if (rbClass == null) {
             throw runtime.newNameError(UNINITIALIZED_CONSTANT, structClass(context), className);
-        }
-
-        if (rbClass.isKindOfModule(runtime.getData())) {
-            return RubyData.unmarshalFrom(context, input, rbClass);
         }
 
         final RubyArray member = __member__(context, rbClass);
@@ -1025,6 +1024,39 @@ public class RubyStruct extends RubyObject {
                         " not compatible (:", slot, " for :", elem, ")").toString());
             }
             result.aset(context, i, input.unmarshalObject());
+        }
+        return result;
+    }
+
+    public static IRubyObject unmarshalFrom(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        Ruby runtime = context.runtime;
+
+        RubySymbol className = input.unique(context, in);
+        RubyClass rbClass = pathToClass(context, className.asJavaString());
+        if (rbClass == null) {
+            throw runtime.newNameError(UNINITIALIZED_CONSTANT, structClass(context), className);
+        }
+
+        if (rbClass.isKindOfModule(runtime.getData())) {
+            return RubyData.unmarshalFrom(context, in, input, rbClass);
+        }
+
+        final RubyArray member = __member__(context, rbClass);
+
+        final int len = input.unmarshalInt(context, in);
+
+        // FIXME: This could all be more efficient, but it's how struct works
+        // 1.9 does not appear to call initialize (JRUBY-5875)
+        final RubyStruct result = (RubyStruct) input.entry(new RubyStruct(context, rbClass));
+
+        for (int i = 0; i < len; i++) {
+            RubySymbol slot = input.symbol(context, in);
+            RubySymbol elem = (RubySymbol) member.eltInternal(i);
+            if (!elem.equals(slot)) {
+                throw typeError(context, str(runtime, "struct ", rbClass,
+                        " not compatible (:", slot, " for :", elem, ")").toString());
+            }
+            result.aset(context, i, input.unmarshalObject(context, in));
         }
         return result;
     }

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -63,7 +63,6 @@ import org.jruby.runtime.callsite.RefinedCachingCallSite;
 import org.jruby.runtime.encoding.EncodingCapable;
 import org.jruby.runtime.encoding.MarshalEncoding;
 import org.jruby.runtime.marshal.MarshalCommon;
-import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.ByteList;
 import org.jruby.util.IdUtil;
@@ -952,7 +951,9 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         return runtime.getSymbolTable().all_symbols(runtime.getCurrentContext());
     }
 
-    public static RubySymbol unmarshalFrom(UnmarshalStream input, UnmarshalStream.MarshalState state) throws java.io.IOException {
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    public static RubySymbol unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input, org.jruby.runtime.marshal.UnmarshalStream.MarshalState state) throws java.io.IOException {
         ByteList byteList = input.unmarshalString();
         byteList.setEncoding(ASCIIEncoding.INSTANCE);
 

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -25,9 +25,10 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
 
 import jnr.constants.platform.Errno;
+import org.jruby.runtime.marshal.MarshalLoader;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 /**
@@ -171,7 +172,9 @@ public class RubySystemCallError extends RubyStandardError {
         }
 
         @Override
-        public Object unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream input) throws IOException {
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
+        public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             var context = runtime.getCurrentContext();
             RubySystemCallError exc = (RubySystemCallError) input.entry(type.allocate(context));
 
@@ -181,6 +184,19 @@ public class RubySystemCallError extends RubyStandardError {
             exc.errno = (IRubyObject) exc.removeInternalVariable("errno");
             exc.set_backtrace(context, (IRubyObject) exc.removeInternalVariable("bt"));
             
+            return exc;
+        }
+
+        @Override
+        public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader input) {
+            RubySystemCallError exc = (RubySystemCallError) input.entry(type.allocate(context));
+
+            input.ivar(context, in, null, exc, null);
+
+            exc.message = (IRubyObject) exc.removeInternalVariable("mesg");
+            exc.errno = (IRubyObject) exc.removeInternalVariable("errno");
+            exc.set_backtrace(context, (IRubyObject) exc.removeInternalVariable("bt"));
+
             return exc;
         }
     };

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -24,7 +24,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 
 import jnr.constants.platform.Errno;
 import org.jruby.runtime.marshal.MarshalLoader;
@@ -160,7 +160,7 @@ public class RubySystemCallError extends RubyStandardError {
 
         @Override
         public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type,
-                              Dumper marshalStream) {
+                              MarshalDumper marshalStream) {
             RubySystemCallError exc = (RubySystemCallError) obj;
             marshalStream.registerLinkTarget(exc);
 

--- a/core/src/main/java/org/jruby/api/Error.java
+++ b/core/src/main/java/org/jruby/api/Error.java
@@ -5,6 +5,7 @@ import org.jruby.RubyArray;
 import org.jruby.RubyFrozenError;
 import org.jruby.RubyModule;
 import org.jruby.exceptions.ArgumentError;
+import org.jruby.exceptions.EOFError;
 import org.jruby.exceptions.IOError;
 import org.jruby.exceptions.NotImplementedError;
 import org.jruby.exceptions.RaiseException;
@@ -270,5 +271,9 @@ public class Error {
 
     private static IRubyObject typeFor(Ruby runtime, IRubyObject object) {
         return object instanceof RubyModule ? types(runtime, (RubyModule) object) : object.getMetaClass().getRealClass();
+    }
+
+    public static EOFError eofError(ThreadContext context, String message) {
+        return (EOFError) context.runtime.newEOFError(message);
     }
 }

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -37,7 +37,7 @@ import org.jruby.api.Access;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.io.RubyInputStream;
@@ -98,7 +98,7 @@ public class RubySet extends RubyObject implements Set {
             defaultMarshal.marshalTo(runtime, obj, type, marshalStream);
         }
 
-        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, Dumper marshalStream) {
+        public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, MarshalDumper marshalStream) {
             defaultMarshal.marshalTo(context, out, obj, type, marshalStream);
         }
 

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -38,8 +38,9 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
 import org.jruby.util.ArraySupport;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import java.io.IOException;
@@ -101,8 +102,16 @@ public class RubySet extends RubyObject implements Set {
             defaultMarshal.marshalTo(context, out, obj, type, marshalStream);
         }
 
-        public Object unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream unmarshalStream) throws IOException {
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
+        public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
             Object result = defaultMarshal.unmarshalFrom(runtime, type, unmarshalStream);
+            ((RubySet) result).unmarshal();
+            return result;
+        }
+
+        public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader loader) {
+            Object result = defaultMarshal.unmarshalFrom(context, in, type, loader);
             ((RubySet) result).unmarshal();
             return result;
         }

--- a/core/src/main/java/org/jruby/runtime/ObjectMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/ObjectMarshal.java
@@ -32,7 +32,8 @@ import java.io.IOException;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.runtime.marshal.Dumper;
-import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.marshal.MarshalLoader;
+import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import static org.jruby.api.Error.typeError;
@@ -54,15 +55,29 @@ public interface ObjectMarshal<T> {
             throw typeError(context, "no marshal_dump is defined for class " + type.getName(context));
         }
 
-        public Object unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream unmarshalStream) {
+        @Deprecated(since = "10.0", forRemoval = true)
+        @SuppressWarnings("removal")
+        public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) {
             var context = runtime.getCurrentContext();
+            throw typeError(context, "no marshal_load is defined for class " + type.getName(context));
+        }
+
+        public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader loader) {
             throw typeError(context, "no marshal_load is defined for class " + type.getName(context));
         }
     };
 
     @Deprecated(since = "10.0", forRemoval = true)
     @SuppressWarnings("removal")
-    void marshalTo(Ruby runtime, T obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException;
+    default void marshalTo(Ruby runtime, T obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
+        // no-op to allow implementing only the Dumper version
+    }
     void marshalTo(ThreadContext context, RubyOutputStream out, T obj, RubyClass type, Dumper marshalStream);
-    T unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream unmarshalStream) throws IOException;
+    @Deprecated(since = "10.0", forRemoval = true)
+    @SuppressWarnings("removal")
+    default T unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
+        // no-op to allow implementing only the MarshalLoader version
+        return null;
+    }
+    T unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader loader);
 }

--- a/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
@@ -36,7 +36,6 @@
 package org.jruby.runtime.builtin;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -49,7 +48,7 @@ import org.jruby.api.JRubyAPI;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.marshal.Dumper;
+import org.jruby.runtime.marshal.MarshalDumper;
 import org.jruby.util.io.RubyOutputStream;
 
 /**
@@ -403,7 +402,7 @@ public interface IRubyObject {
         return getVariableList();
     }
 
-    default void marshalLiveVariables(Dumper stream, ThreadContext context, RubyOutputStream out) {
+    default void marshalLiveVariables(MarshalDumper stream, ThreadContext context, RubyOutputStream out) {
 
     }
 

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
@@ -1,0 +1,769 @@
+/*
+ **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2002-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Charles O Nutter <headius@headius.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2006 Ola Bini <ola.bini@ki.se>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.runtime.marshal;
+
+import org.jcodings.Encoding;
+import org.jcodings.EncodingDB.Entry;
+import org.jcodings.specific.ASCIIEncoding;
+import org.jcodings.specific.USASCIIEncoding;
+import org.jcodings.specific.UTF8Encoding;
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyBignum;
+import org.jruby.RubyClass;
+import org.jruby.RubyEncoding;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyFloat;
+import org.jruby.RubyHash;
+import org.jruby.RubyModule;
+import org.jruby.RubyObject;
+import org.jruby.RubyRegexp;
+import org.jruby.RubyString;
+import org.jruby.RubyStruct;
+import org.jruby.RubySymbol;
+import org.jruby.api.Create;
+import org.jruby.runtime.Constants;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.encoding.EncodingCapable;
+import org.jruby.util.ByteList;
+import org.jruby.util.RegexpOptions;
+import org.jruby.util.StringSupport;
+import org.jruby.util.io.RubyInputStream;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.jruby.api.Access.hashClass;
+import static org.jruby.api.Access.moduleClass;
+import static org.jruby.api.Access.stringClass;
+import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Error.eofError;
+import static org.jruby.api.Error.typeError;
+import static org.jruby.runtime.marshal.MarshalCommon.*;
+import static org.jruby.util.RubyStringBuilder.inspectIdentifierByteList;
+import static org.jruby.util.RubyStringBuilder.str;
+
+/**
+ * Unmarshals objects from strings or streams in Ruby's marshal format.
+ */
+public class MarshalLoader {
+    private final List<IRubyObject> links = new ArrayList<>();
+    private final List<RubySymbol> symbols = new ArrayList<>();
+    private final Map<IRubyObject, IRubyObject> partials = new IdentityHashMap<>();
+    private final IRubyObject proc;
+    private final boolean freeze;
+
+    public MarshalLoader(ThreadContext context, IRubyObject proc) {
+        this(context, false, proc);
+    }
+
+    public MarshalLoader(ThreadContext context, boolean freeze, IRubyObject proc) {
+        // Older native java ext expects proc can be null (spymem.jruby at least).
+        if (proc == null) proc = context.nil;
+        
+        this.proc = proc;
+        this.freeze = freeze;
+    }
+
+    public void start(ThreadContext context, RubyInputStream in) {
+        int major = in.read(); // Major
+        int minor = in.read(); // Minor
+
+        if(major == -1 || minor == -1) {
+            throw eofError(context, "marshal data too short");
+        }
+
+        if(major != Constants.MARSHAL_MAJOR || minor > Constants.MARSHAL_MINOR) {
+            throw typeError(context, String.format("incompatible marshal file format (can't be read)\n\tformat version %d.%d required; %d.%d given", Constants.MARSHAL_MAJOR, Constants.MARSHAL_MINOR, major, minor));
+        }
+    }
+
+    // r_object
+    public IRubyObject unmarshalObject(ThreadContext context, RubyInputStream in) {
+        return object0(context, in, new MarshalState(false), false, null);
+    }
+
+    // introduced for keeping ivar read state recursively.
+    private static class MarshalState {
+        private boolean ivarWaiting;
+
+        MarshalState(boolean ivarWaiting) {
+            this.ivarWaiting = ivarWaiting;
+        }
+
+        boolean isIvarWaiting() {
+            return ivarWaiting;
+        }
+
+        void setIvarWaiting(boolean ivarWaiting) {
+            this.ivarWaiting = ivarWaiting;
+        }
+    }
+
+    public static RubyModule getModuleFromPath(ThreadContext context, String path) {
+        Ruby runtime = context.runtime;
+        final RubyModule value = runtime.getClassFromPath(path, runtime.getArgumentError(), false);
+        if (value == null) throw argumentError(context, "undefined class/module " + path);
+        if ( ! value.isModule() ) throw argumentError(context, path + " does not refer module");
+        return value;
+    }
+
+    public static RubyClass getClassFromPath(ThreadContext context, String path) {
+        Ruby runtime = context.runtime;
+        final RubyModule value = runtime.getClassFromPath(path, runtime.getArgumentError(), false);
+        if (value == null) throw argumentError(context, "undefined class/module " + path);
+        if ( ! value.isClass() ) throw argumentError(context, path + " does not refer class");
+        return (RubyClass) value;
+    }
+
+    private IRubyObject doCallProcForObj(ThreadContext context, IRubyObject result) {
+        if (proc == null || proc.isNil()) return result;
+
+        return Helpers.invoke(context, proc, "call", result);
+    }
+
+    private int r_byte(ThreadContext context, RubyInputStream in) {
+        return readUnsignedByte(context, in);
+    }
+
+    public void ivar(ThreadContext context, RubyInputStream in, MarshalState state, IRubyObject object, boolean[] hasEncoding) {
+        int count = unmarshalInt(context, in);
+        RubyClass clazz = object.getMetaClass().getRealClass();
+
+        // Keys may be "E", "encoding",or any valid ivar.  Weird code what happens with @encoding that happens to have
+        // a string of "US-ASCII"?
+        for (int i = 0; i < count; i++) {
+            RubySymbol key = symbol(context, in);
+            String id = key.idString();
+            IRubyObject value = object0(context, in, state, false, null);
+            Encoding encoding = symbolToEncoding(context, key, value);
+
+            if (encoding != null) {
+                if (object instanceof EncodingCapable) {
+                    ((EncodingCapable) object).setEncoding(encoding);
+                } else {
+                    throw argumentError(context, str(context.runtime, object, "is not enc_capable"));
+                }
+                if (hasEncoding != null) hasEncoding[0] = true;
+            } else if (id.equals(RUBY2_KEYWORDS_FLAG)) {
+                if (object instanceof RubyHash) {
+                    ((RubyHash) object).setRuby2KeywordHash(true);
+                } else {
+                    throw argumentError(context, str(context.runtime, "ruby2_keywords flag is given but ", object, " is not a Hash"));
+                }
+            } else {
+                clazz.getVariableAccessorForWrite(key.idString()).set(object, value);
+            }
+        }
+    }
+
+    public IRubyObject entry(IRubyObject value) {
+        registerDataLink(value);
+        markAsPartialObject(value);
+
+        return value;
+    }
+
+    private IRubyObject leave(ThreadContext context, IRubyObject value, boolean partial) {
+        if (!partial) {
+            noLongerPartial(value);
+            if (freeze) {
+                RubyClass metaClass = value.getMetaClass();
+                if (metaClass == stringClass(context)) {
+                    IRubyObject original = value;
+                    // FIXME: We need to modify original to be frozen but we also need it to be part of the deduped table.
+                    value = context.runtime.freezeAndDedupString((RubyString) value);
+                    if (value != original) {
+                        original.setFrozen(value.isFrozen());
+                    }
+                } else if (!value.isModule() && !value.isClass()) {
+                    value.setFrozen(true);
+                }
+            }
+            value = postProc(context, value);
+        }
+
+        return value;
+    }
+
+    private RubyModule mustBeModule(ThreadContext context, IRubyObject value, IRubyObject path) {
+        if (!value.isModule()) throw argumentError(context, str(context.runtime, path, " does not refer to module"));
+
+        return (RubyModule) value;
+    }
+
+    private IRubyObject object0(ThreadContext context, RubyInputStream in, MarshalState state, boolean partial, List<RubyModule> extendedModules) {
+        return objectFor(context, in, r_byte(context, in), state, partial,  extendedModules);
+    }
+
+    private IRubyObject objectFor(ThreadContext context, RubyInputStream in, int type, MarshalState state, boolean partial,
+                                  List<RubyModule> extendedModules) {
+        return switch (type) {
+            case TYPE_LINK -> objectForLink(context, in);
+            case TYPE_IVAR -> objectForIVar(context, in, state, partial, extendedModules);
+            case TYPE_EXTENDED -> objectForExtended(context, in, extendedModules);
+            case TYPE_UCLASS -> objectForUClass(context, in, partial, extendedModules);
+            case TYPE_NIL -> objectForNil(context);
+            case TYPE_TRUE -> objectForTrue(context);
+            case TYPE_FALSE -> objectForFalse(context);
+            case TYPE_FIXNUM -> objectForFixnum(context, in);
+            case TYPE_FLOAT -> objectForFloat(context, in);
+            case TYPE_BIGNUM -> objectForBignum(context, in);
+            case TYPE_STRING -> objectForString(context, in, partial);
+            case TYPE_REGEXP -> objectForRegexp(context, in, state, partial);
+            case TYPE_ARRAY -> objectForArray(context, in, partial);
+            case TYPE_HASH -> objectForHash(context, in, partial);
+            case TYPE_HASH_DEF -> objectForHashDefault(context, in, partial);
+            case TYPE_STRUCT -> objectForStruct(context, in, partial);
+            case TYPE_USERDEF -> objectForUserDef(context, in, state, partial);
+            case TYPE_USRMARSHAL -> objectForUsrMarshal(context, in, extendedModules);
+            case TYPE_OBJECT -> objectForObject(context, in, partial);
+            case TYPE_DATA -> objectForData(context, in, state, partial, extendedModules);
+            case TYPE_MODULE_OLD -> objectForModuleOld(context, in, state, partial);
+            case TYPE_CLASS -> objectForClass(context, in, partial);
+            case TYPE_MODULE -> objectForModule(context, in, partial);
+            case TYPE_SYMBOL -> objectForSymbol(context, in, state, partial);
+            case TYPE_SYMLINK -> objectForSymlink(context, in);
+            default -> throw argumentError(context, "dump format error(" + (char) type + ")");
+        };
+    }
+
+    private IRubyObject objectForModuleOld(ThreadContext context, RubyInputStream in, MarshalState state, boolean partial) {
+        String name = RubyString.byteListToString(unmarshalString(context, in));
+        RubyModule mod = MarshalLoader.getModuleFromPath(context, name);
+
+        prohibitIVar(context, state, name);
+
+        return leave(context, entry(mod), partial);
+    }
+
+    private void prohibitIVar(ThreadContext context, MarshalState state, String name) {
+        if (state != null && state.isIvarWaiting()) {
+            throw typeError(context, "can't override instance variable of class/module '" + name + "'");
+        }
+    }
+
+    private RubySymbol objectForSymlink(ThreadContext context, RubyInputStream in) {
+        return symlink(context, in);
+    }
+
+    private IRubyObject objectForSymbol(ThreadContext context, RubyInputStream in, MarshalState state, boolean partial) {
+        IRubyObject obj = symreal(context, in, state);
+
+        if (state != null && state.isIvarWaiting()) state.setIvarWaiting(false);
+
+        return leave(context, obj, partial);
+    }
+
+    private IRubyObject objectForModule(ThreadContext context, RubyInputStream in, boolean partial) {
+        return leave(context, entry(RubyModule.unmarshalFrom(context, in, this)), partial);
+    }
+
+    private IRubyObject objectForClass(ThreadContext context, RubyInputStream in, boolean partial) {
+        return leave(context, entry(RubyClass.unmarshalFrom(context, in, this)), partial);
+    }
+
+    private IRubyObject objectForData(ThreadContext context, RubyInputStream in, MarshalState state, boolean partial,
+                                      List<RubyModule> extendedModules) {
+        IRubyObject name = unique(context, in);
+        RubyClass klass = getClassFromPath(context, name.asJavaString());
+        IRubyObject obj = entry(klass.allocate(context));
+        // FIXME: Missing T_DATA error check?
+
+        if (!obj.respondsTo("_load_data")) {
+            throw typeError(context, str(context.runtime, name, " needs to have instance method _load_data"));
+        }
+
+        IRubyObject arg = object0(context, in, state, partial, extendedModules);
+        obj.callMethod(context, "_load_data", arg);
+        return leave(context, obj, partial);
+    }
+
+    private IRubyObject objectForObject(ThreadContext context, RubyInputStream in, boolean partial) {
+        RubySymbol className = symbol(context, in);
+        RubyClass type = getClassFromPath(context, className.idString());
+
+        IRubyObject obj = (IRubyObject) type.unmarshal(context, in, this);
+        return leave(context, obj, partial);
+    }
+
+    private IRubyObject objectForUserDef(ThreadContext context, RubyInputStream in, MarshalState state, boolean partial) {
+        IRubyObject obj = userUnmarshal(context, in, state);
+
+        if (!partial) obj = postProc(context, obj);
+
+        return obj;
+    }
+
+    private IRubyObject objectForStruct(ThreadContext context, RubyInputStream in, boolean partial) {
+        return leave(context, RubyStruct.unmarshalFrom(context, in, this), partial);
+    }
+
+    private IRubyObject objectForHashDefault(ThreadContext context, RubyInputStream in, boolean partial) {
+        return leave(context, RubyHash.unmarshalFrom(context, in, this, true), partial);
+    }
+
+    private IRubyObject objectForHash(ThreadContext context, RubyInputStream in, boolean partial) {
+        return leave(context, RubyHash.unmarshalFrom(context, in, this, false), partial);
+    }
+
+    private IRubyObject objectForArray(ThreadContext context, RubyInputStream in, boolean partial) {
+        return leave(context, RubyArray.unmarshalFrom(context, in, this), partial);
+    }
+
+    private IRubyObject objectForRegexp(ThreadContext context, RubyInputStream in, MarshalState state, boolean partial) {
+        return leave(context, entry(unmarshalRegexp(context, in, state)), partial);
+    }
+
+    private IRubyObject objectForString(ThreadContext context, RubyInputStream in, boolean partial) {
+        return leave(context, entry(RubyString.unmarshalFrom(context, in, this)), partial);
+    }
+
+    private IRubyObject objectForBignum(ThreadContext context, RubyInputStream in) {
+        return leave(context, entry(RubyBignum.unmarshalFrom(context, in, this)), false);
+    }
+
+    private IRubyObject objectForFloat(ThreadContext context, RubyInputStream in) {
+        return leave(context, entry(RubyFloat.unmarshalFrom(context, in, this)), false);
+    }
+
+    private IRubyObject objectForFixnum(ThreadContext context, RubyInputStream in) {
+        return leave(context, RubyFixnum.unmarshalFrom(context, in, this), false);
+    }
+
+    private IRubyObject objectForFalse(ThreadContext context) {
+        return leave(context, context.fals, false);
+    }
+
+    private IRubyObject objectForTrue(ThreadContext context) {
+        return leave(context, context.tru, false);
+    }
+
+    private IRubyObject objectForNil(ThreadContext context) {
+        return leave(context, context.nil, false);
+    }
+
+    private IRubyObject objectForUClass(ThreadContext context, RubyInputStream in, boolean partial, List<RubyModule> extendedModules) {
+        RubyClass c = getClassFromPath(context, unique(context, in).asJavaString());
+
+        if (c.isSingleton()) throw typeError(context, "singleton can't be loaded");
+
+        int type = r_byte(context, in);
+        if (c == hashClass(context) && (type == TYPE_HASH || type == TYPE_HASH_DEF)) {
+            // FIXME: Missing logic to make the following methods use compare_by_identity (and construction of that)
+            return type == TYPE_HASH ? objectForHash(context, in, partial) : objectForHashDefault(context, in, partial);
+        }
+
+        IRubyObject obj = objectFor(context, in, type, null, partial, extendedModules);
+        // if result is a module or type doesn't extend result's class...
+        if (obj.getMetaClass() == moduleClass(context) || !c.isKindOfModule(obj.getMetaClass())) {
+            // if allocators do not match, error
+            // Note: MRI is a bit different here, and tests TYPE(type.allocate()) != TYPE(result)
+            if (c.getAllocator() != obj.getMetaClass().getRealClass().getAllocator()) {
+                throw argumentError(context, "dump format error (user class)");
+            }
+        }
+
+        ((RubyObject) obj).setMetaClass(c);
+        return obj;
+    }
+
+    private IRubyObject objectForExtended(ThreadContext context, RubyInputStream in, List<RubyModule> extendedModules) {
+        IRubyObject path = unique(context, in);
+        IRubyObject m = getModuleFromPath(context, path.asJavaString());
+
+        if (extendedModules == null) extendedModules = new ArrayList<>();
+
+        IRubyObject obj;
+        if (m instanceof RubyClass) {
+            obj = object0(context, in, null, true, null);
+            RubyClass cls = obj.getMetaClass();
+            if (cls != m || cls.isSingleton()) {
+                throw argumentError(context, str(context.runtime, "prepended class ", path, " differs from class ", cls));
+            }
+
+            cls = obj.singletonClass(context);
+
+            for (RubyModule mod: extendedModules) {
+                cls.prependModule(context, mod);
+            }
+        } else {
+            extendedModules.add(mustBeModule(context, m, path));
+
+            obj = object0(context, in, null, true, extendedModules);
+
+            appendExtendedModules(context, obj, extendedModules);
+        }
+
+        return obj;
+    }
+
+    private IRubyObject objectForIVar(ThreadContext context, RubyInputStream in, MarshalState state, boolean partial,
+                                      List<RubyModule> extendedModules) {
+        MarshalState state1 = new MarshalState(true);
+        IRubyObject obj = object0(context, in, state1, true, extendedModules);
+
+        if (state1.ivarWaiting) ivar(context, in, state, obj, null);
+
+        return leave(context, obj, partial);
+    }
+
+    private IRubyObject objectForLink(ThreadContext context, RubyInputStream in) {
+        IRubyObject obj = readDataLink(context, in, this);
+
+        if (!isPartialObject(obj)) obj = postProc(context, obj);
+
+        return obj;
+    }
+
+    private IRubyObject postProc(ThreadContext context, IRubyObject value) {
+        return doCallProcForObj(context, value);
+    }
+
+    public RubySymbol symbol(ThreadContext context, RubyInputStream in) {
+        boolean ivar = false;
+
+        while (true) {
+            int type = r_byte(context, in);
+
+            switch (type) {
+                case TYPE_IVAR:
+                    ivar = true;
+                    continue;
+                case TYPE_SYMBOL: {
+                    MarshalState state1 = new MarshalState(ivar);
+                    return symreal(context, in, state1);
+                }
+                case TYPE_SYMLINK:
+                    if (ivar) throw argumentError(context, "dump format error (symlink with encoding)");
+                    return symlink(context, in);
+                default:
+                    throw argumentError(context, "dump format error for symbol(0x" + Integer.toHexString(type) + ")");
+            }
+        }
+    }
+
+    private RubySymbol symlink(ThreadContext context, RubyInputStream in) {
+        return (RubySymbol) readSymbolLink(context, in, this);
+    }
+
+    private RubySymbol symreal(ThreadContext context, RubyInputStream in, MarshalState state) {
+        ByteList byteList = unmarshalString(context, in);
+        // FIXME: needs to only do this is only us-ascii
+        byteList.setEncoding(ASCIIEncoding.INSTANCE);
+        final MarshalLoader input = this;
+
+        return RubySymbol.newSymbol(context.runtime, byteList,
+                (sym, newSym) -> {
+                    Encoding encoding = null;
+                    registerSymbolLink(sym);
+
+                    if (state != null && state.isIvarWaiting()) {
+                        int num = input.unmarshalInt(context, in);
+                        for (int i = 0; i < num; i++) {
+                            RubySymbol sym2 = input.symbol(context, in);
+                            encoding = symbolToEncoding(context, sym2, input.unmarshalObject(context, in));
+                        }
+                    }
+
+                    if (encoding != null) {
+                        sym.getBytes().setEncoding(encoding);
+
+                        if (StringSupport.codeRangeScan(encoding, sym.getBytes()) == StringSupport.CR_BROKEN) {
+                            throw argumentError(context, str(context.runtime, "invalid byte sequence in " + encoding + ": ",
+                                    inspectIdentifierByteList(context.runtime, sym.getBytes())));
+                        }
+                    }
+                });
+    }
+
+    public RubySymbol unique(ThreadContext context, RubyInputStream in) {
+        return symbol(context, in);
+    }
+
+    private IRubyObject unmarshalRegexp(ThreadContext context, RubyInputStream in, MarshalState state) {
+        ByteList byteList = unmarshalString(context, in);
+        byte opts = readSignedByte(context, in);
+        RegexpOptions reOpts = RegexpOptions.fromJoniOptions(opts);
+
+        RubyRegexp regexp = (RubyRegexp) context.runtime.getRegexp().allocate(context);
+
+        IRubyObject ivarHolder = null;
+        boolean[] hasEncoding = new boolean[] { false };
+
+        if (state != null && state.isIvarWaiting()) {
+            RubyString tmpStr = RubyString.newString(context.runtime, byteList);
+
+            ivar(context, in, state, tmpStr, hasEncoding);
+            byteList = tmpStr.getByteList();
+            state.setIvarWaiting(false);
+            ivarHolder = tmpStr;
+        }
+        if (!hasEncoding[0]) {
+            /* 1.8 compatibility; remove escapes undefined in 1.8 */
+            byte[] ptrBytes = byteList.unsafeBytes();
+            int ptr = byteList.begin();
+            int dst = ptr;
+            int src = ptr;
+            int len = byteList.realSize();
+            long bs = 0;
+            for (; len-- > 0; ptrBytes[dst++] = ptrBytes[src++]) {
+                switch (ptrBytes[src]) {
+                    case '\\':
+                        bs++;
+                        break;
+                    case 'g':
+                    case 'h':
+                    case 'i':
+                    case 'j':
+                    case 'k':
+                    case 'l':
+                    case 'm':
+                    case 'o':
+                    case 'p':
+                    case 'q':
+                    case 'u':
+                    case 'y':
+                    case 'E':
+                    case 'F':
+                    case 'H':
+                    case 'I':
+                    case 'J':
+                    case 'K':
+                    case 'L':
+                    case 'N':
+                    case 'O':
+                    case 'P':
+                    case 'Q':
+                    case 'R':
+                    case 'S':
+                    case 'T':
+                    case 'U':
+                    case 'V':
+                    case 'X':
+                    case 'Y':
+                        if ((bs & 1) != 0) --dst;
+                    default:
+                        bs = 0;
+                        break;
+                }
+            }
+            byteList.setRealSize(dst - ptr);
+        }
+
+        regexp.regexpInitialize(byteList, byteList.getEncoding(), reOpts, null);
+
+        if (ivarHolder != null) {
+            ivarHolder.getInstanceVariables().copyInstanceVariablesInto(regexp);
+        }
+
+        return regexp;
+    }
+
+    public int readUnsignedByte(ThreadContext context, RubyInputStream in) {
+        int result = in.read();
+        if (result == -1) throw eofError(context, "marshal data too short");
+        return result;
+    }
+
+    public byte readSignedByte(ThreadContext context, RubyInputStream in) {
+        int b = readUnsignedByte(context, in);
+        if (b > 127) {
+            return (byte) (b - 256);
+        }
+        return (byte) b;
+    }
+
+    public ByteList unmarshalString(ThreadContext context, RubyInputStream in) {
+        int length = unmarshalInt(context, in);
+        byte[] buffer = new byte[length];
+
+        int readLength = 0;
+        while (readLength < length) {
+            int read = in.read(buffer, readLength, length - readLength);
+            if (read == -1) throw argumentError(context, "marshal data too short");
+
+            readLength += read;
+        }
+
+        return new ByteList(buffer,false);
+    }
+
+    public int unmarshalInt(ThreadContext context, RubyInputStream in) {
+        int c = readSignedByte(context, in);
+        if (c == 0) {
+            return 0;
+        } else if (4 < c) {
+            return c - 5;
+        } else if (c < -4) {
+            return c + 5;
+        }
+        long result;
+        if (c > 0) {
+            result = 0;
+            for (int i = 0; i < c; i++) {
+                result |= (long) readUnsignedByte(context, in) << (8 * i);
+            }
+        } else {
+            c = -c;
+            result = -1;
+            for (int i = 0; i < c; i++) {
+                result &= ~((long) 0xff << (8 * i));
+                result |= (long) readUnsignedByte(context, in) << (8 * i);
+            }
+        }
+        return (int) result;
+    }
+
+    // MRI: sym2encidx
+    private Encoding symbolToEncoding(ThreadContext context, RubySymbol symbol, IRubyObject value) {
+        if (symbol.getEncoding() != USASCIIEncoding.INSTANCE) return null;
+
+        String id = symbol.idString();
+
+        if (id.equals("encoding")) {
+            String encodingNameStr = value.asJavaString();
+            ByteList encodingName = new ByteList(ByteList.plain(encodingNameStr));
+
+            Entry entry = context.runtime.getEncodingService().findEncodingOrAliasEntry(encodingName);
+            if (entry == null) throw argumentError(context, str(context.runtime, "encoding ", value, " is not registered"));
+
+            return entry.getEncoding();
+        } else if (id.equals(SYMBOL_ENCODING_SPECIAL)) {
+            return value.isTrue() ? UTF8Encoding.INSTANCE : USASCIIEncoding.INSTANCE;
+        }
+
+        return null;
+    }
+
+    private IRubyObject userUnmarshal(ThreadContext context, RubyInputStream in, MarshalState state) {
+        String className = unique(context, in).asJavaString();
+        RubyClass classInstance = getClassFromPath(context, className);
+        RubyString data = Create.newString(context, unmarshalString(context, in));
+        IRubyObject unmarshaled;
+
+        // Special case Encoding so they are singletons
+        // See https://bugs.ruby-lang.org/issues/11760
+        if (classInstance == context.runtime.getEncoding()) {
+            unmarshaled = RubyEncoding.find(context, classInstance, data);
+        } else {
+            if (state != null && state.isIvarWaiting()) {
+                ivar(context, in, state, data, null);
+                state.setIvarWaiting(false);
+            }
+            unmarshaled = classInstance.smartLoadOldUser(data);
+        }
+
+        return entry(unmarshaled);
+    }
+
+    // FIXME: This is missing a much more complicated set of logic in tracking old compatibility allocators. See MRI for more details
+    private IRubyObject objectForUsrMarshal(ThreadContext context, RubyInputStream in, List<RubyModule> extendedModules) {
+        RubyClass classInstance = getClassFromPath(context, unique(context, in).asJavaString());
+        IRubyObject obj = classInstance.allocate(context);
+
+        if (extendedModules != null) appendExtendedModules(context, obj, extendedModules);
+
+        obj = entry(obj);
+        IRubyObject marshaled = unmarshalObject(context, in);
+        obj = classInstance.smartLoadNewUser(obj, marshaled);
+        obj = fixupCompat(obj);
+        //obj = copyIVars(obj, marshaled);
+        obj = postProc(context, obj);
+
+        if (extendedModules != null) extendedModules.clear();
+
+        return obj;
+    }
+
+    private IRubyObject fixupCompat(IRubyObject obj) {
+
+        /* FIXME: we need to store allocators and then potentially use the ones associated with compat class values.
+        IRubyObject compatObj = shared.hasCompatValue(obj);
+        if (compatObj != null) {
+
+        }*/
+        return obj;
+    }
+
+    private void appendExtendedModules(ThreadContext context, IRubyObject obj, List<RubyModule> extendedModules) {
+        Collections.reverse(extendedModules);
+        for (RubyModule module: extendedModules) {
+            module.extend_object(context, obj);
+        }
+    }
+
+    private boolean isPartialObject(IRubyObject value) {
+        return partials.containsKey(value);
+    }
+
+    private void markAsPartialObject(IRubyObject value) {
+        partials.put(value, value);
+    }
+
+    private void noLongerPartial(IRubyObject value) {
+        partials.remove(value);
+    }
+
+    private IRubyObject readSymbolLink(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        try {
+            return symbols.get(input.unmarshalInt(context, in));
+        } catch (IndexOutOfBoundsException e) {
+            throw typeError(context,"bad symbol");
+        }
+    }
+
+    private IRubyObject readDataLink(ThreadContext context, RubyInputStream in, MarshalLoader input) {
+        int index = input.unmarshalInt(context, in);
+        try {
+            return links.get(index);
+        } catch (IndexOutOfBoundsException e) {
+            throw argumentError(context, "dump format error (unlinked, index: " + index + ")");
+        }
+    }
+
+    private void registerDataLink(IRubyObject value) {
+        links.add(value);
+    }
+
+    private void registerSymbolLink(RubySymbol value) {
+        symbols.add(value);
+    }
+}

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalCache.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalCache.java
@@ -44,6 +44,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Error.typeError;
 
+@Deprecated(since = "10.0", forRemoval = true)
+@SuppressWarnings("removal")
 public class UnmarshalCache {
     private final Ruby runtime;
     private final List<IRubyObject> links = new ArrayList<>();

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
@@ -84,6 +84,8 @@ import static org.jruby.util.RubyStringBuilder.str;
  *
  * @author Anders
  */
+@Deprecated(since = "10.0", forRemoval = true)
+@SuppressWarnings("removal")
 public class UnmarshalStream extends InputStream {
 
     protected final Ruby runtime;

--- a/core/src/main/java/org/jruby/util/io/RubyInputStream.java
+++ b/core/src/main/java/org/jruby/util/io/RubyInputStream.java
@@ -1,0 +1,97 @@
+package org.jruby.util.io;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.Helpers;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class RubyInputStream {
+    private final Ruby runtime;
+    private final InputStream wrap;
+
+    public RubyInputStream(Ruby runtime, InputStream wrap) {
+        this.runtime = runtime;
+        this.wrap = wrap;
+    }
+
+    public int read() {
+        try {
+            return wrap.read();
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public int read(byte[] b) {
+        try {
+            return wrap.read(b);
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public int read(byte[] b, int off, int len) {
+        try {
+            return wrap.read(b, off, len);
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public byte[] readAllBytes() {
+        try {
+            return wrap.readAllBytes();
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public byte[] readNBytes(int len) {
+        try {
+            return wrap.readNBytes(len);
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public int readNBytes(byte[] b, int off, int len) {
+        try {
+            return wrap.readNBytes(b, off, len);
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public long skip(long n) {
+        try {
+            return wrap.skip(n);
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public void skipNBytes(long n) {
+        try {
+            wrap.skipNBytes(n);
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public int available() {
+        try {
+            return wrap.available();
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+
+    public void close() {
+        try {
+            wrap.close();
+        } catch (IOException e) {
+            throw Helpers.newIOErrorFromException(runtime, e);
+        }
+    }
+}


### PR DESCRIPTION
* Propagate context and stream through stack.
* Privatize methods that don't need to be public.
* Deprecate UnmarshalStream for removal.
* Rename Dumper to MarshalDumper
* Add default impls of deprecated ObjectMarshal methods so they can be dropped by ext authors over time