### PR TITLE
Fix `Time.new` when using (empty) keywords (2 issues)

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1836,50 +1836,45 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "initialize", optional = 8, checkArity = false, visibility = PRIVATE, keywords = true)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         boolean keywords = hasKeywords(ThreadContext.resetCallInfo(context));
-        int argc = args.length - (keywords ? 1 : 0);
+        int argc = args.length;
         IRubyObject zone = context.nil;
         IRubyObject precision = context.nil;
 
         if (keywords) {
             IRubyObject[] opts = ArgsUtil.extractKeywordArgs(context, args[args.length - 1], "in", "precision");
-            if (opts[0] != null) {
-                if (args.length > 7) throw argumentError(context, "timezone argument given as positional and keyword arguments");
-                zone = opts[0];
-            } else if (args.length > 6) {
-                zone = args[6];
-            }
 
-            if (opts[1] != null) {
-                if (!(opts[1] instanceof RubyNumeric)) {
-                    // Weird error since all numerics work at this point so why mention Integer?
-                    throw typeError(context, str(context.runtime, "no implicit conversion of ", typeAsString(opts[1]), " into Integer"));
+            if (opts != null) {
+                argc -= 1;
+
+                if (opts[0] != null) {
+                    if (argc > 6) {
+                        throw argumentError(context, "timezone argument given as positional and keyword arguments");
+                    }
+                    zone = opts[0];
                 }
-                precision = opts[1];
+
+                if (opts[1] != null) {
+                    if (!(opts[1] instanceof RubyNumeric)) {
+                        // Weird error since all numerics work at this point so why mention Integer?
+                        throw typeError(context, str(context.runtime, "no implicit conversion of ", typeAsString(opts[1]), " into Integer"));
+                    }
+                    precision = opts[1];
+                }
             }
-        } else if (args.length > 6) {
-            zone = args[6];
         }
+
+        if (argc > 6) zone = args[6];
 
         IRubyObject nil = context.nil;
 
         return switch (argc) {
             case 0 -> initializeNow(context, zone);
             case 1 -> timeInitParse(context, args[0], zone, precision);
-            case 2 -> keywords ?
-                    initialize(context, args[0], nil, nil, nil, nil, nil, precision, zone) :
-                    initialize(context, args[0], args[1], nil, nil, nil, nil, precision);
-            case 3 -> keywords ?
-                    initialize(context, args[0], args[1], nil, nil, nil, nil, precision, zone) :
-                    initialize(context, args[0], args[1], args[2], nil, nil, nil, precision);
-            case 4 -> keywords ?
-                    initialize(context, args[0], args[1], args[2], nil, nil, nil, precision, zone) :
-                    initialize(context, args[0], args[1], args[2], args[3], nil, nil, precision);
-            case 5 -> keywords ?
-                    initialize(context, args[0], args[1], args[2], args[3], nil, nil, precision, zone) :
-                    initialize(context, args[0], args[1], args[2], args[3], args[4], nil, precision);
-            case 6 -> keywords ?
-                    initialize(context, args[0], args[1], args[2], args[3], args[4], nil, precision, zone) :
-                    initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], precision);
+            case 2 -> initialize(context, args[0], args[1], nil, nil, nil, nil, precision, zone);
+            case 3 -> initialize(context, args[0], args[1], args[2], nil, nil, nil, precision, zone);
+            case 4 -> initialize(context, args[0], args[1], args[2], args[3], nil, nil, precision, zone);
+            case 5 -> initialize(context, args[0], args[1], args[2], args[3], args[4], nil, precision, zone);
+            case 6 -> initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], precision, zone);
             case 7 -> initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], precision, zone);
             default -> throw argumentError(context, argc, 0, 7);
         };

--- a/spec/regression/GH-8854_time_new_with_empty_keywords_spec.rb
+++ b/spec/regression/GH-8854_time_new_with_empty_keywords_spec.rb
@@ -1,0 +1,8 @@
+require 'rspec'
+
+# https://github.com/jruby/jruby/issues/8854
+describe 'Time#new with empty keywords' do
+  it 'should not raise NullPointerException' do
+    expect(Time.new(2000, 3, 2, **{})).to eq Time.new(2000, 3, 2)
+  end
+end

--- a/test/jruby/test_time.rb
+++ b/test/jruby/test_time.rb
@@ -217,4 +217,8 @@ class TestTimeNilOps < Test::Unit::TestCase
     assert_raise(TypeError) { Time.strptime('2020-01-01', 0) }
     assert_raise(TypeError) { Time.strptime('2020-01-01', nil) }
   end
+
+  def test_new_with_empty_keywords
+    assert_equal Time.new(2000, 3, 2), Time.new(2000, 3, 2, **{})
+  end
 end

--- a/test/jruby/test_time.rb
+++ b/test/jruby/test_time.rb
@@ -217,8 +217,4 @@ class TestTimeNilOps < Test::Unit::TestCase
     assert_raise(TypeError) { Time.strptime('2020-01-01', 0) }
     assert_raise(TypeError) { Time.strptime('2020-01-01', nil) }
   end
-
-  def test_new_with_empty_keywords
-    assert_equal Time.new(2000, 3, 2), Time.new(2000, 3, 2, **{})
-  end
 end


### PR DESCRIPTION
Fixes #8854 and #8860.

```
#8854
irb> Time.new(2025, 4, 3, **{})
org.jruby.dist/org.jruby.RubyTime.initialize(RubyTime.java:1758):
Cannot load from object array because "opts" is null (Java::JavaLang::NullPointerException)

#8860
irb> Time.new(2025, 4, 3, in: 'UTC')
=> 2025-04-01 00:00:00 +0000
# The day is incorrect. It always loses the last arg.
```

The [`travel_to` test helper from ActiveSupport](https://github.com/rails/rails/blob/v7.1.5.1/activesupport/lib/active_support/testing/time_helpers.rb#L185) triggers the empty keywords issue.

As a result of fixing the NullPointerException and writing a regression test, it actually triggered the other issue of losing the last argument when using keywords.

I realised that if keywords was empty, `hasKeywords` still returns true and `extractKeywordArgs` returns null, and `args` doesn't have the Hash object, it is just missing. So that is why we can only subtract 1 from argc after `extractKeywordArgs` and confirming it is not null. Also, since we are already subtracting one, then we don't need the keywords condition again in the argc switch.

I added a test for it since it was a regression from JRuby v9.