### PR TITLE
Reduce overhead of indy plumbing

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1413,7 +1413,7 @@ public class RubyClass extends RubyModule {
 
     void addInvalidatorsAndFlush(InvalidatorList invalidators) {
         // add this class's invalidators to the aggregate
-        invalidators.add(methodInvalidator);
+        methodInvalidator.addIfUsed(invalidators);
 
         // if we're not at boot time, don't bother fully clearing caches
         if (!runtime.isBootingCore()) getCachedMethods().clear();

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2376,19 +2376,21 @@ public class RubyModule extends RubyObject {
             return;
         }
 
-        InvalidatorList invalidators = new InvalidatorList();
-        invalidators.add(methodInvalidator);
+        InvalidatorList invalidators = new InvalidatorList((int) (lastInvalidatorSize * 1.25));
+        methodInvalidator.addIfUsed(invalidators);
 
         synchronized (getRuntime().getHierarchyLock()) {
             includingHierarchies.forEachClass(invalidators);
         }
 
+        lastInvalidatorSize = invalidators.size();
+
         methodInvalidator.invalidateAll(invalidators);
     }
 
-    static class InvalidatorList<T> extends ArrayList<T> implements RubyClass.BiConsumerIgnoresSecond<RubyClass> {
-        public InvalidatorList() {
-            super();
+    public static class InvalidatorList<T> extends ArrayList<T> implements RubyClass.BiConsumerIgnoresSecond<RubyClass> {
+        public InvalidatorList(int size) {
+            super(size);
         }
 
         @Override
@@ -6983,6 +6985,9 @@ public class RubyModule extends RubyObject {
 
     // Invalidator used for method caches
     protected final Invalidator methodInvalidator;
+
+    // track last size to avoid thrashing
+    private int lastInvalidatorSize = 4;
 
     /** Whether this class proxies a normal Java class */
     private boolean javaProxy = false;

--- a/core/src/main/java/org/jruby/runtime/opto/FailoverSwitchPointInvalidator.java
+++ b/core/src/main/java/org/jruby/runtime/opto/FailoverSwitchPointInvalidator.java
@@ -65,6 +65,8 @@ public class FailoverSwitchPointInvalidator implements Invalidator {
     }
 
     public void invalidateAll(List<Invalidator> invalidators) {
+        if (invalidators.isEmpty()) return;
+
         SwitchPoint[] switchPoints = new SwitchPoint[invalidators.size()];
         
         for (int i = 0; i < invalidators.size(); i++) {

--- a/core/src/main/java/org/jruby/runtime/opto/GenerationAndSwitchPointInvalidator.java
+++ b/core/src/main/java/org/jruby/runtime/opto/GenerationAndSwitchPointInvalidator.java
@@ -20,19 +20,26 @@ public class GenerationAndSwitchPointInvalidator implements Invalidator {
     }
     
     public void invalidateAll(List<Invalidator> invalidators) {
+        if (invalidators.isEmpty()) return;
+
         SwitchPoint[] switchPoints = new SwitchPoint[invalidators.size()];
         
         for (int i = 0; i < invalidators.size(); i++) {
             Invalidator invalidator = invalidators.get(i);
-            assert invalidator instanceof GenerationAndSwitchPointInvalidator;
-            GenerationAndSwitchPointInvalidator gsInvalidator = (GenerationAndSwitchPointInvalidator)invalidator;
-            gsInvalidator.generationInvalidator.invalidate();
-            switchPoints[i] = gsInvalidator.switchPointInvalidator.replaceSwitchPoint();
+            assert invalidator instanceof SwitchPointInvalidator;
+            SwitchPointInvalidator switchPointInvalidator = (SwitchPointInvalidator) invalidator;
+            switchPoints[i] = switchPointInvalidator.replaceSwitchPoint();
         }
         SwitchPoint.invalidateAll(switchPoints);
     }
 
     public Object getData() {
         return switchPointInvalidator.getData();
+    }
+
+    public void addIfUsed(RubyModule.InvalidatorList invalidators) {
+        // invalidate generation immediately and only add SP invalidator
+        generationInvalidator.invalidate();
+        switchPointInvalidator.addIfUsed(invalidators);
     }
 }

--- a/core/src/main/java/org/jruby/runtime/opto/GenerationInvalidator.java
+++ b/core/src/main/java/org/jruby/runtime/opto/GenerationInvalidator.java
@@ -14,13 +14,11 @@ public class GenerationInvalidator implements Invalidator {
     }
     
     public void invalidateAll(List<Invalidator> invalidators) {
-        for (Invalidator invalidator : invalidators) {
-            invalidator.invalidate();
-        }
+        invalidators.forEach(Invalidator::invalidate);
     }
 
     public Object getData() {
-        return module.getGenerationObject();
+        throw new RuntimeException("generation object should not be used");
     }
     
 }

--- a/core/src/main/java/org/jruby/runtime/opto/Invalidator.java
+++ b/core/src/main/java/org/jruby/runtime/opto/Invalidator.java
@@ -27,6 +27,8 @@
 
 package org.jruby.runtime.opto;
 
+import org.jruby.RubyModule;
+
 import java.util.List;
 
 /**
@@ -43,4 +45,7 @@ public interface Invalidator {
     public void invalidate();
     public void invalidateAll(List<Invalidator> invalidators);
     public Object getData();
+    default void addIfUsed(RubyModule.InvalidatorList invalidators) {
+        invalidators.add(this);
+    }
 }

--- a/core/src/main/java/org/jruby/runtime/opto/ObjectIdentityInvalidator.java
+++ b/core/src/main/java/org/jruby/runtime/opto/ObjectIdentityInvalidator.java
@@ -29,6 +29,7 @@ package org.jruby.runtime.opto;
 
 import java.util.List;
 
+@Deprecated(since = "10.0", forRemoval = true)
 public class ObjectIdentityInvalidator implements Invalidator {
     private volatile Object generation;
     
@@ -41,9 +42,7 @@ public class ObjectIdentityInvalidator implements Invalidator {
     }
     
     public void invalidateAll(List<Invalidator> invalidators) {
-        for (Invalidator invalidator : invalidators) {
-            invalidator.invalidate();
-        }
+        invalidators.forEach(Invalidator::invalidate);
     }
 
     public Object getData() {

--- a/core/src/main/java/org/jruby/runtime/opto/SwitchPointInvalidator.java
+++ b/core/src/main/java/org/jruby/runtime/opto/SwitchPointInvalidator.java
@@ -27,6 +27,8 @@
 
 package org.jruby.runtime.opto;
 
+import org.jruby.RubyModule;
+
 import java.lang.invoke.SwitchPoint;
 import java.util.List;
 
@@ -41,10 +43,12 @@ public class SwitchPointInvalidator implements Invalidator {
         if (switchPoint == DUMMY) return;
 
         SwitchPoint.invalidateAll(new SwitchPoint[]{switchPoint});
-        switchPoint = new SwitchPoint();
+        switchPoint = DUMMY;
     }
 
     public void invalidateAll(List<Invalidator> invalidators) {
+        if (invalidators.isEmpty()) return;
+
         SwitchPoint[] switchPoints = new SwitchPoint[invalidators.size()];
         
         for (int i = 0; i < invalidators.size(); i++) {
@@ -66,7 +70,11 @@ public class SwitchPointInvalidator implements Invalidator {
         if (switchPoint == DUMMY) return switchPoint;
 
         SwitchPoint oldSwitchPoint = switchPoint;
-        this.switchPoint = new SwitchPoint();
+        this.switchPoint = DUMMY;
         return oldSwitchPoint;
+    }
+
+    public void addIfUsed(RubyModule.InvalidatorList invalidators) {
+        if (switchPoint != DUMMY) invalidators.add(this);
     }
 }


### PR DESCRIPTION
JRuby 10 enables invokedynamic for all optimization by default. Unfortunately, some of the plumbing around invokedynamic use has never seen much in the way of profiling and optimization. This can impact early boot times for applications and early execution performance and warmup.

This PR will be a pass over the key parts of indy infrastructure with a goal of "harm reduction" when boot-time and early runtime common cases hit this plumbing heavily.

Optimizations included:

* Reduce overhead from hierarchy-based invalidation by right-sizing lists and avoiding re-invalidation of unused SwitchPoints.