### PR TITLE
Less eager coderange when converting Java String

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1649,7 +1649,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     public final RubyString catString(String str) {
         ByteList other = encodeBytelist(str, UTF8);
-        catWithCodeRange(other, CR_VALID);
+        // if byte string is same size, assume all 7-bit; otherwise, unknown
+        catWithCodeRange(other, other.realSize() == str.length() ? CR_7BIT : CR_UNKNOWN);
         return this;
     }
 


### PR DESCRIPTION
By going to VALID, we force all Java strings produced by this function to do full Unicode validation when they are manipulated or written to another string. This was the root cause of jruby/jruby#8710, when an already-broken StringIO saw an incoming VALID string and followed full MBC verification logic.

This patch assumes that if the resulting byte[] string has the same number of bytes as the original string had chars, and the destination encoding is 7-bit ASCII compatible, then the code range can be 7-BIT, avoiding extra encoding logic for such strings.

This feels like a bit of a hack; CRuby fails the cases in jruby/jruby#8710 exactly like JRuby if an MBC element is in the backtrace, meaning that it was just "lucky" that the test case from rake produced only 7-bit backtrace elements. There's more discussion needed here, because I'm not sure this test is actually testing anything reliable.