### PR TITLE
Better: add asdf support

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -446,6 +446,16 @@ if [ -z "${JAVACMD-}" ]; then
             # use java_home command when none is set (on MacOS)
             JAVA_HOME="$("$java_home_command")" &&
             JAVACMD="$JAVA_HOME"/bin/java
+        elif command -v asdf >/dev/null; then
+            # use asdf to find java executable
+            JAVACMD="$(asdf which java)" &&
+            resolve "$JAVACMD" &&
+            JAVACMD="$REPLY"
+            if [ -z "${JAVA_HOME-}" ]; then
+                # If JAVA_HOME is not set, use the directory of the java executable
+                dir_name "$JAVACMD"
+                JAVA_HOME="$REPLY"
+            fi
         else
             # Linux and others have a chain of symlinks
             JAVACMD="$(command -v java)" &&


### PR DESCRIPTION
Hello,

Little PR to add asdf support. Asdf has its java command in `/home/ylecuyer/.asdf/shims/java` but the real jdk is in `/home/ylecuyer/.asdf/installs/java/openjdk-17/bin/java` so doing `java_command/../../` to get the jdk doesn't work

Instead it uses `asdf which java` which points to the correct path

See repro with this Dockerfile

```Dockerfile
FROM debian:12

RUN apt-get update && apt-get install -y wget git curl build-essential libssl-dev libreadline-dev zlib1g-dev vim

RUN mkdir -p ~/.bin
RUN wget https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz \
    && tar -xzf asdf-v0.18.0-linux-amd64.tar.gz -C ~/.bin \
    && rm asdf-v0.18.0-linux-amd64.tar.gz

# Set environment variables for asdf
ENV PATH="/root/.bin/:/root/.asdf/shims/:${PATH}"

# Install asdf java plugin
RUN asdf plugin add java https://github.com/halcyon/asdf-java.git

# Install java 21
RUN asdf install java openjdk-21

# Install asdf ruby plugin
RUN asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git

ENV ASDF_JAVA_VERSION=openjdk-21

COPY asdf.patch /root/asdf.patch

# PATCH
# ENV RUBY_APPLY_PATCHES=/root/asdf.patch

# Install jruby 10.0.0.1
RUN ASDF_RUBY_BUILD_VERSION=master asdf install ruby jruby-10.0.1.0

RUN ASDF_RUBY_VERSION=jruby-10.0.1.0 jruby -v
```

Without the patch:

```
 > [ 9/10] RUN ASDF_RUBY_BUILD_VERSION=master asdf install ruby jruby-10.0.1.0:                                                                                                                                                                                                           
0.327 Downloading ruby-build...                                                                                                                                                                                                                                                           
1.590 ==> Downloading jruby-dist-10.0.1.0-bin.tar.gz...                                                                                                                                                                                                                                   
2.680 -> curl -q -fL -o jruby-10.0.1.0.tar.gz https://dqw8nmjcqpjn7.cloudfront.net/22174ed408aa19340fc3c609b67f5a83374539ecc50053153d60f6e1f81faa9d                                                                                                                                       
2.689   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                                                                                                                                                     
2.689                                  Dload  Upload   Total   Spent    Left  Speed
100 32.2M  100 32.2M    0     0  77.9M      0 --:--:-- --:--:-- --:--:-- 77.8M
3.611 ==> Installing jruby-10.0.1.0...
3.707 -> ./ruby gem install jruby-launcher --no-document
7.446 
7.446 BUILD FAILED (Debian GNU/Linux 12 on x86_64 using ruby-build 20250724)
7.448 
7.449 You can inspect the build directory at /tmp/ruby-build.20250724122319.73.WxkErp
7.450 See the full build log at /tmp/ruby-build.20250724122319.73.log
7.484 error installing version: failed to run install callback: exit status 1
------
Dockerfile:30
--------------------
  28 |     
  29 |     # Install jruby 10.0.0.1
  30 | >>> RUN ASDF_RUBY_BUILD_VERSION=master asdf install ruby jruby-10.0.1.0
  31 |     
  32 |     RUN ASDF_RUBY_VERSION=jruby-10.0.1.0 jruby -v
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c ASDF_RUBY_BUILD_VERSION=master asdf install ruby jruby-10.0.1.0" did not complete successfully: exit code: 1
```

With the patch:

```
 => [ 9/10] RUN ASDF_RUBY_BUILD_VERSION=master asdf install ruby jruby-10.0.1.0                                                                                                                                                                                                      9.8s
 => [10/10] RUN ASDF_RUBY_VERSION=jruby-10.0.1.0 jruby -v
```