### PR TITLE
Pass multi-elt array key for to_h using yieldArray

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -2371,7 +2371,7 @@ public class RubyEnumerable {
                     break;
                 default:
                     IRubyObject v = RubyArray.newArrayMayCopy(runtime, largs);
-                    value = blockGiven ? block.yield(context, v) : v;
+                    value = blockGiven ? block.yieldArray(context, v, null) : v;
                     break;
             }
 


### PR DESCRIPTION
When incoming argument list contains arguments of the form ([1, 2], 3), ensure the first element is passed as an array to the to_h block, rather than yielded as a splattable argument list.

Fixes part of jruby/jruby#8435

See ruby/spec#1283 for some discussion about how to write a spec for this behavior.