### PR TITLE
Verify to_s is string or fall back on anyToString

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -30,6 +30,7 @@ package org.jruby;
 
 import org.jcodings.Encoding;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.api.Create;
 import org.jruby.api.JRubyAPI;
 import org.jruby.ast.util.ArgsUtil;
@@ -680,7 +681,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *
      * First converts this object into a String using the "to_s"
      * method and returns it. If
-     * to_s doesn't return a Ruby String, {@link #anyToString} is used
+     * to_s doesn't return a Ruby String, {@link Convert#anyToString} is used
      * instead.
      */
     @Override
@@ -690,7 +691,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         BasicObjectSites sites = sites(context);
         IRubyObject str = sites.to_s.call(context, this, this);
 
-        if (!(str instanceof RubyString)) return (RubyString) anyToString();
+        if (!(str instanceof RubyString)) return Convert.anyToString(context, this);
         return (RubyString) str;
     }
 
@@ -789,20 +790,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     @Override
     public IRubyObject anyToString() {
         Ruby runtime = metaClass.runtime;
-
-        /* 6:tags 16:addr 1:eos */
-        String hex = Integer.toHexString(System.identityHashCode(this));
-        ByteList className = metaClass.getRealClass().toRubyString(runtime.getCurrentContext()).getByteList();
-        ByteList bytes = new ByteList(2 + className.realSize() + 3 + hex.length() + 1);
-        bytes.setEncoding(className.getEncoding());
-        bytes.append('#').append('<');
-        bytes.append(className);
-        bytes.append(':').append('0').append('x');
-        bytes.append(hex.getBytes());
-        bytes.append('>');
-
-        RubyString str = RubyString.newString(runtime, bytes);
-        return str;
+        return Convert.anyToString(runtime.getCurrentContext(), this);
     }
 
     /**
@@ -2646,7 +2634,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *  initial execution context of Ruby programs returns ``main.''
      */
     public IRubyObject to_s(ThreadContext context) {
-    	return anyToString();
+    	return Convert.anyToString(context, this);
     }
 
     /* rb_any_to_a

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -43,6 +43,7 @@ import org.joni.exception.JOniException;
 import org.joni.exception.ValueException;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.api.Create;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.runtime.Arity;
@@ -419,7 +420,7 @@ public class RubyMatchData extends RubyObject {
     @JRubyMethod
     @Override
     public RubyString inspect(ThreadContext context) {
-        if (str == null) return (RubyString) anyToString();
+        if (str == null) return (RubyString) Convert.anyToString(context, this);
 
         RubyString result = newString(context, "#<");
         result.append(getMetaClass().getRealClass().to_s(context));

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -71,6 +71,7 @@ import org.jruby.anno.JRubyConstant;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JavaMethodDescriptor;
 import org.jruby.anno.TypePopulator;
+import org.jruby.api.Convert;
 import org.jruby.api.JRubyAPI;
 import org.jruby.api.Warn;
 import org.jruby.common.IRubyWarnings.ID;
@@ -3241,7 +3242,7 @@ public class RubyModule extends RubyObject {
             if (attached instanceof RubyModule) {
                 buffer.catWithCodeRange(attached.inspect(context).convertToString());
             } else if (attached != null) {
-                buffer.catWithCodeRange((RubyString) attached.anyToString());
+                buffer.catWithCodeRange((RubyString) Convert.anyToString(context, attached));
             }
             buffer.cat('>', buffer.getEncoding());
 

--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -162,7 +162,7 @@ public class RubyNameError extends RubyStandardError {
                             if (object == runtime.getTopSelf()) {
                                 className = RubyString.newString(runtime, "main");
                             } else {
-                                className = (RubyString) object.anyToString();
+                                className = (RubyString) Convert.anyToString(context, object);
                             }
                             // we have our string, break out to final composition
                             break;
@@ -189,7 +189,7 @@ public class RubyNameError extends RubyStandardError {
             if (tmp == UNDEF || tmp.isNil()) tmp = tryInspect(context, object);
             if (tmp == UNDEF) context.clearErrorInfo();
             tmp = TypeConverter.checkStringType(context.runtime, tmp);
-            if (tmp.isNil()) tmp = object.anyToString();
+            if (tmp.isNil()) tmp = Convert.anyToString(context, object);
             return (RubyString) tmp;
         }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -59,6 +59,7 @@ import org.joni.Regex;
 import org.joni.Region;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.api.Create;
 import org.jruby.api.JRubyAPI;
 import org.jruby.ast.util.ArgsUtil;
@@ -1609,7 +1610,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     public static RubyString objAsString(ThreadContext context, IRubyObject obj) {
         if (obj instanceof RubyString str) return str;
         IRubyObject str = sites(context).to_s.call(context, obj, obj);
-        if (!(str instanceof RubyString)) return (RubyString) obj.anyToString();
+        if (!(str instanceof RubyString)) return (RubyString) Convert.anyToString(context, obj);
         // TODO: MRI sets an fstring flag on fstrings and uses that flag here
         return (RubyString) str;
     }

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -1,5 +1,6 @@
 package org.jruby.api;
 
+import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBignum;
 import org.jruby.RubyBoolean;
@@ -635,5 +636,27 @@ public class Convert {
      */
     public static RubySymbol toSymbol(ThreadContext context, IRubyObject arg) {
         return RubySymbol.toSymbol(context, arg);
+    }
+
+    /**
+     * Produce a string from a given object using its type identity.
+     *
+     * Equivalent to RubyBasicObject#anyToString but without re-acquiring context.
+     *
+     * @return The object represented as a hashy type string.
+     */
+    public static RubyString anyToString(ThreadContext context, IRubyObject obj) {
+        /* 6:tags 16:addr 1:eos */
+        String hex = Integer.toHexString(System.identityHashCode(obj));
+        ByteList className = obj.getType().toRubyString(context).getByteList();
+        ByteList bytes = new ByteList(2 + className.realSize() + 3 + hex.length() + 1);
+        bytes.setEncoding(className.getEncoding());
+        bytes.append('#').append('<');
+        bytes.append(className);
+        bytes.append(':').append('0').append('x');
+        bytes.append(hex.getBytes());
+        bytes.append('>');
+
+        return Create.newString(context, bytes);
     }
 }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -28,6 +28,7 @@ import org.jruby.RubyRational;
 import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
