### PR TITLE
Fix `sprinf` with explicit zero precision and zero value

### DIFF
--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -874,7 +874,16 @@ public class Sprintf {
                             if (leadChar != 0) len++;
                         }
                     }
+
                     int numlen = bytes.length - first;
+                    switch (fchar) {
+                    case 'd': case 'i': case 'u':
+                        // If the precision is 0 and the value is 0, nothing is written.
+                        if ((flags & FLAG_PRECISION) != 0 && precision == 0 && zero) {
+                            numlen = 0;
+                        }
+                    }
+
                     len += numlen;
 
                     if ((flags & (FLAG_ZERO|FLAG_PRECISION)) == FLAG_ZERO) {

--- a/spec/ruby/core/kernel/shared/sprintf.rb
+++ b/spec/ruby/core/kernel/shared/sprintf.rb
@@ -22,6 +22,7 @@ describe :kernel_sprintf, shared: true do
       @method.call("%d", "112").should == "112"
       @method.call("%d", "0127").should == "87"
       @method.call("%d", "0xc4").should == "196"
+      @method.call("%d", "0").should == "0"
     end
 
     it "raises TypeError exception if cannot convert to Integer" do
@@ -56,6 +57,11 @@ describe :kernel_sprintf, shared: true do
 
         it "works well with large numbers" do
           @method.call("%#{f}", 1234567890987654321).should == "1234567890987654321"
+        end
+
+        it "converts to the empty string if precision is 0 and value is 0" do
+          @method.call("%.#{f}", 0).should == ""
+          @method.call("%.0#{f}", 0).should == ""
         end
       end
     end


### PR DESCRIPTION
In that case, nothing is written. It's documented: https://docs.ruby-lang.org/en/3.4/format_specifications_rdoc.html#:~:text=if%20the%20precision%20is%200%20and%20the%20value%20is%200%2C%20nothing%20is%20written

NOTE: I found this code quite hard to follow and there was at least one other place I contemplated implementing a fix. Not sure if what I chose is in fact the best place for a fix.