### PR TITLE
parameterless blocks must check for `it` outside the block in case it exists already

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -399,9 +399,11 @@ public abstract class RubyParserBase {
             node = new LocalVarNode(lexer.tokline, slot, name);
         } else if (dyna_in_block() && id.equals("it")) {
             if (!hasArguments()) {
-                slot = currentScope.addVariable(id);
+                int existing = currentScope.isDefined(id);
+                slot = existing == -1 ?
+                        currentScope.addVariable(id) : existing;
                 node = new DVarNode(lexer.tokline, slot, name);
-                set_it_id(node);
+                if (existing == -1) set_it_id(node);
             } else {
                 slot = currentScope.isDefined(id);
                 // A special it cannot exist without being marked as a special it.

--- a/spec/ruby/language/block_spec.rb
+++ b/spec/ruby/language/block_spec.rb
@@ -1102,3 +1102,11 @@ describe "`it` calls without arguments in a block with no ordinary parameters" d
     end
   end
 end
+
+describe "`it` is a captured variable in a block if `it` is outside" do
+  ruby_version_is "3.3"..."3.4" do
+    proc { it }.call(0).should eq(0)
+    it = 5
+    proc { it }.call(0).should eq(5)
+  end
+end


### PR DESCRIPTION
parameterless blocks must check for `it` outside the block in case it exists already

Fixes #8767