### PR TITLE
Use a normal ClassValue for all such cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,36 @@ jobs:
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
+  rake-test-ji-stable-class-values:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: ['spec:ji']
+        java-version: ['8']
+      fail-fast: false
+
+    name: rake ${{ matrix.target }} (Java ${{ matrix.java-version }})
+
+    env:
+      JRUBY_OPTS: "-Xji.class.values=STABLE"
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up java ${{ matrix.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java-version }}
+          cache: 'maven'
+      - name: bootstrap
+        run: mvn -ntp -Pbootstrap clean package
+      - name: bundle install
+        run: bin/jruby --dev -S bundle install
+      - name: rake ${{ matrix.target }}
+        run: bin/jruby -S rake ${{ matrix.target }}
+
   rake-test-8:
     runs-on: ubuntu-latest
 
@@ -461,7 +491,7 @@ jobs:
     permissions:
       contents: none
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/jruby-9.3' }}
-    needs: [mvn-test, mvn-test-extended, mvn-test-windows, dependency-check, rake-test, rake-test-17-indy, rake-test-8, test-versions, sequel, concurrent-ruby, jruby-tests-dev, regression-specs-jit]
+    needs: [mvn-test, mvn-test-extended, mvn-test-windows, dependency-check, rake-test, rake-test-17-indy, rake-test-8, test-versions, sequel, concurrent-ruby, jruby-tests-dev, regression-specs-jit, rake-test-ji-stable-class-values]
     uses: jruby/jruby/.github/workflows/snapshot-publish.yml@6cd0d4d96d9406635183d81cf91acc82cd78245f
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -107,7 +107,7 @@ public abstract class JavaSupport {
         this.runtime = runtime;
 
         this.javaClassCache = new ClassValue<JavaClass>() {
-            public JavaClass computeValue(Class<?> klass) {
+            public synchronized JavaClass computeValue(Class<?> klass) {
                 return new JavaClass(runtime, getJavaClassClass(), klass);
             }
         };

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -52,12 +52,12 @@ import org.jruby.javasupport.proxy.JavaProxyClass;
 public class JavaSupportImpl extends JavaSupport {
 
     private final java.lang.ClassValue<Map<String, AssignedName>> staticAssignedNames = new java.lang.ClassValue<Map<String, AssignedName>>() {
-        public Map<String, AssignedName> computeValue(Class clazz) {
+        public synchronized Map<String, AssignedName> computeValue(Class clazz) {
             return new HashMap<>(8, 1);
         }
     };
     private final ClassValue<Map<String, AssignedName>> instanceAssignedNames = new java.lang.ClassValue<Map<String, AssignedName>>() {
-        public Map<String, AssignedName> computeValue(Class clazz) {
+        public synchronized Map<String, AssignedName> computeValue(Class clazz) {
             return new HashMap<>(8, 1);
         }
     };

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -43,7 +43,6 @@ import java.util.Set;
 import org.jruby.Ruby;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.WeakIdentityHashMap;
-import org.jruby.util.collections.ClassValue;
 import org.jruby.javasupport.binding.AssignedName;
 import org.jruby.javasupport.proxy.JavaProxyClass;
 
@@ -52,10 +51,16 @@ import org.jruby.javasupport.proxy.JavaProxyClass;
  */
 public class JavaSupportImpl extends JavaSupport {
 
-    private final ClassValue<Map<String, AssignedName>> staticAssignedNames =
-            ClassValue.newInstance(klass -> new HashMap<>(8, 1));
-    private final ClassValue<Map<String, AssignedName>> instanceAssignedNames =
-            ClassValue.newInstance(klass -> new HashMap<>(8, 1));
+    private final java.lang.ClassValue<Map<String, AssignedName>> staticAssignedNames = new java.lang.ClassValue<Map<String, AssignedName>>() {
+        public Map<String, AssignedName> computeValue(Class clazz) {
+            return new HashMap<>(8, 1);
+        }
+    };
+    private final ClassValue<Map<String, AssignedName>> instanceAssignedNames = new java.lang.ClassValue<Map<String, AssignedName>>() {
+        public Map<String, AssignedName> computeValue(Class clazz) {
+            return new HashMap<>(8, 1);
+        }
+    };
 
     public JavaSupportImpl(final Ruby runtime) {
         super(runtime);

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import org.jruby.Ruby;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.WeakIdentityHashMap;
+import org.jruby.util.collections.ClassValue;
 import org.jruby.javasupport.binding.AssignedName;
 import org.jruby.javasupport.proxy.JavaProxyClass;
 
@@ -51,19 +52,17 @@ import org.jruby.javasupport.proxy.JavaProxyClass;
  */
 public class JavaSupportImpl extends JavaSupport {
 
-    private final java.lang.ClassValue<Map<String, AssignedName>> staticAssignedNames = new java.lang.ClassValue<Map<String, AssignedName>>() {
-        public synchronized Map<String, AssignedName> computeValue(Class clazz) {
-            return new HashMap<>(8, 1);
-        }
-    };
-    private final ClassValue<Map<String, AssignedName>> instanceAssignedNames = new java.lang.ClassValue<Map<String, AssignedName>>() {
-        public synchronized Map<String, AssignedName> computeValue(Class clazz) {
-            return new HashMap<>(8, 1);
-        }
-    };
+    private final ClassValue<Map<String, AssignedName>> staticAssignedNames =
+            ClassValue.newInstance(JavaSupportImpl::newAssignedNames);
+    private final ClassValue<Map<String, AssignedName>> instanceAssignedNames =
+            ClassValue.newInstance(JavaSupportImpl::newAssignedNames);
 
     public JavaSupportImpl(final Ruby runtime) {
         super(runtime);
+    }
+
+    private static Map<String, AssignedName> newAssignedNames(Class<?> klass) {
+        return new HashMap<>(8, 1);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
@@ -58,9 +58,12 @@ final class ClassInitializer extends Initializer {
 
         proxyClass.getName(); // trigger calculateName()
 
-        final MethodGatherer state = new MethodGatherer(runtime, javaClass.getSuperclass());
+        // only gather methods for non-synthetic classes, since we should not bind pure generated methods
+//        if (!javaClass.isSynthetic()) {
+            final MethodGatherer state = new MethodGatherer(runtime, javaClass.getSuperclass());
 
-        state.initialize(javaClass, proxy);
+            state.initialize(javaClass, proxy);
+//        }
 
         return proxyClass;
     }

--- a/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
@@ -58,12 +58,9 @@ final class ClassInitializer extends Initializer {
 
         proxyClass.getName(); // trigger calculateName()
 
-        // only gather methods for non-synthetic classes, since we should not bind pure generated methods
-//        if (!javaClass.isSynthetic()) {
-            final MethodGatherer state = new MethodGatherer(runtime, javaClass.getSuperclass());
+        final MethodGatherer state = new MethodGatherer(runtime, javaClass.getSuperclass());
 
-            state.initialize(javaClass, proxy);
-//        }
+        state.initialize(javaClass, proxy);
 
         return proxyClass;
     }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -201,7 +201,7 @@ public class Options {
     public static final Option<Boolean> JI_LOAD_LAZY = bool(JAVA_INTEGRATION, "ji.load.lazy", true, "Load Java support (class extensions) lazily on demand or ahead of time.");
     public static final Option<Boolean> JI_CLOSE_CLASSLOADER = bool(JAVA_INTEGRATION, "ji.close.classloader", false, "Close the JRubyClassLoader used by each runtime");
     public static final Option<String> JI_NESTED_JAR_TMPDIR = string(JAVA_INTEGRATION, "ji.nested.jar.tmpdir", "Use specified dir as a base for unpacking nested jar files.");
-    public static final Option<ClassValue.Type> JI_CLASS_VALUES = enumeration(JAVA_INTEGRATION, "ji.class.values", ClassValue.Type.class, ClassValue.Type.HARD_MAP, "use the specified type of class-to-value holder for JI proxy structures");
+    public static final Option<ClassValue.Type> JI_CLASS_VALUES = enumeration(JAVA_INTEGRATION, "ji.class.values", ClassValue.Type.class, ClassValue.Type.STABLE, "use the specified type of class-to-value holder for JI proxy structures");
 
     public static final Option<Integer> PROFILE_MAX_METHODS = integer(PROFILING, "profile.max.methods", 100000, "Maximum number of methods to consider for profiling.");
 

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -41,6 +41,8 @@ import org.jruby.compiler.ClassLoaderMode;
 import org.jruby.runtime.Constants;
 import org.jruby.util.KCode;
 import org.jruby.util.SafePropertyAccessor;
+import org.jruby.util.collections.ClassValue;
+
 import static org.jruby.util.cli.Category.*;
 import static org.jruby.RubyInstanceConfig.Verbosity;
 import static org.jruby.RubyInstanceConfig.ProfilingMode;
@@ -199,6 +201,7 @@ public class Options {
     public static final Option<Boolean> JI_LOAD_LAZY = bool(JAVA_INTEGRATION, "ji.load.lazy", true, "Load Java support (class extensions) lazily on demand or ahead of time.");
     public static final Option<Boolean> JI_CLOSE_CLASSLOADER = bool(JAVA_INTEGRATION, "ji.close.classloader", false, "Close the JRubyClassLoader used by each runtime");
     public static final Option<String> JI_NESTED_JAR_TMPDIR = string(JAVA_INTEGRATION, "ji.nested.jar.tmpdir", "Use specified dir as a base for unpacking nested jar files.");
+    public static final Option<ClassValue.Type> JI_CLASS_VALUES = enumeration(JAVA_INTEGRATION, "ji.class.values", ClassValue.Type.class, ClassValue.Type.HARD_MAP, "use the specified type of class-to-value holder for JI proxy structures");
 
     public static final Option<Integer> PROFILE_MAX_METHODS = integer(PROFILING, "profile.max.methods", 100000, "Maximum number of methods to consider for profiling.");
 

--- a/core/src/main/java/org/jruby/util/collections/ClassValue.java
+++ b/core/src/main/java/org/jruby/util/collections/ClassValue.java
@@ -2,12 +2,44 @@ package org.jruby.util.collections;
 
 import org.jruby.util.cli.Options;
 
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 /**
  * Represents a cache or other mechanism for getting the Ruby-level proxy classes
  * for a given Java class.
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "deprecation"})
 public abstract class ClassValue<T> {
+
+    public enum Type {
+        /**
+         * A ClassValue based on java.lang.ClassValue but with stable, once-only computation.
+         */
+        STABLE(StableClassValue::new),
+
+        /**
+         * A ClassValue based on a hard-referencing, concurrent Map implementation with once-only computation.
+         *
+         * @see MapBasedClassValue
+         */
+        HARD_MAP(MapBasedClassValue::new),
+
+        /**
+         * A ClassValue based on java.lang.ClassValue but all values are strongly referenced until the ClassValue is
+         * dereferenced. No guarantee of once-only computation.
+         *
+         * @see Java7ClassValue
+         */
+        @Deprecated
+        HARD_VALUES(Java7ClassValue::new);
+
+        Type(Function<ClassValueCalculator, ClassValue> function) {
+            this.function = function;
+        }
+
+        final Function<ClassValueCalculator, ClassValue> function;
+    }
 
     public ClassValue(ClassValueCalculator<T> calculator) {
         this.calculator = calculator;
@@ -18,14 +50,13 @@ public abstract class ClassValue<T> {
     protected final ClassValueCalculator<T> calculator;
 
     public static <T> ClassValue<T> newInstance(ClassValueCalculator<T> calculator) {
-        if ( CLASS_VALUE ) return newJava7Instance(calculator);
-        return new MapBasedClassValue<>(calculator);
+        if (Options.INVOKEDYNAMIC_CLASS_VALUES.load()) return newJava7Instance(calculator);
+        return Options.JI_CLASS_VALUES.load().function.apply(calculator);
     }
 
+    @Deprecated
     private static <T> ClassValue<T> newJava7Instance(ClassValueCalculator<T> calculator) {
         return new Java7ClassValue<>(calculator);
     }
-
-    private static final boolean CLASS_VALUE = Options.INVOKEDYNAMIC_CLASS_VALUES.load();
 
 }

--- a/core/src/main/java/org/jruby/util/collections/ClassValue.java
+++ b/core/src/main/java/org/jruby/util/collections/ClassValue.java
@@ -3,7 +3,6 @@ package org.jruby.util.collections;
 import org.jruby.util.cli.Options;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Represents a cache or other mechanism for getting the Ruby-level proxy classes

--- a/core/src/main/java/org/jruby/util/collections/ClassValueCalculator.java
+++ b/core/src/main/java/org/jruby/util/collections/ClassValueCalculator.java
@@ -1,8 +1,13 @@
 package org.jruby.util.collections;
 
+import java.util.function.Function;
+
 /**
  * Calculate a value based on an incoming class. Used by ClassValue.
  */
-public interface ClassValueCalculator<T> {
-    public T computeValue(Class<?> cls);
+public interface ClassValueCalculator<T> extends Function<Class<?>, T> {
+    T computeValue(Class<?> cls);
+    default T apply(Class<?> cls) {
+        return computeValue(cls);
+    }
 }

--- a/core/src/main/java/org/jruby/util/collections/Java7ClassValue.java
+++ b/core/src/main/java/org/jruby/util/collections/Java7ClassValue.java
@@ -7,6 +7,7 @@ import java.util.List;
 /**
  * A proxy cache that uses Java 7's ClassValue.
  */
+@Deprecated
 final class Java7ClassValue<T> extends ClassValue<T> {
 
     public Java7ClassValue(ClassValueCalculator<T> calculator) {

--- a/core/src/main/java/org/jruby/util/collections/StableClassValue.java
+++ b/core/src/main/java/org/jruby/util/collections/StableClassValue.java
@@ -1,0 +1,51 @@
+package org.jruby.util.collections;
+
+import java.util.function.Function;
+
+/**
+ * An implementation of JRuby's ClassValue, using java.lang.ClassValue directly but ensuring computation of each value
+ * occurs at most once.
+ */
+final class StableClassValue<T> extends ClassValue<T> {
+
+    public StableClassValue(ClassValueCalculator<T> calculator) {
+        super(calculator);
+    }
+
+    public T get(Class<?> cls) {
+        // We don't check for null on the WeakReference since the
+        // value is strongly referenced by proxy's list
+        return proxy.get(cls).get(cls);
+    }
+
+    /**
+     * Represents a stable value, which is computed at most once and then stored forever.
+     *
+     * This should be replaced with a JDK StableValue once it becomes available in Java 25. The double-checked locking
+     * implementation cannot be folded by the JVM and will not have the same performance characteristics.
+     *
+     * @param <Input> input of the computation
+     * @param <Result> result of the computation
+     */
+    private static class StableValue<Input, Result> {
+        private final Function<Input, Result> calculator;
+        private volatile Result result;
+        StableValue(Function<Input, Result> calculator) {
+            this.calculator = calculator;
+        }
+        Result get(Input input) {
+            Result result = this.result;
+            if (result == null) synchronized (this) {
+                this.result = result = this.calculator.apply(input);
+            }
+            return result;
+        }
+    }
+
+    private final java.lang.ClassValue<StableValue<Class<?>, T>> proxy = new java.lang.ClassValue<StableValue<Class<?>, T>>() {
+        @Override
+        protected StableValue<Class<?>, T> computeValue(Class<?> type) {
+            return new StableValue<>(calculator);
+        }
+    };
+}

--- a/spec/regression/GH-8842_interface_impl_duck_typed_classes_do_not_unload.rb
+++ b/spec/regression/GH-8842_interface_impl_duck_typed_classes_do_not_unload.rb
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+
+# https://github.com/jruby/jruby/issues/8842
+
+# A script to cause exactly one InterfaceImpl class to be loaded after boot.
+# NOTE: If future changes in JI cause incidental InterfaceImpl classes, this may start to fail.
+src = <<~RUBY
+  require 'jruby'
+
+  puts 'started'
+
+  # do this in a block so the object goes fully out of scope
+  tap do
+    cls = Class.new do
+      def accept(*)
+      end
+    end
+    obj = cls.new
+    java.util.ArrayList.new([1]).for_each(obj)
+  end
+  
+  # GC a sufficient number of times to clear the impl class
+  10.times do
+    JRuby.gc
+  end
+  
+  puts 'exiting'
+RUBY
+
+def run_script_get_output(class_values, src)
+  pout, cout = IO.pipe
+
+  pid = spawn("jruby --dev -J-XX:+TraceClassLoading -J-XX:+TraceClassUnloading -Xji.class.values=#{class_values} -e \"#{src}\"", { out: cout })
+  cout.close
+  output = pout.read
+  Process.wait pid
+  output
+end
+
+describe 'Duck-typed interface implementation classes' do
+  describe 'when using stable JI class values' do
+    it 'are unloaded after being dereferenced' do
+      output = run_script_get_output("STABLE", src)
+
+      # match only impl classes loaded and unloaded after script starts
+      output =~ /started.*Loaded (org.jruby.gen.InterfaceImpl[0-9+]+).*exiting/m
+
+      expect(output).to_not be_nil
+      expect(output).to match /Unloading class #{$1}/
+    end
+  end
+
+  describe 'when using hard mapped JI class values' do
+    it 'are not unloaded after being dereferenced' do
+      output = run_script_get_output("HARD_MAP", src)
+
+      # match only impl classes loaded and unloaded after script starts
+      output =~ /started.*Loaded (org.jruby.gen.InterfaceImpl[0-9+]+).*exiting/m
+
+      expect(output).to_not be_nil
+      expect(output).to_not match /Unloading class #{$1}/
+    end
+  end
+end


### PR DESCRIPTION
JRuby includes two versions of ClassValue: one with a hard- referenced Map from Class to value, and one based on a normal ClassValue but with the added oddity that it hard-references its values while storing them in the ClassValue slot weakly. This was originally intended to allow the values to collect properly when the ClassValue collected, but on recent testing it seems to just leak in a different way.

This change siwtches everything to normal ClassValue. Given this change, the example cases in #8842 no longer leak, nor does a more aggressive torture test that also spins up and tears down JRuby runtimes as well as interface implementations. A 30-minute run of that test uses a lot of memory and GCs heavily, but does level off in both heap and metaspace. Forced GCs reduce both nearly back to startup levels.

Note this is a work in progress; we will likely not want to change the default behavior for 9.4.x, so this will need to be guarded behind an option relating to the existing invokedynamic.class.values toggle. It may be safe enough as-is for JRuby 10 as that is still stabilizing.