### PR TITLE
Update snapshot deploy to use new maven infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
       contents: read
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/10-dev' }}
     needs: [mvn-test, mvn-test-extended, mvn-test-windows, dependency-check, rake-test, rake-test-indy-off, rake-test, test-versions, sequel, concurrent-ruby, jruby-tests-dev, regression-specs-jit]
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@5c281bb7db572a7ecbbb88fa7bd3e31253837291
     with:
       javaLevel: 21
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
       contents: read
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/10-dev' }}
     needs: [mvn-test, mvn-test-extended, mvn-test-windows, dependency-check, rake-test, rake-test-indy-off, rake-test, test-versions, sequel, concurrent-ruby, jruby-tests-dev, regression-specs-jit]
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@be3447be266437d35861b8d73cb30db4c6f4ad95
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
     with:
       javaLevel: 21
     secrets:

--- a/.github/workflows/manual-snapshot-publish-21.yml
+++ b/.github/workflows/manual-snapshot-publish-21.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     permissions:
       contents: read
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@5c281bb7db572a7ecbbb88fa7bd3e31253837291
     with:
       javaLevel: 21
     secrets:

--- a/.github/workflows/manual-snapshot-publish-21.yml
+++ b/.github/workflows/manual-snapshot-publish-21.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     permissions:
       contents: read
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@be3447be266437d35861b8d73cb30db4c6f4ad95
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
     with:
       javaLevel: 21
     secrets:

--- a/.github/workflows/manual-snapshot-publish.yml
+++ b/.github/workflows/manual-snapshot-publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     permissions:
       contents: read
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@be3447be266437d35861b8d73cb30db4c6f4ad95
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
     with:
       javaLevel: 8
     secrets:

--- a/.github/workflows/manual-snapshot-publish.yml
+++ b/.github/workflows/manual-snapshot-publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     permissions:
       contents: read
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@5c281bb7db572a7ecbbb88fa7bd3e31253837291
     with:
       javaLevel: 8
     secrets:

--- a/.github/workflows/nightly-snapshot-publish-21.yml
+++ b/.github/workflows/nightly-snapshot-publish-21.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     if: ${{ github.ref == 'refs/heads/master' }}
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@be3447be266437d35861b8d73cb30db4c6f4ad95
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
     with:
       javaLevel: 21
     secrets:

--- a/.github/workflows/nightly-snapshot-publish-21.yml
+++ b/.github/workflows/nightly-snapshot-publish-21.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     if: ${{ github.ref == 'refs/heads/master' }}
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@5c281bb7db572a7ecbbb88fa7bd3e31253837291
     with:
       javaLevel: 21
     secrets:

--- a/.github/workflows/nightly-snapshot-publish.yml
+++ b/.github/workflows/nightly-snapshot-publish.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     if: ${{ github.ref == 'refs/heads/jruby-9.4' }}
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@5c281bb7db572a7ecbbb88fa7bd3e31253837291
     with:
       javaLevel: 8
     secrets:

--- a/.github/workflows/nightly-snapshot-publish.yml
+++ b/.github/workflows/nightly-snapshot-publish.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     if: ${{ github.ref == 'refs/heads/jruby-9.4' }}
-    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@be3447be266437d35861b8d73cb30db4c6f4ad95
+    uses: jruby/jruby/.github/workflows/snapshot-publish.yml@d70e4874ce4216e95f775da8dfc6d6a0f77153f9
     with:
       javaLevel: 8
     secrets:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -30,8 +30,8 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ inputs.javaLevel }}
           server-id: central
-          server-username: ${{ secrets.SONATYPE_USERNAME }}
-          server-password: ${{ secrets.SONATYPE_PASSWORD }}
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
       - name: Publish package
         run: ./mvnw -B clean deploy -Psnapshots
         env:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -33,7 +33,7 @@ jobs:
           server-username: ${{ secrets.SONATYPE_USERNAME }}
           server-password: ${{ secrets.SONATYPE_PASSWORD }}
       - name: Publish package
-        run: ./mvnw -B clean deploy -Prelease
+        run: ./mvnw -B clean deploy -Psnapshots
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -33,7 +33,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: ./mvnw -B clean deploy -Psnapshots
+        run: ./mvnw -B clean deploy -Psnapshots -X
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -108,20 +108,20 @@ project 'JRuby Complete' do
         plugin :dependency do
           items = set.collect do |classifier|
             { 'groupId' =>  '${project.groupId}',
-              'artifactId' =>  'jruby-core',
+              'artifactId' =>  'jruby-base',
               'version' =>  '${project.version}',
               'classifier' =>  classifier,
               'overWrite' =>  'false',
               'outputDirectory' =>  '${project.build.directory}' }
           end
           execute_goals( 'copy',
-                         :id => 'copy javadocs and sources from jruby-core',
+                         :id => 'copy javadocs and sources from jruby-base',
                          'artifactItems' => items )
         end
 
         plugin 'org.codehaus.mojo:build-helper-maven-plugin' do
           artifacts = set.collect do |classifier|
