### PR TITLE
Handle argument or block passed to Range#count

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -1214,14 +1214,23 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod
     public IRubyObject count(ThreadContext context, Block block) {
-        if (isBeginless || isEndless) return asFloat(context, RubyFloat.INFINITY);
+        if (!block.isGiven()) {
+            if (isBeginless || isEndless) return asFloat(context, RubyFloat.INFINITY);
 
-        if (begin instanceof RubyInteger) {
-            IRubyObject size = size(context);
-            if (!size.isNil()) return size;
+            if (begin instanceof RubyInteger) {
+                IRubyObject size = size(context);
+                if (!size.isNil()) return size;
+            }
+
+            // fall back on Enumerable logic for other cases
         }
 
         return RubyEnumerable.count(context, this, block);
+    }
+
+    @JRubyMethod
+    public IRubyObject count(ThreadContext context, IRubyObject arg, Block block) {
+        return RubyEnumerable.count(context, this, arg, block);
     }
 
     @JRubyMethod

--- a/spec/ruby/core/range/count_spec.rb
+++ b/spec/ruby/core/range/count_spec.rb
@@ -9,4 +9,18 @@ describe "Range#count" do
     (...nil).count.should == inf
     (..10.0).count.should == inf
   end
+
+  it "accepts an argument for comparison using ==" do
+    (1..10).count(2).should == 1
+  end
+
+  it "uses a block for comparison" do
+    (1..10).count{|x| x%2==0 }.should == 5
+  end
+
+  it "ignores the block when given an argument" do
+    -> {
+      (1..10).count(4){|x| x%2==0 }.should == 1
+    }.should complain(/given block not used/)
+  end
 end


### PR DESCRIPTION
Logic installed to prevent large ranges from manually iterating to calculate a count (79ee9204d6786a587509acd500fbd4e8831c3a16) short-circuited the fallback on `Enumerable#count` logic. That broke `count` when passed a block (as described in #8955). Additionally, we did not handle the case where `Range#count` is passed an argument.

This PR fixes both cases and adds specs.