### PR TITLE
More broad jsa gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ latest_source_cache
 core/src/main/java/META-INF/
 lib/jni
 lib/jruby*.jar
-lib/jruby.jsa*
+lib/jruby*.jsa*
 lib/native
 lib/ruby/gems
 


### PR DESCRIPTION
For me, this one is (currently) named like `jruby-java21.0.6.jsa`