### PR TITLE
Don't clear callInfo for Ruby methods

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
@@ -832,12 +832,12 @@ public abstract class InvokeSite extends MutableCallSite {
         SmartBinder baseBinder = SmartBinder.from(signature.changeReturn(void.class)).permute("context");
 
         // if target method takes keywords and we are passing them, set callInfo
-        boolean acceptsKeywords = true;
+        boolean acceptsKeywords;
         DynamicMethod method = entry.method;
 
-        if (method instanceof AbstractIRMethod irMethod && irMethod.getRuby2Keywords()) {
-            // Ruby methods with ruby2_keywords don't use formal keywords
-            acceptsKeywords = false;
+        if (method instanceof AbstractIRMethod irMethod) {
+            // Ruby methods handle clearing kwargs flags on their own
+            acceptsKeywords = true;
         } else if (method instanceof NativeCallMethod nativeMethod && nativeMethod.getNativeCall() != null) {
             // native methods accept keywords only if specified
             DynamicMethod.NativeCall nativeCall = nativeMethod.getNativeCall();
@@ -847,6 +847,8 @@ public abstract class InvokeSite extends MutableCallSite {
             } else {
                 acceptsKeywords = false;
             }
+        } else {
+            acceptsKeywords = true;
         }
 
         if (flags == 0 || !acceptsKeywords) {

--- a/spec/ruby/core/module/ruby2_keywords_spec.rb
+++ b/spec/ruby/core/module/ruby2_keywords_spec.rb
@@ -232,4 +232,29 @@ describe "Module#ruby2_keywords" do
       end
     }.should complain(/Skipping set of ruby2_keywords flag for/)
   end
+
+  describe "used on a method that forwards rest arguments" do
+    it "properly forwards to a keyword arguments-receiving method" do
+      obj = Class.new do
+        def foo(*a, **b)
+          [a, b]
+        end
+
+        ruby2_keywords def bar(*d)
+          foo(*d)
+        end
+
+        def test(...)
+          bar(...)
+        end
+      end.new
+
+      # Use test forwarding method to ensure bar call site is used repeatedly
+      # See https://github.com/jruby/jruby/issues/8920#issuecomment-3097667358
+      obj.test().should == [[], {}]
+      obj.test(e: 3).should == [[], {e: 3}]
+      obj.test(1).should == [[1], {}]
+      obj.test(1, e: 3).should == [[1], {e: 3}]
+    end
+  end
 end

--- a/spec/tags/ruby/core/module/ruby2_keywords_tags.txt
+++ b/spec/tags/ruby/core/module/ruby2_keywords_tags.txt
@@ -1,2 +1,1 @@
 fails:Module#ruby2_keywords does NOT copy the Hash when calling a method taking (*args)
-fails(JIT mode only):Module#ruby2_keywords makes a copy and unmark the Hash when calling a method taking (arg)


### PR DESCRIPTION
In https://github.com/jruby/jruby/issues/8918 we attempted to fix an issue where the keyword arguments `callInfo` flags were getting stuck passing through a native method that did not formally accept keyword arguments. Unfortunately that change incorrectly included Ruby-based `ruby2_keywords` methods in the set of methods considered to not accept formal keywords and require `callInfo` clearing. This led to #8920 where a `ruby2_keywords` method fails to properly forward incoming keyword arguments to a non-`ruby2_keywords` method.

The fix here narrows the `callInfo` clearing to only native methods that do not formally accept keywords, preventing such flags from propagating to other calls but avoiding the `callInfo` clearing previously done for `ruby2_keywords` Ruby-based methods.