### PR TITLE
respond_to?(<symbol>) => true optimization

### DIFF
--- a/bench/bench_respond_to.rb
+++ b/bench/bench_respond_to.rb
@@ -1,0 +1,56 @@
+require 'benchmark/ips'
+
+class Foo
+  def foo; end
+end
+
+def respond_to_foo(obj)
+  obj.respond_to?(:foo)
+end
+
+def respond_to_bar(obj)
+  obj.respond_to?(:bar)
+end
+
+Benchmark.ips do |ips|
+  obj = Foo.new
+
+  ips.report("control") do |i|
+    while i > 0
+      i -= 1
+      break unless obj && obj && obj && obj && obj && obj && obj && obj && obj && obj
+    end
+  end
+
+  ips.report("10x respond_to? = true") do |i|
+    while i > 0
+      i -= 1
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+      respond_to_foo(obj)
+    end
+  end
+
+  ips.report("10x respond_to? = false") do |i|
+    while i > 0
+      i -= 1
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+      respond_to_bar(obj)
+    end
+  end
+end

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -57,7 +57,7 @@ project 'JRuby Base' do
   jar 'org.jruby.jcodings:jcodings:1.0.63'
   jar 'org.jruby:dirgra:0.5'
 
-  jar 'com.headius:invokebinder:1.14'
+  jar 'com.headius:invokebinder:1.15'
   jar 'com.headius:options:1.6'
 
   jar 'org.jruby:jzlib:1.1.5'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -164,7 +164,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>invokebinder</artifactId>
-      <version>1.14</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>com.headius</groupId>

--- a/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
@@ -1,5 +1,6 @@
 package org.jruby.ir.targets;
 
+import org.jruby.RubySymbol;
 import org.jruby.ir.instructions.AsStringInstr;
 import org.jruby.ir.instructions.CallBase;
 import org.jruby.ir.instructions.EQQInstr;
