### PR TITLE
New check for System.console tty on JDK 22+

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -29,6 +29,8 @@
 
 package org.jruby.util.cli;
 
+import java.io.Console;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,7 +58,28 @@ import static org.jruby.RubyInstanceConfig.CompileMode;
  */
 public class Options {
     private static final List<Option> _loadedOptions = new ArrayList<>(240);
-    private static final boolean COLOR = System.console() != null;
+    private static final boolean COLOR;
+
+    static {
+        boolean isatty;
+        Console console = System.console();
+
+        if (console == null) {
+            isatty = false;
+        } else if (Integer.parseInt(SafePropertyAccessor.getProperty("java.specification.version", "21")) <= 21) {
+            isatty = true;
+        } else {
+            // Java 22 always returns a Console so we have to check for tty with isTerminal()
+            try {
+                isatty = (Boolean) Console.class.getMethod("isTerminal").invoke(console);
+            } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException |
+                     InvocationTargetException e) {
+                isatty = false;
+            }
+        }
+
+        COLOR = isatty;
+    }
 
     public static final String IR_PRINT_PATTERN_NO_PATTERN_STRING = "<NO_PATTERN>";
 

--- a/spec/jruby/options/console_color_spec.rb
+++ b/spec/jruby/options/console_color_spec.rb
@@ -1,0 +1,7 @@
+# https://github.com/jruby/jruby/issues/8934
+describe "org.jruby.util.cli.Options::IR_PRINT_COLOR" do
+  it "should be off for non-terminals" do
+    output = `#{ENV_JAVA["jruby.home"]}/bin/jruby -e "print org.jruby.util.cli.Options::IR_PRINT_COLOR.load.to_s"`
+    output.chomp.should == "false"
+  end
+end


### PR DESCRIPTION
This uses the new `isTerminal` method when running on JDK 22+ due to that version now always returning a non-null `Console` from `System.console()`.

I may modify the handling of these color-configuring properties such that "true" means "use color if we are outputting to a terminal", defaulting to true.

Fixes #8934.