### PR TITLE
Don't attempt to forward block to non-zsuper

### DIFF
--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -2725,9 +2725,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
 
     protected Operand buildSuper(Variable aResult, U iterNode, U argsNode, int line, boolean isNewline) {
         Variable result = aResult == null ? temp() : aResult;
-        Operand tempBlock = setupCallClosure(argsNode, iterNode);
-        if (tempBlock == NullBlock.INSTANCE) tempBlock = getYieldClosureVariable();
-        Operand block = tempBlock;
+        Operand block = setupCallClosure(argsNode, iterNode);
 
         boolean inClassBody = scope instanceof IRMethod && scope.getLexicalParent() instanceof IRClassBody;
         boolean isInstanceMethod = inClassBody && ((IRMethod) scope).isInstanceMethod;


### PR DESCRIPTION
Not sure how this has not been noticed up to now, but we should not be forwarding the passed-in block to super when it is a normal non-z super. This patch removes that logic and only passes along any block that was directly provided to the super call.

Fixes jruby/jruby#8728

This should be fixed for 9.4.13.0 but JRuby 10 will be released first... so I'm not sure how best to mark this milestone.