@@ -138,4 +139,13 @@ public interface InvocationCompiler {
      * Invoke __method__ or __callee__ with awareness of any built-in methods.
      */
     void invokeFrameName(String methodName, String file);
+
+    /**
+     * Check for a literal respond_to? result
+     *
+     * Stack required: context, caller, target
+     *
+     * @param id the method name to check respond_to?
+     */
+    void respondTo(CallBase callBase, RubySymbol id, String scopeFieldName, String file);
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/ArrayDerefInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ArrayDerefInvokeSite.java
@@ -77,7 +77,7 @@ public class ArrayDerefInvokeSite extends NormalInvokeSite {
             // strdup for this call
             args[0] = dupString(context, (RubyString) args[0]);
 
-            if (methodMissing(entry, caller)) {
+            if (methodMissing(method, methodName, callType, caller)) {
                 return callMethodMissing(entry, callType, context, self, selfClass, methodName, args, block);
             }
 
@@ -130,7 +130,7 @@ public class ArrayDerefInvokeSite extends NormalInvokeSite {
 
         entry = selfClass.searchWithCache(name);
 
-        if (methodMissing(entry, caller)) {
+        if (methodMissing(entry.method, methodName, callType, caller)) {
             return callMethodMissing(entry, callType, context, self, selfClass, name, arg0, block);
         }
 

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -1,6 +1,8 @@
 package org.jruby.ir.targets.indy;
 
 import org.jruby.RubyClass;
+import org.jruby.RubyEncoding;
+import org.jruby.RubySymbol;
 import org.jruby.compiler.NotCompilableException;
 import org.jruby.ir.instructions.AsStringInstr;
 import org.jruby.ir.instructions.CallBase;
@@ -17,6 +19,7 @@ import org.jruby.runtime.MethodIndex;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.invokedynamic.MathLinker;
+import org.jruby.util.ByteList;
 import org.jruby.util.CodegenUtils;
 import org.jruby.util.JavaNameMangler;
 
@@ -245,5 +248,15 @@ public class IndyInvocationCompiler implements InvocationCompiler {
         compiler.loadSelf();
         compiler.loadFrameName();
         compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callVariable", methodName), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, String.class), FrameNameSite.FRAME_NAME_BOOTSTRAP, file, compiler.getLastLine());
+    }
+
+    @Override
+    public void respondTo(CallBase callBase, RubySymbol id, String scopeFieldName, String file) {
+        String sig = callBase.getCallType().isSelfCall() ?
+                sig(IRubyObject.class, ThreadContext.class, IRubyObject.class) :
+                sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, IRubyObject.class);
+
+        ByteList bytes = id.getBytes();
+        compiler.adapter.invokedynamic("respond_to", sig, RespondToSite.RESPOND_TO_BOOTSTRAP, RubyEncoding.decodeRaw(bytes), bytes.getEncoding().toString(), file, compiler.getLastLine());
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
@@ -6,6 +6,7 @@ import com.headius.invokebinder.SmartHandle;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubySymbol;
+import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.ir.targets.simple.NormalInvokeSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.ThreadContext;
@@ -177,7 +178,9 @@ public class RespondToSite extends MutableCallSite {
     }
 
     private static boolean respondToDefined(IRubyObject caller, CacheEntry entry) {
-        if (InvokeSite.methodMissing(entry.method, "respond_to?", CallType.NORMAL, caller)) {
+        DynamicMethod method = entry.method;
+
+        if (method.isUndefined() || InvokeSite.methodMissing(method, "respond_to?", CallType.NORMAL, caller)) {
             return false;
         }
 
@@ -186,8 +189,9 @@ public class RespondToSite extends MutableCallSite {
 
     private static boolean respondToMissingDefined(IRubyObject caller, RubyClass selfClass) {
         CacheEntry entry = selfClass.searchWithCache("respond_to_missing?");
+        DynamicMethod method = entry.method;
 
-        if (InvokeSite.methodMissing(entry.method, "respond_to_missing?", CallType.NORMAL, caller)) {
+        if (method.isUndefined() || InvokeSite.methodMissing(method, "respond_to_missing?", CallType.FUNCTIONAL, caller)) {
             return false;
         }
 

--- a/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
@@ -69,7 +69,7 @@ public class RespondToSite extends MutableCallSite {
         if (!InvokeSite.methodMissing(entry.method)) {
             if (entry.method.isBuiltin()) {
                 // standard respond_to, check if method is naturally defined (not via respond_to_missing?)
-                boolean respondsTo = self.getMetaClass().respondsToMethod(rawValue, false);
+                boolean respondsTo = self.getMetaClass().respondsToMethod(rawValue, true);
                 if (respondsTo) {
                     // cache result; method table changes will invalidate this whole thing
                     target = Binder.from(type())
@@ -103,7 +103,7 @@ public class RespondToSite extends MutableCallSite {
         if (!InvokeSite.methodMissing(entry.method, "respond_to?", CallType.NORMAL, caller)) {
             if (entry.method.isBuiltin()) {
                 // standard respond_to, check if method is naturally defined (not via respond_to_missing?)
-                boolean respondsTo = self.getMetaClass().respondsToMethod(rawValue, false);
+                boolean respondsTo = self.getMetaClass().respondsToMethod(rawValue, true);
                 if (respondsTo) {
                     // cache result; method table changes will invalidate this whole thing
                     target = Binder.from(type())

--- a/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
@@ -1,0 +1,139 @@
+package org.jruby.ir.targets.indy;
+
+import com.headius.invokebinder.Binder;
+import com.headius.invokebinder.Signature;
+import com.headius.invokebinder.SmartHandle;
+import org.jruby.RubyModule;
+import org.jruby.RubySymbol;
+import org.jruby.api.Convert;
+import org.jruby.ir.targets.simple.NormalInvokeSite;
+import org.jruby.runtime.CallType;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.CacheEntry;
+import org.jruby.util.JavaNameMangler;
+import org.objectweb.asm.Handle;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.lang.invoke.SwitchPoint;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static org.jruby.util.CodegenUtils.sig;
+
+/**
+ * Perform an optimized __method__ or __callee__ invocation without accessing a caller's frame.
+ *
+ * This logic checks if the target method is our built-in version and uses fast logic in that case. All other calls
+ * fall back on normal indy call logic. Only the built-in versions can actually access the caller's frame, so we can
+ * omit the frame altogether if we only use the specialized site.
+ *
+ * Note that if the target method is initially not built-in, or becomes a not built-in version later, we permanently
+ * fall back on the invocation logic. No further checking is done and the site is optimized as a normal call from there.
+ */
+public class RespondToSite extends MutableCallSite {
+    private final String rawValue;
+    private final String encoding;
+    private final String file;
+    private final int line;
+    private RubySymbol methodCached;
+
+    public RespondToSite(MethodType type, String rawValue, String encoding, String file, int line) {
+        super(type);
+
+        this.rawValue = rawValue;
+        this.encoding = encoding;
+        this.file = file;
+        this.line = line;
+    }
+
+    public static final Handle RESPOND_TO_BOOTSTRAP = Bootstrap.getBootstrapHandle("respondToBootstrap", RespondToSite.class, sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, String.class, String.class, int.class));
+
+    public static CallSite respondToBootstrap(MethodHandles.Lookup lookup, String name, MethodType methodType, String rawValue, String encoding, String file, int line) {
+        RespondToSite respondToSite = new RespondToSite(methodType, rawValue, encoding, file, line);
+
+        respondToSite.setTarget(Binder.from(methodType).prepend(respondToSite).invokeVirtualQuiet("respondToFallback"));
+
+        return respondToSite;
+    }
+
+    public IRubyObject respondToFallback(ThreadContext context, IRubyObject self) throws Throwable {
+        SwitchPoint switchPoint = (SwitchPoint) self.getMetaClass().getInvalidator().getData();
+        CacheEntry entry = self.getMetaClass().searchWithCache("respond_to?");
+        MethodHandle target = null;
+
+        if (!InvokeSite.methodMissing(entry.method)) {
+            if (entry.method.isBuiltin()) {
+                // standard respond_to, check if method is naturally defined (not via respond_to_missing?)
+                boolean respondsTo = self.getMetaClass().respondsToMethod(rawValue, false);
+                if (respondsTo) {
+                    // cache result; method table changes will invalidate this whole thing
+                    target = Binder.from(type())
+                            .dropAll()
+                            .append(context.tru)
+                            .identity();
+                }
+            }
+        }
+
+        if (target == null) {
+            RubySymbol id = SymbolObjectSite.constructSymbolFromRaw(context, rawValue, encoding);
+            target = Binder.from(type())
+                    .append(IRubyObject.class, id)
+                    .invoke(SelfInvokeSite.bootstrap(lookup(), "invokeFunctional:" + JavaNameMangler.mangleMethodName("respond_to?"), type().appendParameterTypes(IRubyObject.class), 0, 0, file, line).dynamicInvoker());
+        }
+
+        MethodHandle guardedtarget = typeCheck(target, Signature.from(type().returnType(), type().parameterArray(), "context", "self"), self, self.getMetaClass(), getTarget());
+        guardedtarget = InvokeSite.switchPoint(switchPoint, getTarget(), guardedtarget);
+
+        setTarget(guardedtarget);
+
+        return (IRubyObject) target.invokeExact(context, self);
+    }
+
+    public IRubyObject respondToFallback(ThreadContext context, IRubyObject caller, IRubyObject self) throws Throwable {
+        SwitchPoint switchPoint = (SwitchPoint) self.getMetaClass().getInvalidator().getData();
+        CacheEntry entry = self.getMetaClass().searchWithCache("respond_to?");
+        MethodHandle target = null;
+
+        if (!InvokeSite.methodMissing(entry.method, "respond_to?", CallType.NORMAL, caller)) {
+            if (entry.method.isBuiltin()) {
+                // standard respond_to, check if method is naturally defined (not via respond_to_missing?)
+                boolean respondsTo = self.getMetaClass().respondsToMethod(rawValue, false);
+                if (respondsTo) {
+                    // cache result; method table changes will invalidate this whole thing
+                    target = Binder.from(type())
+                            .dropAll()
+                            .append(context.tru)
+                            .identity();
+                }
+            }
+        }
+
+        if (target == null) {
+            RubySymbol id = SymbolObjectSite.constructSymbolFromRaw(context, rawValue, encoding);
+            target = Binder.from(type())
+                    .append(IRubyObject.class, id)
+                    .invoke(NormalInvokeSite.bootstrap(lookup(), "invoke:" + JavaNameMangler.mangleMethodName("respond_to?"), type().appendParameterTypes(IRubyObject.class), 0, 0, file, line).dynamicInvoker());
+        }
+
+        MethodHandle guardedtarget = typeCheck(target, Signature.from(type().returnType(), type().parameterArray(), "context", "self"), self, self.getMetaClass(), getTarget());
+        guardedtarget = InvokeSite.switchPoint(switchPoint, getTarget(), guardedtarget);
+
+        setTarget(guardedtarget);
+
+        return (IRubyObject) target.invokeExact(context, caller, self);
+    }
+
+    public static MethodHandle typeCheck(MethodHandle target, Signature signature, IRubyObject self, RubyModule testClass, MethodHandle fallback) {
+        MethodHandle result;
+        SmartHandle test = InvokeSite.testTarget(signature, self, testClass);
+
+        result = MethodHandles.guardWithTest(test.handle(), target, fallback);
+        return result;
+    }
+}

--- a/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/RespondToSite.java
@@ -121,7 +121,7 @@ public class RespondToSite extends MutableCallSite {
                     .invoke(NormalInvokeSite.bootstrap(lookup(), "invoke:" + JavaNameMangler.mangleMethodName("respond_to?"), type().appendParameterTypes(IRubyObject.class), 0, 0, file, line).dynamicInvoker());
         }
 
-        MethodHandle guardedtarget = typeCheck(target, Signature.from(type().returnType(), type().parameterArray(), "context", "self"), self, self.getMetaClass(), getTarget());
+        MethodHandle guardedtarget = typeCheck(target, Signature.from(type().returnType(), type().parameterArray(), "context", "caller", "self"), self, self.getMetaClass(), getTarget());
         guardedtarget = InvokeSite.switchPoint(switchPoint, getTarget(), guardedtarget);
 
         setTarget(guardedtarget);

--- a/core/src/main/java/org/jruby/ir/targets/indy/SymbolObjectSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/SymbolObjectSite.java
@@ -1,6 +1,7 @@
 package org.jruby.ir.targets.indy;
 
 import org.jruby.RubyEncoding;
+import org.jruby.RubySymbol;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -42,7 +43,11 @@ public class SymbolObjectSite extends LazyObjectSite {
     }
 
     public IRubyObject construct(ThreadContext context) {
+        return constructSymbolFromRaw(context, value, encoding);
+    }
+
+    static RubySymbol constructSymbolFromRaw(ThreadContext context, String rawValue, String encoding) {
         return asSymbol(context,
-                new ByteList(RubyEncoding.encodeISO(value), IRRuntimeHelpers.retrieveJCodingsEncoding(context, encoding), false));
+                new ByteList(RubyEncoding.encodeISO(rawValue), IRRuntimeHelpers.retrieveJCodingsEncoding(context, encoding), false));
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -3,6 +3,7 @@ package org.jruby.ir.targets.simple;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
+import org.jruby.RubySymbol;
 import org.jruby.compiler.NotCompilableException;
 import org.jruby.compiler.impl.SkinnyMethodAdapter;
 import org.jruby.ir.instructions.AsStringInstr;
@@ -503,5 +504,15 @@ public class NormalInvocationCompiler implements InvocationCompiler {
     public void invokeFrameName(String methodName, String file) {
         // direct __method__ and __callee__ calls always use indy
         IndyInvocationCompiler.invokeFrameName(compiler, methodName, file);
+    }
+
+    @Override
+    public void respondTo(CallBase callBase, RubySymbol id, String scopeFieldName, String file) {
+        compiler.getValueCompiler().pushSymbol(id.getBytes());
+        if (callBase.getCallType().isSelfCall()) {
+            invokeSelf(file, scopeFieldName, callBase, 1);
+        } else {
+            invokeOther(file, scopeFieldName, callBase, 1);
+        }
     }
 }

--- a/core/src/main/java/org/jruby/runtime/CallType.java
+++ b/core/src/main/java/org/jruby/runtime/CallType.java
@@ -41,4 +41,12 @@ public enum CallType {
         }
         return VALUES[ordinal];
     }
+
+    public boolean isSelfCall() {
+        return this == FUNCTIONAL || this == VARIABLE;
+    }
+
+    public boolean isSuper() {
+        return this == SUPER;
+    }
 }


### PR DESCRIPTION
This optimizes the common case of respond_to? with a literal symbol. When the method is "naturally" respond_to? => true then that result can be cached behind the usual guards. This makes the success path essentially free.

The logic here has a lot of copied behavior from elsewhere and utilizes some now-static methods from InvokeSite, so it could be refactored along with the rest of indy logic to be much simpler.