### PR TITLE
Restructure gem_prelude to fit JRuby's needs

### DIFF
--- a/core/src/main/ruby/jruby/kernel/gem_prelude.rb
+++ b/core/src/main/ruby/jruby/kernel/gem_prelude.rb
@@ -1,3 +1,4 @@
+# Note: this file is modified from CRuby's gem_prelude.rb and should be carefully updated
 begin
   require 'rubygems'
 rescue LoadError => e
@@ -6,24 +7,19 @@ rescue LoadError => e
   warn "`RubyGems' were not loaded."
 else
   require 'bundled_gems'
+
+  begin
+    require 'did_you_mean'
+  rescue LoadError
+    warn "`did_you_mean' was not loaded."
+  end if defined?(DidYouMean)
+
+  begin
+    require 'syntax_suggest/core_ext'
+  rescue LoadError
+    warn "`syntax_suggest' was not loaded."
+  end if defined?(SyntaxSuggest)
+
+  # clear RubyGems paths so they can be reinitialized after boot
+  Gem.clear_paths
 end if defined?(Gem)
-
-# error_highlight is currently CRuby-specific and should not be used on JRuby
-# begin
-#   require 'error_highlight'
-# rescue LoadError
-#   warn "`error_highlight' was not loaded."
-# end if defined?(ErrorHighlight)
-
-begin
-  require 'did_you_mean'
-rescue LoadError
-  warn "`did_you_mean' was not loaded."
-end if defined?(DidYouMean)
-
-begin
-  require 'syntax_suggest/core_ext'
-rescue LoadError
-  warn "`syntax_suggest' was not loaded."
-end if defined?(SyntaxSuggest)
-


### PR DESCRIPTION
* Don't bother trying to load did_you_mean and syntax_suggest if gems are not enabled.
* Clear gem paths after load when gems are enabled.

Fixes jruby/jruby#8712