### PR TITLE
Don't include Object for pathed constant searches

### DIFF
--- a/spec/ruby/core/module/const_defined_spec.rb
+++ b/spec/ruby/core/module/const_defined_spec.rb
@@ -164,4 +164,11 @@ describe "Module#const_defined?" do
     name.should_receive(:to_str).and_return(123)
     -> { ConstantSpecs.const_defined? name }.should raise_error(TypeError)
   end
+
+  it "does not search Object for a scoped constant name" do
+    Object.const_defined?("ConstantSpecs::ModueA::String").should == false
+    Object.const_defined?("ConstantSpecs::ClassA::String").should == false
+    ConstantSpecs.const_defined?("ModuleA::String").should == false
+    ConstantSpecs.const_defined?("ClassA::String").should == false
+  end
 end


### PR DESCRIPTION
The fix here is a little bit form-fitting but largely avoids inheriting constants from Object when doing String-based constant lookups and skips the additional search of Object if we are doing a path search.