### PR TITLE
Quick stab and limited profile runtime

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1772,7 +1772,7 @@ public final class Ruby implements Constantizable {
         // if we can't use reflection, 'jruby' and 'java' won't work; no load.
         boolean reflectionWorks = doesReflectionWork();
 
-        if (reflectionWorks && profile.allowLoad("java")) {
+        if (reflectionWorks) {
             new Java().load(context.runtime, false);
             new JRubyUtilLibrary().load(context.runtime, false);
 

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -199,7 +199,9 @@ public class RubyGlobal {
         runtime.defineVariable(new LastlineGlobalVariable(runtime, "$_"), FRAME);
         runtime.defineVariable(new LastExitStatusVariable(runtime, "$?"), THREAD);
 
-        runtime.defineVariable(new ErrorInfoGlobalVariable(runtime, "$!", context.nil), THREAD);
+        if (runtime.getProfile().allowClass("Thread")) {
+            runtime.defineVariable(new ErrorInfoGlobalVariable(runtime, "$!", context.nil), THREAD);
+        }
         runtime.defineVariable(new NonEffectiveGlobalVariable(runtime, "$=", context.fals), GLOBAL);
 
         if(instanceConfig.getInputFieldSeparator() == null) {

--- a/core/src/test/java/org/jruby/javasupport/JavaEmbedUtilsTest.java
+++ b/core/src/test/java/org/jruby/javasupport/JavaEmbedUtilsTest.java
@@ -21,6 +21,7 @@ import org.jruby.Profile;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyString;
 import org.jruby.exceptions.NameError;
+import org.jruby.exceptions.SyntaxError;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.runtime.ThreadContext;
@@ -72,7 +73,7 @@ public class JavaEmbedUtilsTest {
     class CustomProfile implements Profile {
         private List classAllow = List.of("String", "Fixnum", "Integer", "Numeric", "Hash", "Array",
                 "Thread", "ThreadGroup", "RubyError", "StopIteration", "LoadError", "ArgumentError", "Encoding",
-                "EncodingError", "StandardError", "Exception", "NameError");
+                "EncodingError", "StandardError", "Exception", "NameError", "SyntaxError", "ScriptError");
         private List loadAllow = List.of("jruby/java.rb", "jruby/java/core_ext.rb", "jruby/java/java_ext.rb",
                 "jruby/java/core_ext/object.rb");
 
@@ -114,6 +115,7 @@ public class JavaEmbedUtilsTest {
         assertThrows(NameError.class, () -> runtime.evalScriptlet("UDPSocket.new"));
         assertEquals("cute_cats",((RubyString)runtime.evalScriptlet("\"cute_cats\"")).getValue());
         assertEquals("cute_cat",((RubyString)runtime.evalScriptlet("\"cute_cats\".delete('s')")).getValue());
+        assertThrows(SyntaxError.class, () -> runtime.evalScriptlet("puts 'you shouldn't see this'"));
         //assertThrows(NameError.class, () -> runtime.evalScriptlet("IO.sysopen('test.tmp')"));
     }
 

--- a/core/src/test/java/org/jruby/javasupport/JavaEmbedUtilsTest.java
+++ b/core/src/test/java/org/jruby/javasupport/JavaEmbedUtilsTest.java
@@ -13,11 +13,14 @@ import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.jruby.Profile;
 import org.jruby.RubyFixnum;
+import org.jruby.RubyString;
+import org.jruby.exceptions.NameError;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.runtime.ThreadContext;
@@ -69,7 +72,7 @@ public class JavaEmbedUtilsTest {
     class CustomProfile implements Profile {
         private List classAllow = List.of("String", "Fixnum", "Integer", "Numeric", "Hash", "Array",
                 "Thread", "ThreadGroup", "RubyError", "StopIteration", "LoadError", "ArgumentError", "Encoding",
-                "EncodingError", "StandardError", "Exception");
+                "EncodingError", "StandardError", "Exception", "NameError");
         private List loadAllow = List.of("jruby/java.rb", "jruby/java/core_ext.rb", "jruby/java/java_ext.rb",
                 "jruby/java/core_ext/object.rb");
 
@@ -107,7 +110,11 @@ public class JavaEmbedUtilsTest {
 
         Ruby runtime = Ruby.newInstance(config);
         assertEquals(20L, ((RubyFixnum) runtime.evalScriptlet("def double(a); a * 2; end; double(10)")).getValue());
-        //Ruby runtime = JavaEmbedUtils.initialize(EMPTY, config);
+        assertThrows(NameError.class, () -> runtime.evalScriptlet("File.open('test.tmp')"));
+        assertThrows(NameError.class, () -> runtime.evalScriptlet("UDPSocket.new"));
+        assertEquals("cute_cats",((RubyString)runtime.evalScriptlet("\"cute_cats\"")).getValue());
+        assertEquals("cute_cat",((RubyString)runtime.evalScriptlet("\"cute_cats\".delete('s')")).getValue());
+        //assertThrows(NameError.class, () -> runtime.evalScriptlet("IO.sysopen('test.tmp')"));
     }
 
     @Test

--- a/core/src/test/java/org/jruby/javasupport/JavaEmbedUtilsTest.java
+++ b/core/src/test/java/org/jruby/javasupport/JavaEmbedUtilsTest.java
@@ -70,6 +70,8 @@ public class JavaEmbedUtilsTest {
         private List classAllow = List.of("String", "Fixnum", "Integer", "Numeric", "Hash", "Array",
                 "Thread", "ThreadGroup", "RubyError", "StopIteration", "LoadError", "ArgumentError", "Encoding",
                 "EncodingError", "StandardError", "Exception");
+        private List loadAllow = List.of("jruby/java.rb", "jruby/java/core_ext.rb", "jruby/java/java_ext.rb",
+                "jruby/java/core_ext/object.rb");
 
         @Override
         public boolean allowBuiltin(String name) {
@@ -88,7 +90,7 @@ public class JavaEmbedUtilsTest {
 
         @Override
         public boolean allowLoad(String name) {
-            return false;
+            return loadAllow.contains(name);
         }
 
         @Override


### PR DESCRIPTION
This was quickest and minimal needed to work to get a profile which can load a Ruby runtime.  It is not really correct and is meant as a starting point.

There are some obvious problems with profile as it is defined.  Basic fundamental things like primal Exception types need to be loaded.  Allowing people to omit them is a footgun.

There is obvious issues with ommitting jruby/kernel.  Some of that is required but at the same time it likely hits profile excluded types.

Regex is a major source of DOS so it must be excludable but at the same time I suspect we call it many places internally.

Methods which use types which are excludable (like Regexp) probably should be aware of excluded types and not bind.  This would be a MAJOR amount of work but it would fit into idea of a dependency graph.  Likewise we could make a much smarter type declaration where something like:

```java
        return defineClass(context, "Integer", Numeric, NOT_ALLOCATABLE_ALLOCATOR).
                reifiedClass(RubyInteger.class).
                kindOf(new RubyModule.JavaClassKindOf(RubyInteger.class)).
                classIndex(ClassIndex.INTEGER).
                defineMethods(context, RubyInteger.class).
                tap(c-> c.singletonClass(context).undefMethods(context, "new"));
```

(we are only pretending with this example as Integer is too primal to Ruby to be allowed to be excluded) we would want to add something to this which would know that it cannot defineClass unless "Numeric" has been defined.

```java
        return  requires("Numeric", "Fixnum", "Bignum").
                defineClass(context, "Integer", Numeric, NOT_ALLOCATABLE_ALLOCATOR).
                reifiedClass(RubyInteger.class).
                kindOf(new RubyModule.JavaClassKindOf(RubyInteger.class)).
                classIndex(ClassIndex.INTEGER).
                defineMethods(context, RubyInteger.class).
                tap(c-> c.singletonClass(context).undefMethods(context, "new"));
```

This would end up simplifying the smattering of if's in Ruby to just declare these dependencies in the setup method for the type.