### PR TITLE
Missing splatNode creation

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -3952,15 +3952,7 @@ states[328] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
 };
 states[329] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     /*%%%*/
-                    Node node = null;
-
-                    /* FIXME: lose syntactical elements here (and others like this)*/
-                    if (((Node)yyVals[0+yyTop].value) instanceof ArrayNode &&
-                        (node = p.splat_array(((Node)yyVals[-2+yyTop].value))) != null) {
-                        yyVal = p.list_concat(node, ((Node)yyVals[0+yyTop].value));
-                    } else {
-                        yyVal = arg_concat(((Node)yyVals[-2+yyTop].value), ((Node)yyVals[0+yyTop].value));
-                    }
+                    yyVal = p.rest_arg_append(((Node)yyVals[-2+yyTop].value), p.newSplatNode(((Node)yyVals[0+yyTop].value)));
                     /*% %*/
                     /*% ripper: args_add_star!($1, $3) %*/
   return yyVal;
@@ -6807,7 +6799,7 @@ states[822] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 }
-					// line 4826 "parse.y"
+					// line 4818 "parse.y"
 
 }
-					// line 14939 "-"
+					// line 14931 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -2179,15 +2179,7 @@ args            : arg_value { // ArrayNode
                 }
                 | args ',' arg_splat { // ArgsCatNode, SplatNode, ArrayNode
                     /*%%%*/
-                    Node node = null;
-
-                    // FIXME: lose syntactical elements here (and others like this)
-                    if ($3 instanceof ArrayNode &&
-                        (node = p.splat_array($1)) != null) {
-                        $$ = p.list_concat(node, $3);
-                    } else {
-                        $$ = arg_concat($1, $3);
-                    }
+                    $$ = p.rest_arg_append($1, p.newSplatNode($3));
                     /*% %*/
                     /*% ripper: args_add_star!($1, $3) %*/
                 };

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1816,7 +1816,7 @@ public abstract class RubyParserBase {
      */
     public Node splat_array(Node node) {
         if (node instanceof SplatNode) node = ((SplatNode) node).getValue();
-        if (node instanceof BlockNode) return node;
+        if (node instanceof ListNode) return node;
         return null;
     }
 

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -58,9 +58,7 @@ import org.jruby.ast.types.INameNode;
 import org.jruby.ast.visitor.OperatorCallNode;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.common.IRubyWarnings.ID;
-import org.jruby.common.RubyWarnings;
 import org.jruby.ext.coverage.CoverageData;
-import org.jruby.ir.IRScopeType;
 import org.jruby.ir.builder.StringStyle;
 import org.jruby.lexer.LexerSource;
 import org.jruby.lexer.yacc.LexContext;
@@ -1818,7 +1816,7 @@ public abstract class RubyParserBase {
      */
     public Node splat_array(Node node) {
         if (node instanceof SplatNode) node = ((SplatNode) node).getValue();
-        if (node instanceof ArrayNode) return node;
+        if (node instanceof BlockNode) return node;
         return null;
     }
 

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1816,7 +1816,7 @@ public abstract class RubyParserBase {
      */
     public Node splat_array(Node node) {
         if (node instanceof SplatNode) node = ((SplatNode) node).getValue();
-        if (node instanceof ListNode) return node;
+        if (node instanceof ArrayNode) return node;
         return null;
     }
 


### PR DESCRIPTION
As it turns out the problem is that JRuby grammar file arg_splat is not made into a splatNode whereas it is in MRI (this involves dual use of this grammar file with ripper but I do not want to try and fix whatever the underlying problem is).  The production `args ',' arg_splat {` was not creating the splatnode for arg_splat.  This in turn joined some tree values together instead of nesting them.

Will make separate PR for 9.4 as the grammar file will not cleanly apply