### PR TITLE
Missing splatNode creation

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -3945,15 +3945,7 @@ states[323] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
 };
 states[324] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     /*%%%*/
-                    Node node = null;
-
-                    /* FIXME: lose syntactical elements here (and others like this)*/
-                    if (((Node)yyVals[0+yyTop].value) instanceof ArrayNode &&
-                        (node = p.splat_array(((Node)yyVals[-3+yyTop].value))) != null) {
-                        yyVal = p.list_concat(node, ((Node)yyVals[0+yyTop].value));
-                    } else {
-                        yyVal = arg_concat(((Node)yyVals[-3+yyTop].value), ((Node)yyVals[0+yyTop].value));
-                    }
+                    yyVal = p.rest_arg_append(((Node)yyVals[-3+yyTop].value), p.newSplatNode(((Node)yyVals[0+yyTop].value)));
                     /*% %*/
                     /*% ripper: args_add_star!($1, $4) %*/
   return yyVal;
@@ -6800,7 +6792,7 @@ states[819] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 }
-					// line 4770 "parse.y"
+					// line 4762 "parse.y"
 
 }
-					// line 14586 "-"
+					// line 14578 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -2177,15 +2177,7 @@ args            : arg_value { // ArrayNode
                 }
                 | args ',' tSTAR arg_value { // ArgsCatNode, SplatNode, ArrayNode
                     /*%%%*/
-                    Node node = null;
-
-                    // FIXME: lose syntactical elements here (and others like this)
-                    if ($4 instanceof ArrayNode &&
-                        (node = p.splat_array($1)) != null) {
-                        $$ = p.list_concat(node, $4);
-                    } else {
-                        $$ = arg_concat($1, $4);
-                    }
+                    $$ = p.rest_arg_append($1, p.newSplatNode($4));
                     /*% %*/
                     /*% ripper: args_add_star!($1, $4) %*/
                 }


### PR DESCRIPTION
This extra splat node ends up preventing masgn elements from combining that should be their own elements from the standpoint of masgn combines. 

Fixes https://github.com/jruby/jruby/issues/8830