### PR TITLE
`it` broken in irb. Used wrong scope type field in parser.

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -2487,7 +2487,7 @@ public abstract class RubyParserBase {
     }
 
     protected boolean dyna_in_block() {
-        return currentScope.isBlockScope() && currentScope.scopeType != IRScopeType.EVAL_SCRIPT;
+        return currentScope.isBlockScope() && currentScope.getType() != StaticScope.Type.EVAL;
     }
 
     private boolean hasArguments() {


### PR DESCRIPTION
Fixes #8796

There is a magic function `dyna_in_block` and it was using the hard containing lexiical scope (`scopeType`) and not the actual current scope (`type`).  Very confusing naming to the point I melded these two fields into only being a single field.