### PR TITLE
Update maven plugins to latest

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -154,7 +154,6 @@ project 'JRuby Lib Setup' do
 
   properties( 'polyglot.dump.pom' => 'pom.xml',
               'polyglot.dump.readonly' => true,
-              'jruby.plugins.version' => '3.0.5',
               'gem.home' => '${basedir}/ruby/gems/shared',
               # we copy everything into the target/classes/META-INF
               # so the jar plugin just packs it - see build/resources below

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -20,7 +20,6 @@ DO NOT MODIFY - GENERATED CODE
     <gem.home>${basedir}/ruby/gems/shared</gem.home>
     <jruby.complete.gems>${jruby.complete.home}/lib/ruby/gems/shared</jruby.complete.gems>
     <jruby.complete.home>${project.build.outputDirectory}/META-INF/jruby.home</jruby.complete.home>
-    <jruby.plugins.version>3.0.5</jruby.plugins.version>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>true</polyglot.dump.readonly>
   </properties>

--- a/pom.rb
+++ b/pom.rb
@@ -62,7 +62,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'github.global.server' => 'github',
               'polyglot.dump.pom' => 'pom.xml',
               'polyglot.dump.readonly' => 'true',
-              'jruby.plugins.version' => '3.0.5',
+              'jruby.plugins.version' => '3.0.6',
 
               # versions for default gems with bin executables
               # used in ./lib/pom.rb and ./maven/jruby-stdlib/pom.rb

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ DO NOT MODIFY - GENERATED CODE
     <joda.time.version>2.12.7</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>
-    <jruby.plugins.version>3.0.5</jruby.plugins.version>
+    <jruby.plugins.version>3.0.6</jruby.plugins.version>
     <main.basedir>${project.basedir}</main.basedir>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>true</polyglot.dump.readonly>


### PR DESCRIPTION
This fixes issues with downloads (of poms, gems, etc) sometimes garbling the output and including null bytes (jruby/jruby-maven-plugins@fea0a42502af8bb94e9dc6c9e4a2d7aa394a08cf) as well as updating to latest JRuby 9.4 and a few other small fixes.