### PR TITLE
Allow binding instance/internal vars to fields

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -68,6 +68,7 @@ import org.jruby.anno.AnnotationHelper;
 import org.jruby.anno.FrameField;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyConstant;
+import org.jruby.anno.JRubyField;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JavaMethodDescriptor;
 import org.jruby.anno.TypePopulator;

--- a/core/src/main/java/org/jruby/RubyNoMethodError.java
+++ b/core/src/main/java/org/jruby/RubyNoMethodError.java
@@ -26,6 +26,7 @@
 
 package org.jruby;
 
+import org.jruby.anno.JRubyField;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.NoMethodError;
@@ -47,15 +48,17 @@ import static org.jruby.api.Define.defineClass;
  */
 @JRubyClass(name="NoMethodError", parent="NameError")
 public class RubyNoMethodError extends RubyNameError implements Reified {
+    @JRubyField
     private IRubyObject args;
 
     private static final ObjectAllocator ALLOCATOR = RubyNoMethodError::new;
 
     static RubyClass define(ThreadContext context, RubyClass NameError) {
         RubyClass noMethodError = defineClass(context, "NoMethodError", NameError, ALLOCATOR).
-                defineMethods(context, RubyNoMethodError.class);
-        noMethodError.reifiedClass(RubyNoMethodError.class);
-        noMethodError.getVariableTableManager().requestFieldStorage("args", "args", IRubyObject.class, false, null, MethodHandles.lookup());
+                reifiedClass(RubyNoMethodError.class).
+                defineMethods(context, RubyNoMethodError.class).
+                defineFields(context, RubyNoMethodError.class, MethodHandles.lookup());
+
         return noMethodError;
     }
 

--- a/core/src/main/java/org/jruby/RubyNoMethodError.java
+++ b/core/src/main/java/org/jruby/RubyNoMethodError.java
@@ -30,10 +30,13 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.NoMethodError;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.java.codegen.Reified;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+
+import java.lang.invoke.MethodHandles;
 
 import static org.jruby.api.Define.defineClass;
 
@@ -43,14 +46,17 @@ import static org.jruby.api.Define.defineClass;
  * @see NoMethodError
  */
 @JRubyClass(name="NoMethodError", parent="NameError")
-public class RubyNoMethodError extends RubyNameError {
+public class RubyNoMethodError extends RubyNameError implements Reified {
     private IRubyObject args;
 
     private static final ObjectAllocator ALLOCATOR = RubyNoMethodError::new;
 
     static RubyClass define(ThreadContext context, RubyClass NameError) {
-        return defineClass(context, "NoMethodError", NameError, ALLOCATOR).
+        RubyClass noMethodError = defineClass(context, "NoMethodError", NameError, ALLOCATOR).
                 defineMethods(context, RubyNoMethodError.class);
+        noMethodError.reifiedClass(RubyNoMethodError.class);
+        noMethodError.getVariableTableManager().requestFieldStorage("args", "args", IRubyObject.class, false, null, MethodHandles.lookup());
+        return noMethodError;
     }
 
     protected RubyNoMethodError(Ruby runtime, RubyClass exceptionClass) {

--- a/core/src/main/java/org/jruby/anno/JRubyField.java
+++ b/core/src/main/java/org/jruby/anno/JRubyField.java
@@ -1,0 +1,5 @@
+package org.jruby.anno;
+
+public @interface JRubyField {
+    String value() default "";
+}

--- a/core/src/main/java/org/jruby/javasupport/util/JavaClassConfiguration.java
+++ b/core/src/main/java/org/jruby/javasupport/util/JavaClassConfiguration.java
@@ -26,6 +26,9 @@
 
 package org.jruby.javasupport.util;
 
+import org.jruby.specialized.RubyObjectSpecializer;
+
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -129,15 +132,22 @@ public class JavaClassConfiguration implements Cloneable {
     
     public static class DirectFieldConfiguration {
         public String name;
+        public String rubyName;
         public Class<?> fieldType;
         public Boolean unwrap;
         public Class<?> unwrapType;
+        public MethodHandles.Lookup lookup;
         public DirectFieldConfiguration(String name, Class<?> fieldType, Boolean unwrap, Class<?> unwrapType) {
+            this(name, '@' + name, fieldType, unwrap, unwrapType, RubyObjectSpecializer.LOOKUP);
+        }
+
+        public DirectFieldConfiguration(String name, String rubyName, Class<?> fieldType, Boolean unwrap, Class<?> unwrapType, MethodHandles.Lookup lookup) {
             this.name = name;
+            this.rubyName = rubyName;
             this.fieldType = fieldType;
             this.unwrap = unwrap;
             this.unwrapType = unwrapType;
+            this.lookup = lookup;
         }
-        
     }
 }

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -194,8 +195,16 @@ public class VariableTableManager {
      * This is internal API, don't call this directly if you aren't in the JRuby codebase, it may change
      * Request that the listed ivars (no @ in name) have field storage when we are reified
      */
-    public synchronized void requestFieldStorage(String name, Class<?> fieldType,  Boolean unwrap, Class<?> toType) {
-        DirectFieldConfiguration config = new JavaClassConfiguration.DirectFieldConfiguration(name, fieldType, unwrap, toType);
+    public synchronized void requestFieldStorage(String name, Class<?> fieldType, Boolean unwrap, Class<?> toType) {
+        requestFieldStorage(name, '@' + name, fieldType, unwrap, toType, RubyObjectSpecializer.LOOKUP);
+    }
+
+    /**
+     * This is internal API, don't call this directly if you aren't in the JRuby codebase, it may change
+     * Request that the listed ivars (no @ in name) have field storage when we are reified
+     */
+    public synchronized void requestFieldStorage(String name, String rubyName, Class<?> fieldType, Boolean unwrap, Class<?> toType, MethodHandles.Lookup lookup) {
+        DirectFieldConfiguration config = new JavaClassConfiguration.DirectFieldConfiguration(name, rubyName, fieldType, unwrap, toType, lookup);
         if (realClass.reifiedClass() != null)
             requestFieldStorage(config);
         else {
@@ -212,7 +221,7 @@ public class VariableTableManager {
     public void requestFieldStorage(DirectFieldConfiguration config) {
         try {
             Class<? extends Reified> reifiedClass = realClass.reifiedClass();
-            Class<?> fieldType = reifiedClass.getField(config.name).getType();
+            Class<?> fieldType = reifiedClass.getDeclaredField(config.name).getType();
             if (fieldType != config.fieldType) {
                 throw typeError(realClass.getClassRuntime().getCurrentContext(), "java_field " + config.name + " has incorrectly specified types for @ivar mapping");
             }
@@ -224,12 +233,12 @@ public class VariableTableManager {
                 throw typeError(realClass.getClassRuntime().getCurrentContext(), config.name + " has incorrectly specified unwrap type for @ivar mapping: type is incompatible");
             }
             
-            getVariableAccessorForJavaMappedVar("@" + config.name,
+            getVariableAccessorForJavaMappedVar(config.rubyName,
                     unwrap,
                     fieldType,
                     unwrapType,
-                    RubyObjectSpecializer.LOOKUP.findGetter(reifiedClass, config.name, fieldType),
-                    RubyObjectSpecializer.LOOKUP.findSetter(reifiedClass, config.name, fieldType));
+                    config.lookup.findGetter(reifiedClass, config.name, fieldType),
+                    config.lookup.findSetter(reifiedClass, config.name, fieldType));
         } catch (NoSuchFieldException e) {
             throw nameError(realClass.getClassRuntime().getCurrentContext(), "java_field " + config.name + " was marked for @ivar mapping, but wasn't found (was the class reifed already?)", config.name);
         } catch (IllegalAccessException e) {

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -33,7 +33,6 @@ import java.io.ObjectOutputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -196,14 +195,14 @@ public class VariableTableManager {
      * Request that the listed ivars (no @ in name) have field storage when we are reified
      */
     public synchronized void requestFieldStorage(String name, Class<?> fieldType, Boolean unwrap, Class<?> toType) {
-        requestFieldStorage(name, '@' + name, fieldType, unwrap, toType, RubyObjectSpecializer.LOOKUP);
+        addDirectField(name, '@' + name, fieldType, unwrap, toType, RubyObjectSpecializer.LOOKUP);
     }
 
     /**
      * This is internal API, don't call this directly if you aren't in the JRuby codebase, it may change
      * Request that the listed ivars (no @ in name) have field storage when we are reified
      */
-    public synchronized void requestFieldStorage(String name, String rubyName, Class<?> fieldType, Boolean unwrap, Class<?> toType, MethodHandles.Lookup lookup) {
+    public synchronized void addDirectField(String name, String rubyName, Class<?> fieldType, Boolean unwrap, Class<?> toType, MethodHandles.Lookup lookup) {
         DirectFieldConfiguration config = new JavaClassConfiguration.DirectFieldConfiguration(name, rubyName, fieldType, unwrap, toType, lookup);
         if (realClass.reifiedClass() != null)
             requestFieldStorage(config);


### PR DESCRIPTION
This is an extension of the existing mechanism for reification of Ruby classes, allowing us to use normal Java fields for either instance or internal variables.

The logic here is largely unchanged from the original reification logic except for enhancements to allow actively requesting a specific binding:

* Allow specifying a Ruby name to be used in the variable table, so that both instance vars (@var) and internal vars (no @) can be tied to a specific field.
* Allow the direct field configuration to aggregate a Lookup object so that private fields can bound.

The example usage here binds the "args" internal variable on NoMethodError to the "args" field on RubyNoMethodError, allowing it to be seen by marshal dumping and fixing one of the DRb issues in ruby/drb#36. The reification change was not strictly necessary to fix that issue, but the alternative converts it into a slow-path internal variable lookup which is less than ideal.

Assuming this change is safe, all other instance and internal variables used by concrete JRuby core classes can be converted with the following process:

* Set the reified class (the real concrete class) at definition time.
* Request the direct field with a Java name and either the @var or bare var name, providing an appropriate Lookup object if the field shoud be private.

Enhancements to this feature could include:

* Allow binding read-only variables. Currently both a read and write path are expected.
* Enhance conversion logic to allow variables to be a more natural Java type. The logic for this exists but has not been heavily tested. See Java logic for treating fields as instance variables.