### PR TITLE
Remove this warning to match standard set.rb

### DIFF
--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -188,9 +188,6 @@ public class RubySet extends RubyObject implements Set {
      */
     @JRubyMethod(visibility = Visibility.PRIVATE) // def initialize(enum = nil, &block)
     public IRubyObject initialize(ThreadContext context, Block block) {
-        if ( block.isGiven() && context.runtime.isVerbose() ) {
-            context.runtime.getWarnings().warning(IRubyWarnings.ID.BLOCK_UNUSED, "given block not used");
-        }
         allocHash(context.runtime);
         return this;
     }


### PR DESCRIPTION
The standard set library does not warn along any path if an unused block is passed to initialize. We should do the same until the maintainers of the set gem decide that the warning should be added.

Fixes jruby/jruby#8728

See ruby/set#41 for a report about the "missing" warning.