### PR TITLE
Require the correct case for this library

### DIFF
--- a/lib/ruby/stdlib/win32/registry.rb
+++ b/lib/ruby/stdlib/win32/registry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 require 'win32/importer'
-require 'Win32API'
+require 'win32api'
 
 module Win32
 


### PR DESCRIPTION
The library was renamed to `win32api` some time ago and this require was never updated. A recent change to resolv.rb (77471759d) now triggers loading win32/registry.rb, which in turn hits this incorrectly-cased require.

Whether the path should require successfully on Windows is a separate debate, but we mostly use JDK classes to check for the target file. That logic may not consider the two paths identical and not find the file on Windows.

When running inside a jar, all paths must be cased properly, so this will also fix the situation of running with jruby-complete on a Windows system.

Fixes #8866