### PR TITLE
Refactor launcher AppCDS logic

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -750,13 +750,13 @@ if $use_jsa_file; then
         jruby_jsa_file="$JRUBY_JSA"
     fi
 
+    # Default to no-op script when explicitly generating
     if $regenerate_jsa_file; then
-        # Run no-op script if AppCDS caching was requested
         case $ruby_args in
-            (*[![:space:]]*) append ruby_args -e 1 ;;
+            (*[![:space:]]*) ;;
+            (*) append ruby_args -e 1 ;;
         esac
     fi
-
 
     # Archive should be regenerated manually if requested or it's outdated relative to JRuby
     if ! $regenerate_jsa_file && is_newer "$jruby_jar" "$jruby_jsa_file"; then

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -145,6 +145,18 @@ a_isempty() {
     return 0
 }
 
+# exists [FILE...]
+#
+# Returns 0 if all FILEs exist or none provided, otherwise returns 1
+exists() {
+    while [ "$#" -gt 0 ]; do
+        [ -e "$1" ] || return
+        shift
+    done
+
+    return 0
+}
+
 # is_newer FILE OTHER...
 #
 # Returns 0 if FILE is newer than all OTHER files. If FILE doesn't exist,
@@ -500,7 +512,7 @@ add_log "Detected Java version: $java_version"
 java_major=${java_version%%.*}
 
 # AppCDS support
