### PR TITLE
Don't set callInfo when target does not use kwargs

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
@@ -16,6 +16,7 @@ import org.jruby.RubyNil;
 import org.jruby.RubyStruct;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.internal.runtime.AbstractIRMethod;
 import org.jruby.internal.runtime.methods.AliasMethod;
 import org.jruby.internal.runtime.methods.AttrReaderMethod;
 import org.jruby.internal.runtime.methods.AttrWriterMethod;
@@ -701,7 +702,27 @@ public abstract class InvokeSite extends MutableCallSite {
 
         SmartHandle callInfoWrapper;
         SmartBinder baseBinder = SmartBinder.from(signature.changeReturn(void.class)).permute("context");
-        if (flags == 0) {
+
+        // if target method takes keywords and we are passing them, set callInfo
+        boolean acceptsKeywords = true;
+        DynamicMethod method = entry.method;
+
+        NativeCallMethod nativeMethod;
+        if (method instanceof AbstractIRMethod && ((AbstractIRMethod) method).getRuby2Keywords()) {
+            // Ruby methods with ruby2_keywords don't use formal keywords
+            acceptsKeywords = false;
+        } else if (method instanceof NativeCallMethod && (nativeMethod = (NativeCallMethod) method).getNativeCall() != null) {
+            // native methods accept keywords only if specified
+            DynamicMethod.NativeCall nativeCall = nativeMethod.getNativeCall();
+            JRubyMethod jrubyMethod = nativeCall.getMethod().getAnnotation(JRubyMethod.class);
+            if (jrubyMethod != null) {
+                acceptsKeywords = jrubyMethod.keywords();
+            } else {
+                acceptsKeywords = false;
+            }
+        }
+
+        if (flags == 0 || !acceptsKeywords) {
             callInfoWrapper = baseBinder.invokeStaticQuiet(LOOKUP, ThreadContext.class, "clearCallInfo");
         } else {
             callInfoWrapper = baseBinder.append("flags", flags).invokeStaticQuiet(LOOKUP, IRRuntimeHelpers.class, "setCallInfo");


### PR DESCRIPTION
Native methods that don't accept formal keyword arguments and Ruby methods that are ruby2_keywords will not use callInfo to handle formal keyword arguments. We clear it here so any incoming kwargs flags do not get stuck and interfere with other calls.

Fixes #8782