### PR TITLE
Fix locking of stable class values for JI proxies

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -110,24 +110,21 @@ public abstract class JavaSupport {
 
         this.javaClassCache = ClassValue.newInstance(klass -> new JavaClass(runtime, getJavaClassClass(), klass));
 
-        this.proxyClassCache = ClassValue.newInstance(new ClassValueCalculator<RubyModule>() {
-            /**
-             * Because of the complexity of processing a given class and all its dependencies,
-             * we opt to synchronize this logic. Creation of all proxies goes through here,
-             * allowing us to skip some threading work downstream.
-             *
-             * Note: when this is used with StableClassValue, the synchronization is unnecessary, and should be removed
-             * when only the stable form remains.
-             */
-            @Override
-            public synchronized RubyModule computeValue(Class<?> klass) {
-                RubyModule proxyKlass = Java.createProxyClassForClass(runtime, klass);
-                JavaExtensions.define(runtime, klass, proxyKlass); // (lazy) load extensions
-                return proxyKlass;
-            }
-        });
+        this.proxyClassCache = ClassValue.newInstance(this::computeProxyClass);
+
         // Proxy creation is synchronized (see above) so a HashMap is fine for recursion detection.
         this.unfinishedProxies = new ConcurrentHashMap<>(8, 0.75f, 1);
+    }
+
+    /**
+     * Because of the complexity of processing a given class and all its dependencies,
+     * we opt to synchronize this logic. Creation of all proxies goes through here,
+     * allowing us to skip some threading work downstream.
+     */
+    private synchronized RubyModule computeProxyClass(Class<?> klass) {
+        RubyModule proxyKlass = Java.createProxyClassForClass(runtime, klass);
+        JavaExtensions.define(runtime, klass, proxyKlass); // (lazy) load extensions
+        return proxyKlass;
     }
 
     @Deprecated


### PR DESCRIPTION
Because the proxy calculation tends to recurse for classes, there may be multiple StableValue preparing proxies at the same time. Depending on the ordering of the classes encountered, this can lead to deadlocks.

This fixes the deadlock by matching MapBasedClassValue's one lock per ClassValue instance, and also properly double-checks the value which was missing in the previous version.