### PR TITLE
Make closure to method conversion more conservative

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -196,6 +196,7 @@ public class IRClosure extends IRScope {
     public IRMethod convertToMethod(ByteList name) {
         // We want variable scoping to be the same as a method and not see outside itself.
         if (source == null ||
+            isWithinMethod() ||                 // def foo; define_method {}; end has potential to implicitly access parents var yield
             accessesParentsLocalVariables() ||  // Built methods cannot search down past method scope
             receivesClosureArg() ||             // we pass in captured block at define_method as block so explicits ones not supported
             usesZSuper() ||                     // methods defined from closures cannot use zsuper

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -282,6 +282,15 @@ public abstract class IRScope implements ParseResult {
         return false;
     }
 
+    public boolean isWithinMethod() {
+        for (IRScope current = this; current != null; current = current.getLexicalParent()) {
+            if (current instanceof IRModuleBody) return false;
+            if (current instanceof IRMethod) return true;
+        }
+
+        return false;
+    }
+
     // walks up closures
     public IRScope getNearestNonClosurelikeScope() {
         IRScope current = this;


### PR DESCRIPTION
Add a new rule that a define_method closure cannot be converted to a method if it is within a method body.

This prevents implicit yields which want to yield to the outer methods block that was passed in.