-if [ "$java_major" -ge 13 ]; then
+if [ "$java_major" -ge 13 ] && exists "$JAVA_HOME"/lib/server/*.jsa; then
     java_has_appcds=true
 else
     java_has_appcds=false

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -477,10 +477,8 @@ java_is_modular() {
 }
 
 if java_is_modular; then
-    use_jsa_file=true
     use_modules=true
 else
-    use_jsa_file=false
     use_modules=false
 fi
 readonly use_modules
@@ -507,6 +505,9 @@ else
     java_has_appcds=false
 fi
 readonly java_has_appcds
+
+# Default to using AppCDS if available
+use_jsa_file="$java_has_appcds"
 
 # AppCDS autogeneration
 if [ "$java_major" -ge 19 ]; then

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -706,7 +706,7 @@ do
         --restore) append java_args -XX:CRaCRestoreFrom=.jruby.checkpoint ;;
         --cache)
             if $java_has_appcds; then
-                use_jsa_file=true
+                #use_jsa_file=true  # Currently this defaults to true
                 regenerate_jsa_file=true
             else
                 echo "Warning: Java $java_major doesn't support automatic AppCDS, ignoring --cache" >&2

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -135,6 +135,19 @@ preextend() {
     eval "$1=\"\${$2} \${$1}\""
 }
 
+# is_newer FILE OTHER...
+#
+# Returns 0 if FILE is newer than all OTHER files. If FILE doesn't exist,
+# return error. If OTHER files don't exist, pretend they're older than FILE.
+is_newer() {
+    local output master
+    master="$1"
+    shift
+
+    # Find any other files that are newer, negate outside find in case any don't exist
+    [ -e "$master" ] && ! find "$@" -newer "$master" 2>/dev/null | read -r _
+}
+
 # echo [STRING...]
 #
 # Dumb echo, i.e. print arguments joined by spaces with no further processing

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -703,34 +703,6 @@ JFFI_OPTS="-Djffi.boot.library.path=$JRUBY_HOME/lib/jni"
 
 CLASSPATH="${CP-}${CP_DELIMITER}${CLASSPATH-}"
 
-# ----- Tweak console environment for cygwin ----------------------------------
-
-if $cygwin; then
-    use_exec=false
-    JRUBY_HOME="$(cygpath --mixed "$JRUBY_HOME")"
-    JRUBY_SHELL="$(cygpath --mixed "$JRUBY_SHELL")"
-
-    eval set -- "$ruby_args"
-
-    case $1 in
-        /*)
-            if [ -f "$1" ] || [ -d "$1" ]; then
-                # replace first element of ruby_args with cygwin form
-                win_arg="$(cygpath -w "$1")"
-                shift
-                set -- "$win_arg" "$@"
-                assign ruby_args "$@"
-            fi
-            ;;
-    esac
-
-    # fix JLine to use UnixTerminal
-    if stty -icanon min 1 -echo > /dev/null 2>&1; then
-        JAVA_OPTS="$JAVA_OPTS -Djline.terminal=jline.UnixTerminal"
-    fi
-
-fi
-
 # ----- Module and Class Data Sharing flags for Java 9+ -----------------------
 
 if $use_modules; then
@@ -757,6 +729,34 @@ if $use_modules; then
             append java_args -Xlog:cds=info:file="$JRUBY_JSA".log -Xlog:cds+dynamic=info:file="$JRUBY_JSA".log
         fi
     fi
+fi
+
+# ----- Tweak console environment for cygwin ----------------------------------
+
+if $cygwin; then
+    use_exec=false
+    JRUBY_HOME="$(cygpath --mixed "$JRUBY_HOME")"
+    JRUBY_SHELL="$(cygpath --mixed "$JRUBY_SHELL")"
+
+    eval set -- "$ruby_args"
+
+    case $1 in
+        /*)
+            if [ -f "$1" ] || [ -d "$1" ]; then
+                # replace first element of ruby_args with cygwin form
+                win_arg="$(cygpath -w "$1")"
+                shift
+                set -- "$win_arg" "$@"
+                assign ruby_args "$@"
+            fi
+            ;;
+    esac
+
+    # fix JLine to use UnixTerminal
+    if stty -icanon min 1 -echo > /dev/null 2>&1; then
+        JAVA_OPTS="$JAVA_OPTS -Djline.terminal=jline.UnixTerminal"
+    fi
+
 fi
 
 # ----- Final prepration of the Java command line -----------------------------

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -744,7 +744,6 @@ readonly jruby_jsa_file="$JRUBY_HOME/lib/jruby-java$java_version.jsa"
 assign jruby_jsa_files "$JRUBY_HOME"/lib/jruby-java*.jsa
 readonly jruby_jsa_files
 
-
 if $use_jsa_file; then
     # Allow overriding default JSA file location
     if [ -n "${JRUBY_JSA-}" ]; then
@@ -877,11 +876,14 @@ if $print_environment_log; then
 fi
 
 # ----- Perform final mutations after logging ---------------------------------
+# Delete All AppCDS files and exit if requested
 if $remove_jsa_files; then
-    # Delete All AppCDS files if requested
     eval rm -f -- "$jruby_jsa_files"
-elif $regenerate_jsa_file && [ -e "$jruby_jsa_file" ]; then
-    # Delete AppCDS file if requested or if it's outdated
+    exit
+fi
+
+if $regenerate_jsa_file && [ -e "$jruby_jsa_file" ]; then
+    # Delete selected AppCDS file if requested or if it's outdated
     rm -f -- "$jruby_jsa_file"
 fi
 

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -872,7 +872,7 @@ fi
 # ----- Perform final mutations after logging ---------------------------------
 # Delete AppCDS file if requested or if it's outdated
 if $regenerate_jsa_file && [ -e "$jruby_jsa_file" ]; then
-    rm -f "$jruby_jsa_file"
+    rm -f -- "$jruby_jsa_file"
 fi
 
 # ----- Run JRuby! ------------------------------------------------------------

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -656,10 +656,8 @@ do
             java_class=org.jruby.main.CheckpointMain
             append java_args -XX:CRaCCheckpointTo=.jruby.checkpoint ;;
         # restore from checkpoint
-        --restore=*)
-            append java_args -XX:CRaCRestoreFrom="${1#--restore=}" ;;
-        --restore)
-            append java_args -XX:CRaCRestoreFrom=.jruby.checkpoint ;;
+        --restore=*) append java_args -XX:CRaCRestoreFrom="${1#--restore=}" ;;
+        --restore) append java_args -XX:CRaCRestoreFrom=.jruby.checkpoint ;;
         --cache)
             echo "EXPERIMENTAL: Regenerating the JRuby AppCDS archive at $jruby_jsa_file"
             echo "EXPERIMENTAL: Log output at ${jruby_jsa_file}.log"
@@ -668,10 +666,8 @@ do
             rm -f "$jruby_jsa_file"
             append java_args -XX:ArchiveClassesAtExit="$jruby_jsa_file" -Xlog:cds=off -Xlog:cds+dynamic=off
             ;;
-        --nocache)
-            use_jsa_file=false ;;
-        --logcache)
-            log_cds=true ;;
+        --nocache) use_jsa_file=false ;;
+        --logcache) log_cds=true ;;
         # Abort processing on the double dash
         --) break ;;
         # Other opts go to ruby

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -485,6 +485,29 @@ if $use_modules; then
     add_log "Detected Java modules at $JAVA_HOME"
 fi
 
+# ----- Detect Java version and determine available features ------------------
+# shellcheck source=/dev/null
+java_version=$(. "$JAVA_HOME/release" && echo "${JAVA_VERSION-}")
+
+# Split version out for integer comparisons
+java_major=${java_version%%.*}
+
+# AppCDS support
+if [ "$java_major" -ge 10 ]; then
+    java_has_appcds=true
+else
+    java_has_appcds=false
+fi
+readonly java_has_appcds
+
+# AppCDS autogeneration
+if [ "$java_major" -ge 19 ]; then
+    java_has_appcds_autogenerate=true
+else
+    java_has_appcds_autogenerate=false
+fi
+readonly java_has_appcds_autogenerate
+
 # ----- Process .java_opts files ----------------------------------------------
 
 # We include options on the java command line in the following order:

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -184,6 +184,7 @@ NO_BOOTCLASSPATH=false
 VERIFY_JRUBY=false
 print_environment_log=false
 regenerate_jsa_file=false
+remove_jsa_files=false
 log_cds=false
 
 if [ -z "${JRUBY_OPTS-}" ]; then
@@ -700,6 +701,7 @@ do
             fi
             ;;
         --nocache) use_jsa_file=false ;;
+        --rmcache) remove_jsa_files=true ;;
         --logcache) log_cds=true ;;
         # Abort processing on the double dash
         --) break ;;
@@ -737,6 +739,11 @@ fi
 
 # Default JVM Class Data Sharing Archive (jsa) file for JVMs that support it
 readonly jruby_jsa_file="$JRUBY_HOME/lib/jruby-java$java_version.jsa"
+
+# Find JSAs for all Java versions
+assign jruby_jsa_files "$JRUBY_HOME"/lib/jruby-java*.jsa
+readonly jruby_jsa_files
+
 
 if $use_jsa_file; then
     # Allow overriding default JSA file location
@@ -870,8 +877,11 @@ if $print_environment_log; then
 fi
 
 # ----- Perform final mutations after logging ---------------------------------
-# Delete AppCDS file if requested or if it's outdated
-if $regenerate_jsa_file && [ -e "$jruby_jsa_file" ]; then
+if $remove_jsa_files; then
+    # Delete All AppCDS files if requested
+    eval rm -f -- "$jruby_jsa_files"
+elif $regenerate_jsa_file && [ -e "$jruby_jsa_file" ]; then
+    # Delete AppCDS file if requested or if it's outdated
     rm -f -- "$jruby_jsa_file"
 fi
 

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -505,8 +505,8 @@ JAVA_OPTS="$JAVA_OPTS_TEMP"
 
 CP_DELIMITER=":"
 
-# add main jruby jar to the classpath
-JRUBY_ALREADY_ADDED=false
+# Find main jruby jar and add it to the classpath
+jruby_jar=
 for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
     if [ ! -e "$j" ]; then
         continue
@@ -516,11 +516,12 @@ for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
     else
         JRUBY_CP="$j"
     fi
-    if $JRUBY_ALREADY_ADDED; then
+    if [ -n "$jruby_jar" ]; then
         echo "WARNING: more than one JRuby JAR found in lib directory" 1>&2
     fi
-    JRUBY_ALREADY_ADDED=true
+    jruby_jar="$j"
 done
+readonly jruby_jar
 
 if $cygwin; then
     JRUBY_CP="$(cygpath -p -w "$JRUBY_CP")"

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -135,6 +135,16 @@ preextend() {
     eval "$1=\"\${$2} \${$1}\""
 }
 
+# a_isempty
+#
+# Return 0 if an array is empty, otherwise return 1
+a_isempty() {
+    case $ruby_args in
+        (*[![:space:]]*) return 1 ;;  # If any nonblank, not empty
+    esac
+    return 0
+}
+
 # is_newer FILE OTHER...
 #
 # Returns 0 if FILE is newer than all OTHER files. If FILE doesn't exist,
@@ -751,11 +761,8 @@ if $use_jsa_file; then
     fi
 
     # Default to no-op script when explicitly generating
-    if $regenerate_jsa_file; then
-        case $ruby_args in
-            (*[![:space:]]*) ;;
-            (*) append ruby_args -e 1 ;;
-        esac
+    if $regenerate_jsa_file && a_isempty "$ruby_args"; then
+        append ruby_args -e 1
     fi
 
     # Archive should be regenerated manually if requested or it's outdated relative to JRuby

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -501,7 +501,7 @@ java_version=$(. "$JAVA_HOME/release" && echo "${JAVA_VERSION-}")
 java_major=${java_version%%.*}
 
 # AppCDS support
-if [ "$java_major" -ge 10 ]; then
+if [ "$java_major" -ge 13 ]; then
     java_has_appcds=true
 else
     java_has_appcds=false
@@ -707,7 +707,7 @@ do
                 use_jsa_file=true
                 regenerate_jsa_file=true
             else
-                echo "Warning: Java $java_major doesn't support AppCDS, ignoring --cache" >&2
+                echo "Warning: Java $java_major doesn't support automatic AppCDS, ignoring --cache" >&2
             fi
             ;;
         --nocache) use_jsa_file=false ;;

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -394,9 +394,6 @@ readonly pwd_jruby_java_opts_file="$PWD/.jruby.java_opts"
 # Options from .dev_mode.java_opts for "--dev" mode, to reduce JRuby startup time
 readonly dev_mode_opts_file="$JRUBY_HOME/bin/.dev_mode.java_opts"
 
-# Default JVM Class Data Sharing Archive (jsa) file for JVMs that support it
-readonly jruby_jsa_file="$JRUBY_HOME/lib/jruby.jsa"
-
 # ----- Initialize environment log --------------------------------------------
 
 add_log
@@ -737,6 +734,9 @@ if $use_modules; then
     # Add base opens we need for Ruby compatibility
     process_java_opts "$jruby_module_opts_file"
 fi
+
+# Default JVM Class Data Sharing Archive (jsa) file for JVMs that support it
+readonly jruby_jsa_file="$JRUBY_HOME/lib/jruby-java$java_version.jsa"
 
 if $use_jsa_file; then
     # Allow overriding default JSA file location

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -717,12 +717,11 @@ do
         --restore=*) append java_args -XX:CRaCRestoreFrom="${1#--restore=}" ;;
         --restore) append java_args -XX:CRaCRestoreFrom=.jruby.checkpoint ;;
         --cache)
-            if $java_has_appcds; then
-                #use_jsa_file=true  # Currently this defaults to true
-                regenerate_jsa_file=true
-            else
-                echo "Warning: Java $java_major doesn't support automatic AppCDS, ignoring --cache" >&2
+            if ! $java_has_appcds; then
+                echo "Error: Java $java_major doesn't support automatic AppCDS" >&2
+                exit 2
             fi
+            regenerate_jsa_file=true  # Force regeneration of archive
             ;;
         --nocache) use_jsa_file=false ;;
         --rmcache) remove_jsa_files=true ;;

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -494,6 +494,7 @@ fi
 # ----- Detect Java version and determine available features ------------------
 # shellcheck source=/dev/null
 java_version=$(. "$JAVA_HOME/release" && echo "${JAVA_VERSION-}")
+add_log "Detected Java version: $java_version"
 
 # Split version out for integer comparisons
 java_major=${java_version%%.*}


### PR DESCRIPTION
The launcher now detects the Java version and uses the appropriate AppCDS flags. If I researched correctly, AppCDS is supported on Java 10+ and the AutoCreateSharedArchive flag on 19+. The modification time of the JRuby JAR is used to determine if the AppCDS archive should be explicitly regenerated.

The Java version currently does not factor into the regeneration calculation. The easiest solution would be to have an archive for every Java version, which would only involve sticking the relevant version in the filename, but could get unwieldy without a way to clean up old archives. We could also store the last-used version in a sidecar file, which also wouldn't be too bad since we already need access to the JRuby folder. I could use some input on what strategy we would prefer.