### PR TITLE
Save original callers callInfo in tracepoint

### DIFF
--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -20,6 +20,7 @@ import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.util.RubyStringBuilder.str;
 
 public class TracePoint extends RubyObject {
@@ -85,6 +86,8 @@ public class TracePoint extends RubyObject {
             public void event(ThreadContext context, RubyEvent event, String file, int line, String name, IRubyObject type) {
                 if (!enabled || context.isWithinTrace()) return;
 
+                int savedCallInfo = resetCallInfo(context);
+
                 synchronized (this) {
                     inside = true;
 
@@ -109,6 +112,7 @@ public class TracePoint extends RubyObject {
                         update(null, null, line, null, context.nil, context.nil, context.nil, context.nil);
                         context.postTrace();
                         inside = false;
+                        context.callInfo = savedCallInfo;
                     }
                 }
             }


### PR DESCRIPTION
tracepoint ends up dyncalling into a Ruby method and that method basically replaces the original callInfo for the method you will call right after calling your tracepoint ruby code.  The fix is to just save it off until you are done and restore it before the traced method is called.  

This should be generalized for all tracepoint events since the fix is in the main events method.

Fixes #8688 