### PR TITLE
single value makes kwargs hash.  Mark it as such

### DIFF
--- a/core/src/main/java/org/jruby/RubyData.java
+++ b/core/src/main/java/org/jruby/RubyData.java
@@ -324,6 +324,7 @@ public class RubyData {
 
                 RubySymbol sym = members.eltOk(0);
                 init.fastASetSmall(sym, hashOrElt);
+                callInfo = CALL_KEYWORD;
             }
 
             IRubyObject dataObject = klass.getAllocator().allocate(context.runtime, klass);


### PR DESCRIPTION
Pretty obvious issue.  Not sure how this was not failing before.  Note: this failed regardless of JIT or no.  We only test this MRI test segment using JIT mode.