### PR TITLE
Fix Time.new parsing (time/new_tags.txt)

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1858,7 +1858,7 @@ public class RubyTime extends RubyObject {
         boolean keywords = hasKeywords(ThreadContext.resetCallInfo(context));
         int argc = args.length;
         IRubyObject zone = context.nil;
-        IRubyObject precision = context.nil;
+        IRubyObject precision = asFixnum(context, 9);
 
         if (keywords) {
             IRubyObject[] opts = ArgsUtil.extractKeywordArgs(context, args[args.length - 1], "in", "precision");
@@ -1874,10 +1874,6 @@ public class RubyTime extends RubyObject {
                 }
 
                 if (opts[1] != null) {
-                    if (!(opts[1] instanceof RubyNumeric)) {
-                        // Weird error since all numerics work at this point so why mention Integer?
-                        throw typeError(context, str(context.runtime, "no implicit conversion of ", typeAsString(opts[1]), " into Integer"));
-                    }
                     precision = opts[1];
                 }
             }
@@ -1890,12 +1886,12 @@ public class RubyTime extends RubyObject {
         return switch (argc) {
             case 0 -> initializeNow(context, zone);
             case 1 -> timeInitParse(context, args[0], zone, precision);
-            case 2 -> initialize(context, args[0], args[1], nil, nil, nil, nil, precision, zone);
-            case 3 -> initialize(context, args[0], args[1], args[2], nil, nil, nil, precision, zone);
-            case 4 -> initialize(context, args[0], args[1], args[2], args[3], nil, nil, precision, zone);
-            case 5 -> initialize(context, args[0], args[1], args[2], args[3], args[4], nil, precision, zone);
-            case 6 -> initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], precision, zone);
-            case 7 -> initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], precision, zone);
+            case 2 -> initialize(context, args[0], args[1], nil, nil, nil, nil, nil, zone);
+            case 3 -> initialize(context, args[0], args[1], args[2], nil, nil, nil, nil, zone);
+            case 4 -> initialize(context, args[0], args[1], args[2], args[3], nil, nil, nil, zone);
+            case 5 -> initialize(context, args[0], args[1], args[2], args[3], args[4], nil, nil, zone);
+            case 6 -> initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], nil, zone);
+            case 7 -> initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], nil, zone);
             default -> throw argumentError(context, argc, 0, 7);
         };
     }
@@ -1903,7 +1899,7 @@ public class RubyTime extends RubyObject {
     private IRubyObject timeInitParse(ThreadContext context, IRubyObject arg, IRubyObject zone, IRubyObject precision) {
         IRubyObject strArg = arg.checkStringType();
         if (strArg.isNil()) {
-            return initialize(context, arg, context.nil, context.nil, context.nil, context.nil, context.nil, precision, zone);
+            return initialize(context, arg, context.nil, context.nil, context.nil, context.nil, context.nil, context.nil, zone);
         }
         RubyString str = (RubyString) strArg;
 

--- a/core/src/main/java/org/jruby/util/time/TimeArgs.java
+++ b/core/src/main/java/org/jruby/util/time/TimeArgs.java
@@ -15,9 +15,7 @@ import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyRational.rationalCanonicalize;
 import static org.jruby.RubyTime.TIME_SCALE;
-import static org.jruby.RubyTime.TIME_SCALE_DIGITS;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.toDouble;
 import static org.jruby.api.Convert.toInt;

--- a/spec/tags/ruby/core/time/new_tags.txt
+++ b/spec/tags/ruby/core/time/new_tags.txt
@@ -1,7 +1,6 @@
 fails:Time.new with a utc_offset argument returns a Time with a UTC offset of the specified number of Rational seconds
 fails:Time.new with a utc_offset argument raises ArgumentError if the String argument is not in an ASCII-compatible encoding
 fails:Time.new with a utc_offset argument with an argument that responds to #to_r coerces using #to_r
-fails:Time.new with a utc_offset argument raises ArgumentError if the month is greater than 12
 fails(not implemented, jruby/jruby#6161):Time.new with a timezone argument the #abbr method is used by '%Z' in #strftime
 fails(not implemented, jruby/jruby#6161):Time.new with a timezone argument Time-like argument of #utc_to_local and #local_to_utc methods has attribute values the same as a Time object in UTC
 fails(not implemented, jruby/jruby#6161):Time.new with a timezone argument #name method uses the optional #name method for marshaling
@@ -9,12 +8,6 @@ fails(not implemented, jruby/jruby#6161):Time.new with a timezone argument #name
 fails(not implemented, jruby/jruby#6161):Time.new with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object at loading marshaled data
 fails(only during full spec run):Time.new with a utc_offset argument raises ArgumentError if the String argument is not of the form (+|-)HH:MM
 fails:Time.new with a timezone argument returned value by #utc_to_local and #local_to_utc methods cannot have arbitrary #utc_offset if it is an instance of Time
-fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument :in keyword argument allows omitting minor arguments
 fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument Time.new with a String argument accepts precision keyword argument and truncates specified digits of sub-second part
-fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument Time.new with a String argument converts precision keyword argument into Integer if is not nil
 fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument Time.new with a String argument raises ArgumentError if date/time parts values are not valid
 fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument Time.new with a String argument raises ArgumentError if utc offset parts are not valid
-fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument Time.new with a String argument raises ArgumentError if string doesn't start with year
-fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument Time.new with a String argument raises ArgumentError when there are leading space characters
-fails(https://github.com/jruby/jruby/issues/8736):Time.new with a timezone argument Time.new with a String argument raises ArgumentError when there are trailing whitespaces
-fails:Time.new with a timezone argument Time.new with a String argument returns Time with correct subseconds when given seconds fraction is longer than 9 digits


### PR DESCRIPTION
The idea was to help towards this #8736 but most of the fixes here are specifically around parsing the time string, not timezone related.

@enebo I noticed you did recent changes around Time.new parsing as well, in case you want to review.

I'll add some comments in the PR to highlight which changes fix which parts, but here is the TLDR:

- Time.new parsing should ignore "whitespace" chars, not only space chars

- precision keyword argument should only be used by Time.new parsing and ignored otherwise (see Ruby docs), and it should default to 9

- RubyTimeParser.parseInt now returns nil if no digits (so missing year can be detected) and only to a set number of digits (for subsec precision)

- correctly convert subsec to microseconds in RubyTimeParser when more than 9 digits