+import org.jruby.api.Convert;
 import org.jruby.api.Create;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
@@ -2446,7 +2447,7 @@ public class IRRuntimeHelpers {
     @JIT
     public static RubyString asString(ThreadContext context, IRubyObject caller, IRubyObject target, CallSite site) {
         IRubyObject str = site.call(context, caller, target);
-        return str instanceof RubyString string ? string : (RubyString) target.anyToString();
+        return str instanceof RubyString string ? string : (RubyString) Convert.anyToString(context, target);
     }
 
     @JIT

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1579,6 +1579,9 @@ modes.each do |mode|
     end
 
     it "compiles very long dynamic strings" do
+      run('"a#{$$}a#{$$}a#{$$}a#{$$}"') do
+        expect(it).to eq("a#{$$}" * 4)
+      end
       run('"a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}a#{$$}"') do
         expect(it).to eq("a#{$$}" * 24)
       end

--- a/spec/ruby/language/string_spec.rb
+++ b/spec/ruby/language/string_spec.rb
@@ -134,16 +134,14 @@ describe "Ruby character strings" do
   end
 
   it "uses an internal representation when #to_s doesn't return a String" do
-    obj = mock('to_s')
-    obj.stub!(:to_s).and_return(42)
+    # don't use mocking so we have a predictable string representation below (#<Object...>)
+    obj = Object.new
+    def obj.to_s
+      42
+    end
 
-    # See rubyspec commit 787c132d by yugui. There is value in
-    # ensuring that this behavior works. So rather than removing
-    # this spec completely, the only thing that can be asserted
-    # is that if you interpolate an object that fails to return
-    # a String, you will still get a String and not raise an
-    # exception.
-    "#{obj}".should be_an_instance_of(String)
+    # ensure the interpolation succeeds and the content included does not include the non-string value.
+    "#{obj}".should =~ /#<Object:0x[0-9a-fA-F]+>/
   end
 
   it "allows a dynamic string to parse a nested do...end block as an argument to a call without parens, interpolated" do


### PR DESCRIPTION
Logic for "AsString" in a dynamic string must verify the result of calling to_s is a String, or else use anyToString on the original object. Previous logic here only called to_s and did not verify the result, proceeding to append non-string values like Integer or Float rather than falling back. The patch here adds an additional guard around the to_s call to perform this check and fallback.

This only affects the rare case where someone has implemented a to_s method that does not return a String, and is only observable once the dstring has been optimized and invoked twice.

As this is a bit invasive, I'm marking it for 10.0.3.0 so we can create more specs and do more verification that it works correctly before release.