### PR TITLE
Broaden closure to method coercion with included blocks

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2965,6 +2965,7 @@ public class RubyModule extends RubyObject {
                 // Ask closure to give us a method equivalent.
                 IRMethod method = closure.convertToMethod(name.getBytes());
                 if (method != null) {
+                    System.out.println("Converted closure to method: " + method.getName());
                     var newMethod = new DefineMethodMethod(method, visibility, this, context.getFrameBlock());
                     Helpers.addInstanceMethod(this, name, newMethod, visibility, context);
                     return name;


### PR DESCRIPTION
This allows define_method to be converted to a method with nested blocks so long as those nested blocks do not get captures from outside define_method.

As it stands this hurts performance:
https://gist.github.com/enebo/7256fd51d3f0ebb49d433f2bc3e77d02

It appears that something is not optimizing correctly for these converted blocks.  `nested capture def` should be the performance for `nested capture` and for sure should be faster than just invoking `nested capture` with the optimization disabled.