### PR TITLE
[ji] avoid false duplicate method warning

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -215,6 +215,11 @@ public class MethodGatherer {
     }
 
     private static boolean methodsAreEquivalent(Method child, Method parent) {
+        if (child.getDeclaringClass().isAssignableFrom(parent.getDeclaringClass()) && child.getDeclaringClass() != parent.getDeclaringClass()) {
+            final Method temp = parent; // swap them since child is actually the parent in terms of class hierarchy
+            parent = child; child = temp;
+        }
+
         if (parent.getDeclaringClass().isAssignableFrom(child.getDeclaringClass())) {
             return sameTypesAndAccessModifier(child, parent); // most cases will end here
         }
@@ -261,7 +266,7 @@ public class MethodGatherer {
                 // we have seen other methods; check if we already have an equivalent one
                 for (int i = 0; i < childMethods.size(); i++) {
                     final Method current = childMethods.get(i);
-                    if ( methodsAreEquivalent(current, method) ) {
+                    if (methodsAreEquivalent(current, method)) {
                         if (removeDuplicate) {
                             // Replace the existing method, since the super call is more general
                             // and virtual dispatch will call the subclass impl anyway.

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -2008,6 +2008,15 @@ CLASSDEF
     assert_equal 255, color.getRed # assert we called (float,float,float)
   end
 
+  def test_no_ambiguous_warning_when_method_inherited_from_2_interfaces
+    map = org.jruby.javasupport.test.TestConcurrentMapFactory.newMap
+    output = with_stderr_captured do # exact match should not warn:
+      map.compute(:key) { 42 } # warning: multiple Java methods found, use -Xjruby.ji.ambiguous.calls.debug for backtrace.
+      # Choosing compute(java.lang.Object,java.util.function.BiFunction)
+    end
+    assert_equal "", output
+  end
+
   class Runner
     def run; end
   end

--- a/test/org/jruby/javasupport/test/TestConcurrentMap.java
+++ b/test/org/jruby/javasupport/test/TestConcurrentMap.java
@@ -1,0 +1,89 @@
+package org.jruby.javasupport.test;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+
+/**
+ * A test for ambiguous warning when same interface method is declared twice:
+ * <ul>
+ *     <li><link>{@link java.util.Map#compute(Object, BiFunction)}</link></li>
+ *     <li><link>{@link java.util.concurrent.ConcurrentMap#compute(Object, BiFunction)}</link></li>
+ * <ul/>
+ *
+ * @param <K>
+ * @param <V>
+ */
+class TestConcurrentMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> {
+    private final ConcurrentMap<K, V> delegate = new ConcurrentHashMap<>();
+
+    @Override
+    public V get(Object key) {
+        if (key == null) {
+            return null;
+        }
+        return delegate.get(key);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (key == null) {
+            return false;
+        }
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        if (value == null) {
+            return false;
+        }
+        return delegate.containsValue(value);
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        if (key == null) {
+            return null;
+        }
+        return delegate.putIfAbsent(key, value);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        throw new UnsupportedOperationException("remove(2)");
+    }
+
+    @Override
+    public V replace(K key, V value) {
+        throw new UnsupportedOperationException("replace(2)");
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        throw new UnsupportedOperationException("replace(3)");
+    }
+
+    @Override
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> function) {
+        return delegate.compute(key, function);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return delegate.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return delegate.values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return delegate.entrySet();
+    }
+}

--- a/test/org/jruby/javasupport/test/TestConcurrentMapFactory.java
+++ b/test/org/jruby/javasupport/test/TestConcurrentMapFactory.java
@@ -1,0 +1,9 @@
+package org.jruby.javasupport.test;
+
+import java.util.concurrent.ConcurrentMap;
+
+public abstract class TestConcurrentMapFactory {
+    public static <K, V> ConcurrentMap<K, V> newMap() {
+        return new TestConcurrentMap<>();
+    }
+}


### PR DESCRIPTION
The test case is mirrored after a real-world Map impl from Guava:

```ruby
map = com.google.common.cache.CacheBuilder.new_builder.build.as_map 
# map is an instance of: Java::ComGoogleCommonCache::LocalCache
map.compute(:foo) { |_, value| 42 }
```
leading to a false-positive warning:
```
(RuntimeError) multiple Java methods found, dumping backtrace and choosing compute(java.lang.Object,java.util.function.BiFunction)
```
upon inspection of the `CallableSelector` there were 2 methods:
- `public default java.lang.Object java.util.concurrent.ConcurrentMap.compute(java.lang.Object,java.util.function.BiFunction)` 
- `public default java.lang.Object java.util.Map.compute(java.lang.Object,java.util.function.BiFunction)]`