### PR TITLE
Always check array insert pos

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1200,17 +1200,26 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = "insert", required = 1, rest = true, checkArity = false)
     public IRubyObject insert(IRubyObject[] args) {
+        switch (args.length) {
+            case 0:
+                return insert();
+            case 1:
+                return insert(args[0]);
+            case 2:
+                return insert(args[0], args[1]);
+        }
+
         final Ruby runtime = metaClass.runtime;
 
         int argc = Arity.checkArgumentCount(runtime, args, 1, -1);
 
         modifyCheck();
 
+        long pos = RubyNumeric.num2long(args[0]);
+
         if (argc == 1) return this;
 
         unpack();
-
-        long pos = RubyNumeric.num2long(args[0]);
 
         if (pos == -1) pos = realLength;
         if (pos < 0) pos++;

--- a/spec/ruby/core/array/insert_spec.rb
+++ b/spec/ruby/core/array/insert_spec.rb
@@ -57,6 +57,11 @@ describe "Array#insert" do
     [].insert(-2).should == []
   end
 
+  # https://bugs.ruby-lang.org/issues/13558
+  it "attempts to coerce a lone position argument" do
+    lambda { [].insert(Object.new) }.should raise_error(TypeError)
+  end
+
   it "tries to convert the passed position argument to an Integer using #to_int" do
     obj = mock('2')
     obj.should_receive(:to_int).and_return(2)


### PR DESCRIPTION
This PR addresses #8902 in two ways:

* Always try to coerce the position argument in the varargs path of `Array#insert`, matching behavior changed for https://bugs.ruby-lang.org/issues/13558.
* Also route specific-arity calls one the variable-arity path to their specific-arity forms. This largely eliminates the need for the first change above, but is more consistent with other places we have both specific and variable-arity method bindings.