### PR TITLE
Fix index -1 error while searching for feature path

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -705,13 +705,17 @@ public class LibrarySearcher {
         }
         else {
             int e;
-            for (e = nameLength - 1; e >= 0 && name.charAt(e) != '.' && name.charAt(e) != '/'; --e);
+            // search from end until we find '.' or '/' or we're at the first character
+            for (e = nameLength - 1; e > 0 && name.charAt(e) != '.' && name.charAt(e) != '/'; --e);
+            // if initial character is not '.' or we have too few chars left or the remaining region doesn't match, quit
             if (name.charAt(e) != '.' ||
                     e < featureLength ||
                     !name.regionMatches(e - featureLength, feature, 0, featureLength))
                 return null;
+            // new path length is current position minus the feature length
             plen = e - featureLength;
         }
+        // if path length is zero or the last character of path is not '/', quit
         if (plen > 0 && name.charAt(plen-1) != '/') {
             return null;
         }

--- a/core/src/test/java/org/jruby/runtime/load/TestLoadService.java
+++ b/core/src/test/java/org/jruby/runtime/load/TestLoadService.java
@@ -33,6 +33,8 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.test.Base;
 import org.jruby.test.BasicLibraryTestService;
 
+import java.util.Collections;
+
 import static org.jruby.api.Access.loadService;
 
 public class TestLoadService extends Base {
@@ -120,5 +122,12 @@ public class TestLoadService extends Base {
         sw.clear();
 
         assertEquals("StringWrapper()", sw.toString());
+    }
+
+    public void testLoadedFeatureWithPath() {
+        // Test that a simple feature lock name does not trigger AIOOB (https://github.com/jruby/jruby/issues/8958)
+        String lockedFeature = "previous_feature";
+        String feature = "current_feature";
+        assertEquals(null, LibrarySearcher.loadedFeatureWithPath(lockedFeature, feature, LibrarySearcher.Suffix.RUBY, Collections.EMPTY_LIST));
     }
 }


### PR DESCRIPTION
The code here is intended to walk the incoming feature, looking for either '.' or '/' in order to break up the feature into a path and filename. This is then compared with the load path to find a match, indicating that the feature has been loaded via those paths.

The bug is that it should find one of those characters or leave the search index 'e' at the beginning of the feature string for a subsequent check, but it was ported incorrectly from the original C code. Index of stopping at the beginning of the string, it allows one more decrement leaving 'e' as -1, and String.charAt raises.

This is normally only triggered for features that are being required at the same time across threads, and which have not yet been expanded to their full load path form. With the unexpanded feature in flight, the search will never encounter '.' or '/' and walk off the head of the string.

Fixes #8958