### PR TITLE
Always set chilled strings as sharing bytelist

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -960,8 +960,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     public final RubyString dupAsChilled(Ruby runtime, RubyClass clazz, String file, int line) {
         if (runtime.getInstanceConfig().isDebuggingFrozenStringLiteral()) {
             shareLevel = SHARE_LEVEL_BYTELIST;
-            RubyString dup = new DebugChilledString(runtime, clazz, value, getCodeRange(), file, line + 1);
-            dup.shareLevel = SHARE_LEVEL_BYTELIST;
+            RubyString dup = new DebugChilledString(runtime, clazz, value, getCodeRange(), file, line + 1 + 1);
             dup.flags |= flags & CR_MASK;
 
             return dup;
@@ -1247,6 +1246,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             this.file = file;
             this.line = line;
+
+            // Always set as shared bytelist, since chilled strings reuse bytelists and will eventually be immutable
+            this.shareLevel = SHARE_LEVEL_BYTELIST;
 
             chill();
         }

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1566,5 +1566,16 @@ modes.each do |mode|
         BZSuper.new.z_super
       SUPER
     end
+
+    it "compiles debug chilled strings that can be modified without impacting other strings" do
+      JRuby.runtime.instance_config.debugging_frozen_string_literal = true
+      run(<<~CHILLED) {|val| expect(val).to eq("")}
+        str = ""
+        str << "hello"
+        ""
+      CHILLED
+    ensure
+      JRuby.runtime.instance_config.debugging_frozen_string_literal = false
+    end
   end
 end


### PR DESCRIPTION
Chilled strings are constructed much like frozen strings, reusing the same bytelist for each new instance. But unlike frozen strings, chilled strings may still be mutated for now. We mark all such strings as having a shared ByteList to ensure that it is copied before making modifications.

Fixes #8861
