### PR TITLE
Add missing logic I added for procs to methods for ruby-facing arity

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -144,7 +144,11 @@ public class RubyMethod extends AbstractRubyMethod {
      */
     @JRubyMethod
     public RubyFixnum arity(ThreadContext context) {
-        return asFixnum(context, method.getSignature().arityValue());
+        Signature signature = method.getSignature();
+        int min = signature.min();
+        int max = signature.max();
+
+        return asFixnum(context, min == max ? min : -min-1);
     }
 
     @JRubyMethod(name = "eql?")


### PR DESCRIPTION
Fixes #8698.  I made similar logic for blocks as the internal arity value which execution decides things is different than the external arity that #arity provides.