### PR TITLE
== and === need to support endless method definitions

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1757,8 +1757,12 @@ public abstract class RubyParserBase {
                 return Global;
         }
 
-        byte last = (byte) identifier.get(identifier.length() - 1);
+        int length = identifier.length();
+        byte last = (byte) identifier.get(length - 1);
         if (last == '=') {
+            if (length > 1 && identifier.charAt(length - 2) == '=') {
+                return Local;
+            }
             return AttrSet;
         }
 


### PR DESCRIPTION
== and === need to support endless method definitions

Fixes #8776