### PR TITLE
Add a USERS.md file to track JRuby users

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,6 +16,14 @@ If you need help, feel free to join the JRuby chat room on Matrix:
 
 * https://matrix.to/#/#jruby:matrix.org
 
+We also request that current users of JRuby add themselves to our user
+list by submitting a pull request to the following file:
+
+* https://github.com/jruby/jruby/blob/master/USERS.md
+
+This helps the JRuby community grow and share best practices and new ideas
+for how to apply JRuby to JVM and Ruby apps around the world.
+
 -->
 
 **Environment Information**

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -12,6 +12,14 @@ All branches are merged forward to the next major release (e.g. 9.4 is merged to
 
 If you have questions, please just submit as best you can and we will assist.
 
+We also request that current users of JRuby add themselves to our user
+list by submitting a pull request to the following file:
+
+* https://github.com/jruby/jruby/blob/master/USERS.md
+
+This helps the JRuby community grow and share best practices and new ideas
+for how to apply JRuby to JVM and Ruby apps around the world.
+
 Replace this text with your pull request details.
 
 -->

--- a/USERS.md
+++ b/USERS.md
@@ -16,22 +16,27 @@ Adding yourself as a user
 
 If you are using JRuby or it is integrated into your product, service, or
 platform, please consider adding yourself as a user with a quick
-description of your use case by opening a pull request to this file and adding
-a section describing your usage of JRuby. If you are open to others contacting
-you about your use of JRuby on Matrix, add your Matrix nickname as well.
+description of your use case by [opening a pull request to this file](https://github.com/jruby/jruby/blob/master/USERS.md)
+and adding a section describing your usage of JRuby:
 
-    N: Name of user (company)
-    D: Description
-    U: Usage of features
-    L: Link with further information (optional)
-    Q: Contacts available for questions (optional)
+If you are open to others contacting you about your use of JRuby, add your
+Matrix nickname or contact info as well.
+
+    Name: Name of user (company)
+    Desc: Description
+    Usage: Usage of features
+    Since: How long have you used JRuby (optional)
+    Link: Link with further information (optional)
+    Contact: Contacts available for questions (optional)
 
 Example entry:
 
-    * N: JRuby Example User Inc.
-      D: JRuby Example User Inc. is using JRuby to scale our app
-      U: Parallelism, deploying to Java servers, calling JVM libraries
-      Q: @slacknick1, @slacknick2
+    * Name: The JRuby Project
+      Desc: The project that brings you JRuby
+      Usage: JRuby uses JRuby to build JRuby via our Maven toolchain
+      Since: 2009
+      Link: https://github.com/jruby/jruby
+      Contact: @headius, @enebo
 
 Requirements to be listed
 -------------------------

--- a/USERS.md
+++ b/USERS.md
@@ -1,0 +1,47 @@
+Who is using JRuby?
+====================
+
+Sharing experiences and learning from other users is essential. We are
+frequently asked who is using a particular feature of JRuby so people can get in
+contact with other users to share experiences and best practices. People
+also often want to know if product/platform X supports JRuby.
+While the [JRuby Matrix community](https://matrix.to/#/#jruby:matrix.org) allows
+users to get in touch, it can be challenging to find this information quickly.
+
+The following is a directory of adopters to help identify users of individual
+features. The users themselves directly maintain the list.
+
+Adding yourself as a user
+-------------------------
+
+If you are using JRuby or it is integrated into your product, service, or
+platform, please consider adding yourself as a user with a quick
+description of your use case by opening a pull request to this file and adding
+a section describing your usage of JRuby. If you are open to others contacting
+you about your use of JRuby on Matrix, add your Matrix nickname as well.
+
+    N: Name of user (company)
+    D: Description
+    U: Usage of features
+    L: Link with further information (optional)
+    Q: Contacts available for questions (optional)
+
+Example entry:
+
+    * N: JRuby Example User Inc.
+      D: JRuby Example User Inc. is using JRuby to scale our app
+      U: Parallelism, deploying to Java servers, calling JVM libraries
+      Q: @slacknick1, @slacknick2
+
+Requirements to be listed
+-------------------------
+
+ * You must represent the user listed. Do *NOT* add entries on behalf of
+   other users.
+ * There is no minimum deployment size but we request to list permanent
+   production deployments only, i.e., no demo or trial deployments. Commercial
+   use is not required. A well-done home lab setup can be equally
+   interesting as a large-scale commercial deployment.
+
+Users (Alphabetically)
+----------------------

--- a/maven/jruby-dist/src/main/assembly/common.xml
+++ b/maven/jruby-dist/src/main/assembly/common.xml
@@ -52,6 +52,8 @@
         <include>COPYING*</include>
         <include>BSDL</include>
         <include>LEGAL</include>
+        <include>USERS.md</include>
+        <include>README.md</include>
         <include>lib/jni/**/*</include>
         <include>samples/**/*</include>
         <include>docs/**/*</include>


### PR DESCRIPTION
Several open source projects have a list of users or use cases in their repository, so it's easily accessible and included in the source or binary distributions. This is an initial version of that list based on one from the Cilium project: https://github.com/cilium/cilium/blob/main/USERS.md

TODO:

* [x] Include in source distribution
* [x] Include in binary distribution
* [x] Revise and improve text of this form

Once it is in place, we can send a blast out on social media for current users to add themselves.