### PR TITLE
Move jruby.gem.home and jruby.gem.path to Options

### DIFF
--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -50,6 +50,7 @@ import org.jruby.runtime.Constants;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.load.Library;
 import org.jruby.util.SafePropertyAccessor;
+import org.jruby.util.cli.Options;
 
 @JRubyModule(name="Config")
 public class RbConfigLibrary implements Library {
@@ -366,8 +367,8 @@ public class RbConfigLibrary implements Library {
         setConfig(context, CONFIG, "ridir", newFile(shareDir, "ri").getPath());
 
         // These will be used as jruby defaults for rubygems if found
-        String gemhome = SafePropertyAccessor.getProperty("jruby.gem.home");
-        String gempath = SafePropertyAccessor.getProperty("jruby.gem.path");
+        String gemhome = Options.GEM_HOME.load();
+        String gempath = Options.GEM_PATH.load();
         if (gemhome != null) setConfig(context, CONFIG, "default_gem_home", gemhome);
         if (gempath != null) setConfig(context, CONFIG, "default_gem_path", gempath);
 

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -168,6 +168,8 @@ public class Options {
     public static final Option<Integer> JAR_CACHE_EXPIRATION = integer(MISCELLANEOUS, "jar.cache.expiration", 750, "The time (ms) between checks if a JAR file containing resources has been updated.");
     public static final Option<String> WINDOWS_FILESYSTEM_ENCODING = string(MISCELLANEOUS, "windows.filesystem.encoding", "UTF-8", "The encoding to use for filesystem names and paths on Windows.");
     public static final Option<Boolean> NAME_ERROR_INSPECT_OBJECT = bool(MISCELLANEOUS, "nameError.inspect.object", true, "Inspect the target object for display in NameError messages.");
+    public static final Option<String> GEM_HOME = string(MISCELLANEOUS, "gem.home", "The home dir where Ruby gems will be installed.");
+    public static final Option<String> GEM_PATH = string(MISCELLANEOUS, "gem.path", "The path containing all dirs to search for installed Ruby gems.");
 
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");


### PR DESCRIPTION
These are prefixed with "jruby." but not registered as official JRuby options. This causes a warning when they are used. The patch here moves them to Options.

Fixes #8670