### PR TITLE
Launcher: Defensive fixes

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -702,6 +702,10 @@ do
         -X*.*) append java_args -Djruby."${1#-X}" ;;
         # Match switches that take an argument
         -[CeIS])
+            if [ "$#" -eq 1 ]; then
+                echo "Error: Missing argument to $1" >&2
+                exit 2
+            fi
             append ruby_args "$1" "$2"
             shift
             ;;

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -523,6 +523,11 @@ if $use_modules; then
 fi
 
 # ----- Detect Java version and determine available features ------------------
+
+# assume Java 8 if no release file
+java_version=1.8
+java_major=8
+
 # shellcheck source=/dev/null
 if [ -f "$JAVA_HOME/release" ]; then
     # Get java version from JAVA_HOME/release file
@@ -550,11 +555,10 @@ if [ -f "$JAVA_HOME/release" ]; then
         1.8 | 1.8.*) java_major=8 ;;
         *)           java_major=${java_version%%.*} ;;
     esac
-else
-    # assume Java 8 if no release file
-    java_version=1.8
-    java_major=8
 fi
+
+# Default java_runtime_version to $java_version
+: "${java_runtime_version:=$java_version}"
 
 # shellcheck source=/dev/null
 if [ -f "$JRUBY_HOME/bin/.java-version" ] && . "$JRUBY_HOME/bin/.java-version" && [ "${JRUBY_MINIMUM_JAVA_VERSION-}" ]; then

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -540,6 +540,7 @@ if [ -f "$JAVA_HOME/release" ]; then
 
         case $name in
             (JAVA_VERSION) java_version=$value ;;
+            (JAVA_RELEASE_VERSION) java_runtime_version=$value ;;
         esac
     done < "$JAVA_HOME"/release
     unset line name value
@@ -563,6 +564,7 @@ else
     minimum_java_version=8
 fi
 add_log "Detected Java version: $java_version"
+add_log "Detected Java runtime version: $java_runtime_version"
 
 # Present a useful error if running a Java version lower than bin/.java-version
 if [ "$java_major" -lt "$minimum_java_version" ]; then
@@ -843,7 +845,7 @@ if $use_modules; then
 fi
 
 # Default JVM Class Data Sharing Archive (jsa) file for JVMs that support it
-readonly jruby_jsa_file="$JRUBY_HOME/lib/jruby-java$java_version.jsa"
+readonly jruby_jsa_file="$JRUBY_HOME/lib/jruby-java$java_runtime_version.jsa"
 
 # Find JSAs for all Java versions
 assign jruby_jsa_files "$JRUBY_HOME"/lib/jruby-java*.jsa

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -402,6 +402,15 @@ JRUBY_HOME="${SELF_PATH%/*/*}"
 
 # ----- File paths for various options and files we'll process later ----------
 
+# Find HOME of current user if empty
+if [ -z "${HOME-}" ]; then
+    username=$(id -un)
+    case $username in
+        (*[!_[:alnum]]*) ;;
+        (*) eval HOME="~$username"; export HOME ;;
+    esac
+fi
+
 # Module options to open up packages we need to reflect
 readonly jruby_module_opts_file="$JRUBY_HOME/bin/.jruby.module_opts"
 

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -537,15 +537,11 @@ if [ -f "$JAVA_HOME/release" ]; then
         esac
 
         name=${line%%=*}
-
-        # I think the values are JSON encoded but the ones we care about don't
-        # require any special parsing
-        unquote "${line#*=}"
-        value=$REPLY
+        value=${line#*=}
 
         case $name in
-            (JAVA_VERSION) java_version=$value ;;
-            (JAVA_RELEASE_VERSION) java_runtime_version=$value ;;
+            (JAVA_VERSION) unquote "$value" && java_version=$REPLY ;;
+            (JAVA_RELEASE_VERSION) unquote "$value" && java_runtime_version=$REPLY ;;
         esac
     done < "$JAVA_HOME"/release
     unset line name value


### PR DESCRIPTION
Added some checks to the launcher to handle missing `HOME`, `JAVA_HOME`, or argument to `-{C,e,I,S}`

Fixes #8747