### PR TITLE
Secuity: Bump cgi to 0.4.2. CVE-2025-27220 CVE-2025-27219

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -27,7 +27,7 @@ This will run the default "install" goal (`mvn install`) and will do all of the 
 
 * Compile JRuby
 * Build `lib/jruby.jar`, needed for running at command line
-* It will install the default gems specifications `lib/ruby/gems/shared/specifications/default/` and the ruby files of those gems in `lib/ruby/stdlib/`.
+* It will install the default gems specifications `lib/pom.rb` and the ruby files of those gems in `lib/ruby/stdlib/`.
 
 The environment is now suitable for running Ruby applications.
 

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -20,7 +20,7 @@ default_gems = [
     ['rubygems-update', '3.6.9', { bin: false, require_paths: ['lib'] }],
     ['benchmark', '0.4.0'],
     ['bundler', '2.6.9'],
-    ['cgi', '0.4.1'],
+    ['cgi', '0.4.2'],
     # Currently using a stub gem for JRuby until we can incorporate our code.
     # https://github.com/ruby/date/issues/48
     ['date', '3.4.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -73,7 +73,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>cgi</artifactId>
-      <version>0.4.1</version>
+      <version>0.4.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1121,7 +1121,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/rubygems-update-3.6.9*</include>
           <include>specifications/benchmark-0.4.0*</include>
           <include>specifications/bundler-2.6.9*</include>
-          <include>specifications/cgi-0.4.1*</include>
+          <include>specifications/cgi-0.4.2*</include>
           <include>specifications/date-3.4.1*</include>
           <include>specifications/delegate-0.4.0*</include>
           <include>specifications/did_you_mean-2.0.0*</include>
@@ -1203,7 +1203,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/rubygems-update-3.6.9*/**/*</include>
           <include>gems/benchmark-0.4.0*/**/*</include>
           <include>gems/bundler-2.6.9*/**/*</include>
-          <include>gems/cgi-0.4.1*/**/*</include>
+          <include>gems/cgi-0.4.2*/**/*</include>
           <include>gems/date-3.4.1*/**/*</include>
           <include>gems/delegate-0.4.0*/**/*</include>
           <include>gems/did_you_mean-2.0.0*/**/*</include>
@@ -1285,7 +1285,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/rubygems-update-3.6.9*</include>
           <include>cache/benchmark-0.4.0*</include>
           <include>cache/bundler-2.6.9*</include>
-          <include>cache/cgi-0.4.1*</include>
+          <include>cache/cgi-0.4.2*</include>
           <include>cache/date-3.4.1*</include>
           <include>cache/delegate-0.4.0*</include>
           <include>cache/did_you_mean-2.0.0*</include>


### PR DESCRIPTION
Bump cgi version to fix CVE-2025-27220 and CVE-2025-27219

<img width="1175" height="289" alt="Screenshot_2025-08-08_11-17-42" src="https://github.com/user-attachments/assets/00a14663-4d38-4dff-a088-953fc940cea3" />
