### PR TITLE
fix #8880.  Added a second with Rational

### DIFF
--- a/core/src/main/java/org/jruby/util/time/TimeArgs.java
+++ b/core/src/main/java/org/jruby/util/time/TimeArgs.java
@@ -130,7 +130,7 @@ public class TimeArgs {
 
                     var numerator = subSecond.getNumerator().asLong(context);
                     var denominator = subSecond.getDenominator().asLong(context);
-                    if (numerator > denominator) {
+                    if (numerator >= denominator) {
                         secondsInRational = (int) (numerator / (double) denominator);
                         numerator = numerator % denominator;
                         subSecond = RubyRational.newRational(context.runtime, numerator, denominator);


### PR DESCRIPTION
Missed case that Rational(1,1) is in fact a whole number and needs to be subtracted if seconds to Time are passed in.