### PR TITLE
Coerce the chdir for popen

### DIFF
--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -1703,7 +1703,7 @@ public class PopenExecutor {
         IRubyObject chdir;
         if (!optForChdir.isNil() && (chdir = ((RubyHash) optForChdir).delete(chdirSym)) != null) {
             eargp.chdirGiven = true;
-            eargp.chdir_dir = chdir.convertToString().toString();
+            eargp.chdir_dir = RubyFile.get_path(context, chdir).toString();
         }
 
         execFillarg(context, prog, argv_p[0], env_opt[0], env_opt[1], eargp);

--- a/spec/ruby/core/io/popen_spec.rb
+++ b/spec/ruby/core/io/popen_spec.rb
@@ -95,6 +95,20 @@ describe "IO.popen" do
     @io = IO.popen(ruby_cmd('exit 0'), mode)
   end
 
+  it "accepts a path using the chdir: keyword argument" do
+    File.write(@fname, 'hello world')
+    @io = IO.popen("/bin/ls", chdir: File.dirname(@fname));
+    @io.read.chomp.should == File.basename(@fname)
+  end
+
+  it "accepts a path using the chdir: keyword argument and a coercible path" do
+    path = mock("path")
+    path.should_receive(:to_path).and_return(File.dirname(@fname))
+    File.write(@fname, 'hello world')
+    @io = IO.popen("/bin/ls", chdir: path);
+    @io.read.chomp.should == File.basename(@fname)
+  end
+
   describe "with a block" do
     it "yields an open IO to the block" do
       IO.popen(ruby_cmd('exit'), "r") do |io|


### PR DESCRIPTION
The value passed to IO.popen for the chdir keyword argument should be coerced like other paths.

Fixes #8859.