### PR TITLE
Fixes #8867. Object constants found in Module#const_defined?

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4625,7 +4625,7 @@ public class RubyModule extends RubyObject {
         int realSize = value.getRealSize();
         int end = begin + realSize;
         int currentOffset = 0;
-        int patternIndex;
+        int patternIndex = 0;
         int index = 0;
         RubyModule mod = this;
 
@@ -4661,7 +4661,6 @@ public class RubyModule extends RubyObject {
 
             mod = (RubyModule) obj;
             currentOffset = patternIndex + pattern.getRealSize();
-            inherit = false;
         }
 
         if (mod == null) mod = this; // Bare 'Foo'
@@ -4670,7 +4669,9 @@ public class RubyModule extends RubyObject {
 
         String id = RubySymbol.newConstantSymbol(context, fullName, lastSegment).idString();
 
-        return mod.getConstantSkipAutoload(context, id, inherit, inherit) != null;
+        // index of 0 (::Foo) would naturaally happen above loop and not make it here.  This
+        // tells us we are in a chain and to not look at Object for our last lookup.
+        return mod.getConstantSkipAutoload(context, id, inherit, patternIndex == 0) != null;
     }
 
     // MRI: rb_mod_const_get

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4661,6 +4661,7 @@ public class RubyModule extends RubyObject {
 
             mod = (RubyModule) obj;
             currentOffset = patternIndex + pattern.getRealSize();
+            inherit = false;
         }
 
         if (mod == null) mod = this; // Bare 'Foo'

--- a/spec/ruby/core/module/const_defined_spec.rb
+++ b/spec/ruby/core/module/const_defined_spec.rb
@@ -151,6 +151,7 @@ describe "Module#const_defined?" do
     ConstantSpecs.const_defined?("::Object").should == true
     ConstantSpecs.const_defined?("ClassA::CS_CONST10").should == true
     ConstantSpecs.const_defined?("ClassA::CS_CONST10_").should == false
+    ConstantSpecs.const_defined?("ClassA::String").should == false
   end
 
   it "raises a NameError if the name contains non-alphabetic characters except '_'" do


### PR DESCRIPTION
For compound constants (Foo::Bar) the inherit flag was being pushed along all lhs constants when we only want this to happen for the first search.