-            { 'file' =>  "${project.build.directory}/jruby-core-${project.version}-#{classifier}.jar", 'classifier' =>  classifier }
+            { 'file' =>  "${project.build.directory}/jruby-base-${project.version}-#{classifier}.jar", 'classifier' =>  classifier }
           end
           execute_goals( 'attach-artifact',
                          :id => 'attach-artifacts',

--- a/pom.rb
+++ b/pom.rb
@@ -296,7 +296,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
     end
     plugin(:javadoc) do
       execute_goals('jar', :id => 'attach-javadocs')
-      configuration(doclint: 'none')
+      configuration(doclint: 'none', additionalOptions: '-Xdoclint:none', failOnError: 'false')
     end
   end
 

--- a/pom.rb
+++ b/pom.rb
@@ -287,11 +287,6 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
 
     modules [ 'maven' ]
 
-    distribution_management do
-      repository( :url => "file:${project.build.directory}/maven", :id => 'local releases' )
-      snapshot_repository( :url => "file:${project.build.directory}/maven",
-                           :id => 'local snapshots' )
-    end
     build do
       default_goal :deploy
     end

--- a/pom.rb
+++ b/pom.rb
@@ -296,6 +296,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
     end
     plugin(:javadoc) do
       execute_goals('jar', :id => 'attach-javadocs')
+      configuration(doclint: 'none')
     end
   end
 

--- a/pom.xml
+++ b/pom.xml
@@ -838,16 +838,6 @@ DO NOT MODIFY - GENERATED CODE
       <modules>
         <module>maven</module>
       </modules>
-      <distributionManagement>
-        <repository>
-          <id>local releases</id>
-          <url>file:${project.build.directory}/maven</url>
-        </repository>
-        <snapshotRepository>
-          <id>local snapshots</id>
-          <url>file:${project.build.directory}/maven</url>
-        </snapshotRepository>
-      </distributionManagement>
     </profile>
     <profile>
       <id>single invoker test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -827,22 +827,15 @@ DO NOT MODIFY - GENERATED CODE
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <doclint>none</doclint>
+            </configuration>
           </plugin>
         </plugins>
       </build>
       <modules>
         <module>maven</module>
       </modules>
-      <distributionManagement>
-        <repository>
-          <id>local releases</id>
-          <url>file:${project.build.directory}/maven</url>
-        </repository>
-        <snapshotRepository>
-          <id>local snapshots</id>
-          <url>file:${project.build.directory}/maven</url>
-        </snapshotRepository>
-      </distributionManagement>
     </profile>
     <profile>
       <id>single invoker test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -829,6 +829,8 @@ DO NOT MODIFY - GENERATED CODE
             </executions>
             <configuration>
               <doclint>none</doclint>
+              <additionalOptions>-Xdoclint:none</additionalOptions>
+              <failOnError>false</failOnError>
             </configuration>
           </plugin>
         </plugins>
@@ -836,6 +838,16 @@ DO NOT MODIFY - GENERATED CODE
       <modules>
         <module>maven</module>
       </modules>
+      <distributionManagement>
+        <repository>
+          <id>local releases</id>
+          <url>file:${project.build.directory}/maven</url>
+        </repository>
+        <snapshotRepository>
+          <id>local snapshots</id>
+          <url>file:${project.build.directory}/maven</url>
+        </snapshotRepository>
+      </distributionManagement>
     </profile>
     <profile>
       <id>single invoker test</id>


### PR DESCRIPTION
There's a number of changes here to support deploying snapshots locally or automatically on GHA:

* Moving GPG signing to the `snapshots` profile and using that profile to create snapshots instead of `release`.
* Switching jruby-complete's source jar generation to use the contents of jruby-base instead of jruby-core (which was empty and now seems to be failing to generate altogether).
* Updates to the maven configuration in the GHA jobs to use the "central" repository name.

This appears to be working to deploy snapshots now locally and on GHA, but I have some doubts:

* Why did the jruby-complete use of jruby-core sources work before but suddenly fail. Why did it release ok for 9.4.13.0 and simply publish no sources jar (something I thought Maven Central rejected)?
* I'm pretty sure snapshots worked fine when I started the process of updating to the latest Maven Central infrastructure last week, testing again the `jruby-9.4` branch. Why then did it fail after merging those changes to master (10)?