### PR TITLE
Tweaks to further improve startup speed and memory use

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/ExternalScript.java
+++ b/core/src/main/java/org/jruby/runtime/load/ExternalScript.java
@@ -56,7 +56,7 @@ public class ExternalScript implements Library {
             } else {
                 name = CompiledScriptLoader.getFilenameFromPathAndName(resource.getPath(), name, resource.isAbsolute());
 
-                runtime.loadFile(name, new LoadServiceResourceInputStream(in), wrap);
+                runtime.loadFile(name, in, wrap);
             }
         } catch (IOException e) {
             throw runtime.newIOErrorFromException(e);

--- a/core/src/main/java/org/jruby/runtime/load/LoadServiceResourceInputStream.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadServiceResourceInputStream.java
@@ -41,17 +41,9 @@ public class LoadServiceResourceInputStream extends ByteArrayInputStream {
         return buf;
     }
 
-    private static final int READ_CHUNK_SIZE = 16384;
-
     private void bufferEntireStream(InputStream stream) throws IOException {
-        byte[] chunk = new byte[READ_CHUNK_SIZE];
-        int bytesRead;
-        while ((bytesRead = stream.read(chunk)) != -1) {
-            byte[] newbuf = new byte[buf.length + bytesRead];
-            System.arraycopy(buf, 0, newbuf, 0, buf.length);
-            System.arraycopy(chunk, 0, newbuf, buf.length, bytesRead);
-            buf = newbuf;
-            count = buf.length;
-        }
+        byte[] all = stream.readAllBytes();
+        buf = all;
+        count = all.length;
     }
 }


### PR DESCRIPTION
Just a few tweaks based on some recent profiling of JRuby 10, both doing a simple hello world `jruby -e gets` and spinning up JRuby instances in a tight loop.