### PR TITLE
Normalize arch to universal-java-version

### DIFF
--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -243,9 +243,13 @@ public class RbConfigLibrary implements Library {
         setConfig(context, CONFIG, "TEENY", teeny);
         setConfig(context, CONFIG, "PATCHLEVEL", "0");
         setConfig(context, CONFIG, "ruby_version", major + '.' + minor + ".0");
+
+        // normalize Java version 1.8 to 8
+        String javaSpecVersion = System.getProperty("java.specification.version");
+        if (javaSpecVersion.equals("1.8")) javaSpecVersion = "8";
+
         // Rubygems is too specific on host cpu so until we have real need lets default to universal
-        //setConfig(CONFIG, "arch", System.getProperty("os.arch") + "-java" + System.getProperty("java.specification.version"));
-        setConfig(context, CONFIG, "arch", "universal-java" + System.getProperty("java.specification.version"));
+        setConfig(context, CONFIG, "arch", "universal-java-" + javaSpecVersion);
 
         // Use property for binDir if available, otherwise fall back to common bin default
         String binDir = SafePropertyAccessor.getProperty("jruby.bindir");


### PR DESCRIPTION
In order to support an upcoming patch to RubyGems that will ignore the platform version (e.g. darwin-22), we make the following tweaks to our RbConfig::CONFIG['arch'] value:

* Add a hyphen before the Java version.
* Normalize Java 1.8 to 8 so all possible versions are integers.

This does not fix rubygems/rubygems#3520 but will support a future fix.