### PR TITLE
Upgrade polyglot and remove openssl lib hack

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>io.takari.polyglot</groupId>
     <artifactId>polyglot-ruby</artifactId>
-    <version>0.5.0</version>
+    <version>0.8.1</version>
   </extension>
 </extensions>

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -223,21 +223,6 @@ project 'JRuby Lib Setup' do
 
     FileUtils.mkdir_p( default_specs )
 
-    # have an empty openssl.rb so we do not run in trouble with not having
-    # jopenssl which is part of the default gems
-    lib_dir = File.join( target, 'lib' )
-    openssl = File.join( lib_dir, 'openssl.rb' )
-    FileUtils.mkdir_p( lib_dir )
-    FileUtils.touch( openssl )
-    $LOAD_PATH.unshift lib_dir
-
-    # since the bouncy castle .jars are version-ed (e.g. bcprov-jdk15on-1.47)
-    # make sure we cleanup before adding the ones from the jruby-openssl.gem:
-    Dir.glob( File.join( lib_dir, "bc{prov,pkix}*.jar" ) ).each do |f|
-      # use this instead of FileUtils.rm_f - issue #1698
-      File.delete( f ) if File.exists?( f )
-    end
-
     # now we can require the rubygems staff
     require 'rubygems/installer'
     require 'rubygems/package'

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -1414,7 +1414,7 @@ DO NOT MODIFY - GENERATED CODE
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.5.0</version>
+        <version>0.8.1</version>
         <executions>
           <execution>
             <id>install_gems</id>
@@ -1465,7 +1465,7 @@ DO NOT MODIFY - GENERATED CODE
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-ruby</artifactId>
-            <version>0.5.0</version>
+            <version>0.8.1</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>


### PR DESCRIPTION
The lib hack here put a blank openssl.rb into lib/target/lib and added that directory to the LOAD_PATH of the polyglot JRuby runtime. This was done many years ago, perhaps before we had refined how standard libraries could be loaded from released JRuby stdlib jars, and does not appear to be necessary now for a successful build. In jruby/jruby#8634 we learned that because newer RubyGems depends on OpenSSL at runtime, and we're feeding it a bogus openssl.rb, newer polyglot versions that depends on newer JRuby versions cannot successfully build JRuby from repo.

This PR removes the openssl.rb lib hack altogether and does not appear to break local builds of JRuby while allowing polyglot to be upgraded to latest.

Fixes jruby/jruby#8634

Backport of #8962 to 9.4.