### PR TITLE
Run scheduled workflows on main repository only

### DIFF
--- a/.github/workflows/nightly-snapshot-publish-21.yml
+++ b/.github/workflows/nightly-snapshot-publish-21.yml
@@ -14,7 +14,7 @@ jobs:
   publish-snapshot:
     permissions:
       contents: read
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'jruby/jruby' }}
     uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d8369e218d4878b79d394a90483f109a2096a820
     with:
       javaLevel: 21

--- a/.github/workflows/nightly-snapshot-publish.yml
+++ b/.github/workflows/nightly-snapshot-publish.yml
@@ -14,7 +14,7 @@ jobs:
   publish-snapshot:
     permissions:
       contents: read
-    if: ${{ github.ref == 'refs/heads/jruby-9.4' }}
+    if: ${{ github.ref == 'refs/heads/jruby-9.4' && github.repository == 'jruby/jruby' }}
     uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d8369e218d4878b79d394a90483f109a2096a820
     with:
       javaLevel: 8


### PR DESCRIPTION
They currently also run on forks, where they will fail during publishing