### PR TITLE
Fix integer overflow in buffer length calculation for unpack('m') and unpack('u')

### DIFF
--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -75,7 +75,7 @@ public class Pack {
      **/
     private static final String NATIVE_CODES = "sSiIlLjJ";
     private static final String MAPPED_CODES = "sSiIqQjJ";
-    
+
     private static final char BE = '>' + 127; // 189, bumped up to avoid collisions with LE
     private static final char LE = '<'; // 60
     private static final String ENDIANESS_CODES = new String(new char[] {
@@ -156,7 +156,7 @@ public class Pack {
             @Override
             public void encode(ThreadContext context, IRubyObject o, ByteList result) {
                 var value = obj2flt(context, o);
-                if (Platform.BYTE_ORDER == Platform.BIG_ENDIAN) {                
+                if (Platform.BYTE_ORDER == Platform.BIG_ENDIAN) {
                     encodeFloatBigEndian(result, value);
                 } else {
                     encodeFloatLittleEndian(result, value);
@@ -175,7 +175,7 @@ public class Pack {
             @Override
             public void encode(ThreadContext context, IRubyObject o, ByteList result){
                 encodeDoubleLittleEndian(result, obj2dbl(context, o));
-            }               
+            }
         };
         // double precision, big-endian
         converters['G'] = new Converter(8) {
@@ -212,7 +212,7 @@ public class Pack {
             @Override
             public void encode(ThreadContext context, IRubyObject o, ByteList result){
                 encodeShortLittleEndian(result, overflowQuad(num2quad(context, o)));
-            }            
+            }
         };
         converters['v'] = tmp;
         converters['S' + LE] = tmp;
@@ -305,7 +305,7 @@ public class Pack {
             public IRubyObject decode(ThreadContext context, ByteBuffer enc) {
                 return asFixnum(context, decodeIntUnsignedLittleEndian(enc));
             }
-            
+
             public void encode(ThreadContext context, IRubyObject o, ByteList result){
                 encodeIntLittleEndian(result, (int) toLong(context, o));
             }
@@ -320,7 +320,7 @@ public class Pack {
             public IRubyObject decode(ThreadContext context, ByteBuffer enc) {
                 return asFixnum(context, decodeIntUnsignedBigEndian(enc));
             }
-            
+
             public void encode(ThreadContext context, IRubyObject o, ByteList result){
                 encodeIntBigEndian(result, (int) toLong(context, o));
             }
@@ -638,7 +638,7 @@ public class Pack {
      *       Note that if passed a block, this method will return null and instead yield results to the block.
      *       The directives <code>sSiIlL</code> may each be followed by an underscore (``<code>_</code>'') to use the underlying platform's native size for the specified type; otherwise, it uses a platform-independent consistent size.  <br>
      *       Spaces are ignored in the format string.
-     * 
+     *
      *       <table border="1"><caption style="display:none">layout table</caption>
      *           <tr>
      *             <td>
@@ -889,7 +889,7 @@ public class Pack {
         if (length % 4 != 0) throw argumentError(context, "invalid base64");
 
         int p = begin;
-        byte[] out = new byte[3 * ((length + 3) / 4)];
+        byte[] out = new byte[unpackUMMaxOutputBytes(length)];
 
         while (p < end && s != '=') {
             // obtain a
@@ -935,7 +935,7 @@ public class Pack {
                 out[index++] = (byte)((b << 4 | c >> 2) & 255);
             }
         }
-        return newString(context, new ByteList(out, 0, index));
+        return newString(context, new ByteList(out, 0, index, false));
     }
 
     public static IRubyObject unpack1WithBlock(ThreadContext context, RubyString encoded, ByteList formatString, Block block) {
@@ -1000,10 +1000,10 @@ public class Pack {
                     throw argumentError(context, "'" + next + "' allowed only after types " + NATIVE_CODES);
                 }
                 type = MAPPED_CODES.charAt(index);
-                
+
                 next = getDirective(context, "unpack", formatString, format);
             }
-            
+
             if (next == '>' || next == '<') {
                 next = next == '>' ? BE : LE;
                 int index = ENDIANESS_CODES.indexOf(type + next);
@@ -1012,7 +1012,7 @@ public class Pack {
                 }
                 type = ENDIANESS_CODES.charAt(index);
                 next = getDirective(context, "unpack", formatString, format);
-                
+
                 if (next == '_' || next == '!') next = getDirective(context, "unpack", formatString, format);
             }
 
@@ -1256,7 +1256,7 @@ public class Pack {
     }
 
     private static IRubyObject unpack_m(ThreadContext context, Block block, RubyArray result, ByteBuffer encode, int occurrences, int mode) {
-        int length = encode.remaining()*3/4;
+        int length = unpackUMMaxOutputBytes(encode.remaining());
         byte[] lElem = new byte[length];
         int a = -1, b = -1, c = 0, d;
         int index = 0;
@@ -1390,7 +1390,7 @@ public class Pack {
     }
 
     private static IRubyObject unpack_u(ThreadContext context, Block block, RubyArray result, ByteBuffer encode, int mode) {
-        int length = encode.remaining() * 3 / 4;
+        int length = unpackUMMaxOutputBytes(encode.remaining());
         byte[] lElem = new byte[length];
         int index = 0;
         int s = 0;
@@ -1453,6 +1453,10 @@ public class Pack {
             }
         }
         return appendOrYield(context, block, result, new ByteList(lElem, 0, index, ASCII, false), mode);
+    }
+
+    private static int unpackUMMaxOutputBytes(int length) {
+        return (int)((long)length * 3 / 4);  // If we don't cast to long here, the multiplication can overflow!
     }
 
     private static IRubyObject unpack_H(ThreadContext context, Block block, RubyArray result, ByteBuffer encode, int occurrences, int mode) {
@@ -1681,7 +1685,7 @@ public class Pack {
         if ((c & 0x40) == 0) {
             throw new IllegalArgumentException("malformed UTF-8 character");
         }
-        
+
       if      ((uv & 0x20) == 0) { n = 2; uv &= 0x1f; }
       else if ((uv & 0x10) == 0) { n = 3; uv &= 0x0f; }
       else if ((uv & 0x08) == 0) { n = 4; uv &= 0x07; }
@@ -1733,10 +1737,10 @@ public class Pack {
     public static int safeGet(ByteBuffer encode) {
         while (encode.hasRemaining()) {
             int got = encode.get() & 0xff;
-            
+
             if (got != 0) return got;
         }
-        
+
         return 0;
     }
 
@@ -1826,12 +1830,12 @@ public class Pack {
         public Converter(int size) {
             this(size, null);
         }
-        
+
         public Converter(int size, String type) {
             this.size = size;
             this.type = type;
         }
-        
+
         public String getType() {
             return type;
         }
@@ -1844,7 +1848,7 @@ public class Pack {
         public QuadConverter(int size, String type) {
             super(size, type);
         }
-        
+
         public QuadConverter(int size) {
             super(size);
         }
@@ -1963,7 +1967,7 @@ public class Pack {
 
                 next = getDirective(context, "pack", formatString, format);
             }
-            
+
             if (next == '>' || next == '<') {
                 next = next == '>' ? BE : LE;
                 int index = ENDIANESS_CODES.indexOf(type + next);

--- a/spec/ruby/core/string/unpack/m_spec.rb
+++ b/spec/ruby/core/string/unpack/m_spec.rb
@@ -180,6 +180,14 @@ describe "String#unpack with format 'm'" do
     "dGV%zdA==".unpack("m").should == ["test"]
   end
 
+  it "correctly decodes inputs longer than 2^31 / 3 characters" do
+    ("X" * (2 ** 31 / 3 + 98)).unpack("m").first.length.should == 536870985
+  end
+
+  it "correctly decodes inputs longer than 2^32 / 3 characters" do
+    ("X" * (2 ** 32 / 3 + 99)).unpack("m").first.length.should == 1073741898
+  end
+
   describe "when given count 0" do
     it "decodes base64" do
       "dGVzdA==".unpack("m0").should == ["test"]
@@ -187,6 +195,14 @@ describe "String#unpack with format 'm'" do
 
     it "raises an ArgumentError for an invalid base64 character" do
       -> { "dGV%zdA==".unpack("m0") }.should raise_error(ArgumentError)
+    end
+
+    it "correctly decodes inputs longer than 2^31 / 3 characters" do
+      ("X" * (2 ** 31 / 3 + 98)).unpack("m0").first.length.should == 536870985
+    end
+
+    it "correctly decodes inputs longer than 2^32 / 3 characters" do
+      ("X" * (2 ** 32 / 3 + 99)).unpack("m0").first.length.should == 1073741898
     end
   end
 end

--- a/spec/ruby/core/string/unpack/m_spec.rb
+++ b/spec/ruby/core/string/unpack/m_spec.rb
@@ -109,6 +109,26 @@ describe "String#unpack with format 'm'" do
   it_behaves_like :string_unpack_no_platform, 'm'
   it_behaves_like :string_unpack_taint, 'm'
 
+  it "decodes base64" do
+    "dA==".unpack("m").should == ["t"]
+    "dGU=".unpack("m").should == ["te"]
+    "dGVz".unpack("m").should == ["tes"]
+    "dGVzdA==".unpack("m").should == ["test"]
+    "dGVzdHQ=".unpack("m").should == ["testt"]
+    "dGVzdHRl".unpack("m").should == ["testte"]
+    "dGVzdHRlcw==".unpack("m").should == ["testtes"]
+    "dGVzdHRlc3Q=".unpack("m").should == ["testtest"]
+  end
+
+  it "decodes base64 without padding" do
+    "dA".unpack("m").should == ["t"]
+    "dGU".unpack("m").should == ["te"]
+    "dGVzdA".unpack("m").should == ["test"]
+    "dGVzdHQ".unpack("m").should == ["testt"]
+    "dGVzdHRlcw".unpack("m").should == ["testtes"]
+    "dGVzdHRlc3Q".unpack("m").should == ["testtest"]
+  end
+
   it "decodes an empty string" do
     "".unpack("m").should == [""]
   end
@@ -189,8 +209,74 @@ describe "String#unpack with format 'm'" do
   end
 
   describe "when given count 0" do
+    # The implementations of unpack("m") and unpack("m0") are mostly separate, so they deserve to be tested separately.
+
     it "decodes base64" do
+      "dA==".unpack("m0").should == ["t"]
+      "dGU=".unpack("m0").should == ["te"]
+      "dGVz".unpack("m0").should == ["tes"]
       "dGVzdA==".unpack("m0").should == ["test"]
+      "dGVzdHQ=".unpack("m0").should == ["testt"]
+      "dGVzdHRl".unpack("m0").should == ["testte"]
+      "dGVzdHRlcw==".unpack("m0").should == ["testtes"]
+      "dGVzdHRlc3Q=".unpack("m0").should == ["testtest"]
+    end
+
+    it "decodes an empty string" do
+      "".unpack("m0").should == [""]
+    end
+
+    it "appends empty string to the array for directives exceeding the input size" do
+      "YWJjREVG".unpack("m0m0m0").should == ["abcDEF", "", ""]
+    end
+
+    it "decodes all pre-encoded ascii byte values" do
+      [ ["AAECAwQFBg==",                          ["\x00\x01\x02\x03\x04\x05\x06"]],
+        ["BwgJCgsMDQ==",                          ["\a\b\t\n\v\f\r"]],
+        ["Dg8QERITFBUW",                          ["\x0E\x0F\x10\x11\x12\x13\x14\x15\x16"]],
+        ["FxgZGhscHR4f",                          ["\x17\x18\x19\x1a\e\x1c\x1d\x1e\x1f"]],
+        ["ISIjJCUmJygpKissLS4v",                  ["!\"\#$%&'()*+,-./"]],
+        ["MDEyMzQ1Njc4OQ==",                      ["0123456789"]],
+        ["Ojs8PT4/QA==",                          [":;<=>?@"]],
+        ["QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=",  ["ABCDEFGHIJKLMNOPQRSTUVWXYZ"]],
+        ["W1xdXl9g",                              ["[\\]^_`"]],
+        ["YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=",  ["abcdefghijklmnopqrstuvwxyz"]],
+        ["e3x9fg==",                              ["{|}~"]],
+        ["f8KAwoHCgsKD",                          ["\x7f\xc2\x80\xc2\x81\xc2\x82\xc2\x83"]],
+        ["woTChcKGwofC",                          ["\xc2\x84\xc2\x85\xc2\x86\xc2\x87\xc2"]],
+        ["iMKJworCi8KM",                          ["\x88\xc2\x89\xc2\x8a\xc2\x8b\xc2\x8c"]],
+        ["wo3CjsKPwpDC",                          ["\xc2\x8d\xc2\x8e\xc2\x8f\xc2\x90\xc2"]],
+        ["kcKSwpPClMKV",                          ["\x91\xc2\x92\xc2\x93\xc2\x94\xc2\x95"]],
+        ["wpbCl8KYwpnC",                          ["\xc2\x96\xc2\x97\xc2\x98\xc2\x99\xc2"]],
+        ["msKbwpzCncKe",                          ["\x9a\xc2\x9b\xc2\x9c\xc2\x9d\xc2\x9e"]],
+        ["wp/CoMKhwqLC",                          ["\xc2\x9f\xc2\xa0\xc2\xa1\xc2\xa2\xc2"]],
+        ["o8KkwqXCpsKn",                          ["\xa3\xc2\xa4\xc2\xa5\xc2\xa6\xc2\xa7"]],
+        ["wqjCqcKqwqvC",                          ["\xc2\xa8\xc2\xa9\xc2\xaa\xc2\xab\xc2"]],
+        ["rMKtwq7Cr8Kw",                          ["\xac\xc2\xad\xc2\xae\xc2\xaf\xc2\xb0"]],
+        ["wrHCssKzwrTC",                          ["\xc2\xb1\xc2\xb2\xc2\xb3\xc2\xb4\xc2"]],
+        ["tcK2wrfCuMK5",                          ["\xb5\xc2\xb6\xc2\xb7\xc2\xb8\xc2\xb9"]],
+        ["wrrCu8K8wr3C",                          ["\xc2\xba\xc2\xbb\xc2\xbc\xc2\xbd\xc2"]],
+        ["vsK/w4DDgcOC",                          ["\xbe\xc2\xbf\xc3\x80\xc3\x81\xc3\x82"]],
+        ["w4PDhMOFw4bD",                          ["\xc3\x83\xc3\x84\xc3\x85\xc3\x86\xc3"]],
+        ["h8OIw4nDisOL",                          ["\x87\xc3\x88\xc3\x89\xc3\x8a\xc3\x8b"]],
+        ["w4zDjcOOw4/D",                          ["\xc3\x8c\xc3\x8d\xc3\x8e\xc3\x8f\xc3"]],
+        ["kMORw5LDk8OU",                          ["\x90\xc3\x91\xc3\x92\xc3\x93\xc3\x94"]],
+        ["w5XDlsOXw5jD",                          ["\xc3\x95\xc3\x96\xc3\x97\xc3\x98\xc3"]],
+        ["mcOaw5vDnMOd",                          ["\x99\xc3\x9a\xc3\x9b\xc3\x9c\xc3\x9d"]],
+        ["w57Dn8Ogw6HD",                          ["\xc3\x9e\xc3\x9f\xc3\xa0\xc3\xa1\xc3"]],
+        ["osOjw6TDpcOm",                          ["\xa2\xc3\xa3\xc3\xa4\xc3\xa5\xc3\xa6"]],
+        ["w6fDqMOpw6rD",                          ["\xc3\xa7\xc3\xa8\xc3\xa9\xc3\xaa\xc3"]],
+        ["q8Osw63DrsOv",                          ["\xab\xc3\xac\xc3\xad\xc3\xae\xc3\xaf"]],
+        ["w7DDscOyw7PD",                          ["\xc3\xb0\xc3\xb1\xc3\xb2\xc3\xb3\xc3"]],
+        ["tMO1w7bDt8O4",                          ["\xb4\xc3\xb5\xc3\xb6\xc3\xb7\xc3\xb8"]],
+        ["w7nDusO7w7zD",                          ["\xc3\xb9\xc3\xba\xc3\xbb\xc3\xbc\xc3"]],
+        ["vcO+w78=",                              ["\xbd\xc3\xbe\xc3\xbf"]]
+      ].should be_computed_by(:unpack, "m0")
+    end
+
+    it "produces binary strings" do
+      "".unpack("m0").first.encoding.should == Encoding::BINARY
+      "Ojs8PT4/QA==".unpack("m0").first.encoding.should == Encoding::BINARY
     end
 
     it "raises an ArgumentError for an invalid base64 character" do

--- a/spec/ruby/core/string/unpack/u_spec.rb
+++ b/spec/ruby/core/string/unpack/u_spec.rb
@@ -94,4 +94,16 @@ describe "String#unpack with format 'u'" do
       ["%O<.^P[\\`\n",              ["\xbd\xc3\xbe\xc3\xbf"]]
     ].should be_computed_by(:unpack, "u")
   end
+
+  it "correctly decodes inputs longer than 2^31 / 3 characters" do
+    line = "M" + ("X" * 60) + "\n"
+    count = (2**31 / 3) / line.length + 1
+    (line * count).unpack("u").first.length.should == 45 * count
+  end
+
+  it "correctly decodes inputs longer than 2^32 / 3 characters" do
+    line = "M" + ("X" * 60) + "\n"
+    count = (2**32 / 3) / line.length + 1
+    (line * count).unpack("u").first.length.should == 45 * count
+  end
 end

--- a/spec/ruby/core/string/unpack1_spec.rb
+++ b/spec/ruby/core/string/unpack1_spec.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 require_relative '../../spec_helper'
 
 describe "String#unpack1" do
@@ -37,7 +38,67 @@ describe "String#unpack1" do
     # which is why we repeat the tests for unpack("m0") here.
 
     it "decodes base64" do
+      "dA==".unpack1("m0").should == "t"
+      "dGU=".unpack1("m0").should == "te"
+      "dGVz".unpack1("m0").should == "tes"
       "dGVzdA==".unpack1("m0").should == "test"
+      "dGVzdHQ=".unpack1("m0").should == "testt"
+      "dGVzdHRl".unpack1("m0").should == "testte"
+      "dGVzdHRlcw==".unpack1("m0").should == "testtes"
+      "dGVzdHRlc3Q=".unpack1("m0").should == "testtest"
+    end
+
+    it "decodes an empty string" do
+      "".unpack1("m0").should == ""
+    end
+
+    it "decodes all pre-encoded ascii byte values" do
+      [ ["AAECAwQFBg==",                          "\x00\x01\x02\x03\x04\x05\x06"],
+        ["BwgJCgsMDQ==",                          "\a\b\t\n\v\f\r"],
+        ["Dg8QERITFBUW",                          "\x0E\x0F\x10\x11\x12\x13\x14\x15\x16"],
+        ["FxgZGhscHR4f",                          "\x17\x18\x19\x1a\e\x1c\x1d\x1e\x1f"],
+        ["ISIjJCUmJygpKissLS4v",                  "!\"\#$%&'()*+,-./"],
+        ["MDEyMzQ1Njc4OQ==",                      "0123456789"],
+        ["Ojs8PT4/QA==",                          ":;<=>?@"],
+        ["QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=",  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"],
+        ["W1xdXl9g",                              "[\\]^_`"],
+        ["YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=",  "abcdefghijklmnopqrstuvwxyz"],
+        ["e3x9fg==",                              "{|}~"],
+        ["f8KAwoHCgsKD",                          "\x7f\xc2\x80\xc2\x81\xc2\x82\xc2\x83"],
+        ["woTChcKGwofC",                          "\xc2\x84\xc2\x85\xc2\x86\xc2\x87\xc2"],
+        ["iMKJworCi8KM",                          "\x88\xc2\x89\xc2\x8a\xc2\x8b\xc2\x8c"],
+        ["wo3CjsKPwpDC",                          "\xc2\x8d\xc2\x8e\xc2\x8f\xc2\x90\xc2"],
+        ["kcKSwpPClMKV",                          "\x91\xc2\x92\xc2\x93\xc2\x94\xc2\x95"],
+        ["wpbCl8KYwpnC",                          "\xc2\x96\xc2\x97\xc2\x98\xc2\x99\xc2"],
+        ["msKbwpzCncKe",                          "\x9a\xc2\x9b\xc2\x9c\xc2\x9d\xc2\x9e"],
+        ["wp/CoMKhwqLC",                          "\xc2\x9f\xc2\xa0\xc2\xa1\xc2\xa2\xc2"],
+        ["o8KkwqXCpsKn",                          "\xa3\xc2\xa4\xc2\xa5\xc2\xa6\xc2\xa7"],
+        ["wqjCqcKqwqvC",                          "\xc2\xa8\xc2\xa9\xc2\xaa\xc2\xab\xc2"],
+        ["rMKtwq7Cr8Kw",                          "\xac\xc2\xad\xc2\xae\xc2\xaf\xc2\xb0"],
+        ["wrHCssKzwrTC",                          "\xc2\xb1\xc2\xb2\xc2\xb3\xc2\xb4\xc2"],
+        ["tcK2wrfCuMK5",                          "\xb5\xc2\xb6\xc2\xb7\xc2\xb8\xc2\xb9"],
+        ["wrrCu8K8wr3C",                          "\xc2\xba\xc2\xbb\xc2\xbc\xc2\xbd\xc2"],
+        ["vsK/w4DDgcOC",                          "\xbe\xc2\xbf\xc3\x80\xc3\x81\xc3\x82"],
+        ["w4PDhMOFw4bD",                          "\xc3\x83\xc3\x84\xc3\x85\xc3\x86\xc3"],
+        ["h8OIw4nDisOL",                          "\x87\xc3\x88\xc3\x89\xc3\x8a\xc3\x8b"],
+        ["w4zDjcOOw4/D",                          "\xc3\x8c\xc3\x8d\xc3\x8e\xc3\x8f\xc3"],
+        ["kMORw5LDk8OU",                          "\x90\xc3\x91\xc3\x92\xc3\x93\xc3\x94"],
+        ["w5XDlsOXw5jD",                          "\xc3\x95\xc3\x96\xc3\x97\xc3\x98\xc3"],
+        ["mcOaw5vDnMOd",                          "\x99\xc3\x9a\xc3\x9b\xc3\x9c\xc3\x9d"],
+        ["w57Dn8Ogw6HD",                          "\xc3\x9e\xc3\x9f\xc3\xa0\xc3\xa1\xc3"],
+        ["osOjw6TDpcOm",                          "\xa2\xc3\xa3\xc3\xa4\xc3\xa5\xc3\xa6"],
+        ["w6fDqMOpw6rD",                          "\xc3\xa7\xc3\xa8\xc3\xa9\xc3\xaa\xc3"],
+        ["q8Osw63DrsOv",                          "\xab\xc3\xac\xc3\xad\xc3\xae\xc3\xaf"],
+        ["w7DDscOyw7PD",                          "\xc3\xb0\xc3\xb1\xc3\xb2\xc3\xb3\xc3"],
+        ["tMO1w7bDt8O4",                          "\xb4\xc3\xb5\xc3\xb6\xc3\xb7\xc3\xb8"],
+        ["w7nDusO7w7zD",                          "\xc3\xb9\xc3\xba\xc3\xbb\xc3\xbc\xc3"],
+        ["vcO+w78=",                              "\xbd\xc3\xbe\xc3\xbf"]
+      ].should be_computed_by(:unpack1, "m0")
+    end
+
+    it "produces binary strings" do
+      "".unpack1("m0").encoding.should == Encoding::BINARY
+      "Ojs8PT4/QA==".unpack1("m0").encoding.should == Encoding::BINARY
     end
 
     it "raises an ArgumentError for an invalid base64 character" do

--- a/spec/ruby/core/string/unpack1_spec.rb
+++ b/spec/ruby/core/string/unpack1_spec.rb
@@ -31,4 +31,25 @@ describe "String#unpack1" do
   it "raises an ArgumentError when the offset is larger than the string bytesize" do
     -> { "a".unpack1("C", offset: 2) }.should raise_error(ArgumentError, "offset outside of string")
   end
+
+  context "with format 'm0'" do
+    # unpack1("m0") takes a special code path that calls Pack.unpackBase46Strict instead of Pack.unpack_m,
+    # which is why we repeat the tests for unpack("m0") here.
+
+    it "decodes base64" do
+      "dGVzdA==".unpack1("m0").should == "test"
+    end
+
+    it "raises an ArgumentError for an invalid base64 character" do
+      -> { "dGV%zdA==".unpack1("m0") }.should raise_error(ArgumentError)
+    end
+
+    it "correctly decodes inputs longer than 2^31 / 3 characters" do
+      ("X" * (2 ** 31 / 3 + 98)).unpack1("m0").length.should == 536870985
+    end
+
+    it "correctly decodes inputs longer than 2^32 / 3 characters" do
+      ("X" * (2 ** 32 / 3 + 99)).unpack1("m0").length.should == 1073741898
+    end
+  end
 end


### PR DESCRIPTION
This fixes https://github.com/jruby/jruby/issues/8933