### PR TITLE
Use RuboCop to clean up poms (9.4)

### DIFF
--- a/.rubocop-pom.yml
+++ b/.rubocop-pom.yml
@@ -1,0 +1,2 @@
+Style/StringHashKeys:
+  Enabled: true

--- a/bench/pom.rb
+++ b/bench/pom.rb
@@ -1,26 +1,27 @@
+# frozen_string_literal: true
+
 version = ENV['JRUBY_VERSION'] ||
-  File.read(File.join(basedir, '..', 'VERSION')).strip
+          File.read(File.join(basedir, '..', 'VERSION')).strip
 
 project 'JRuby Benchmark' do
-
   model_version '4.0.0'
   inherit 'org.jruby:jruby-parent', version
   id 'org.jruby:jruby-benchmark'
 
-  properties('polyglot.dump.pom' => 'pom.xml',
-             'polyglot.dump.readonly' => true,
-             'maven.build.timestamp.format' => 'yyyy-MM-dd',
-             'maven.test.skip' => 'true',
-             'build.date' => '${maven.build.timestamp}',
-             'main.basedir' => '${project.parent.basedir}',
-             'jruby.basedir' => '${basedir}/..',
-             'jmh.version' => '1.19'
-  )
+  properties("polyglot.dump.pom": 'pom.xml',
+             "polyglot.dump.readonly": true,
+             "maven.build.timestamp.format": 'yyyy-MM-dd',
+             "maven.test.skip": 'true',
+             "build.date": '${maven.build.timestamp}',
+             "main.basedir": '${project.parent.basedir}',
+             "jruby.basedir": '${basedir}/..',
+             "jmh.version": '1.19')
 
   IO.foreach(File.join(basedir, '..', 'default.build.properties')) do |line|
     line.chomp!
     # skip comments
     next if line =~ /(^\W*#|^$)/
+
     # build const name
     name, value = line.split('=', 2)
     properties name => value
@@ -32,24 +33,23 @@ project 'JRuby Benchmark' do
   jar 'org.openjdk.jmh:jmh-core-benchmarks:${jmh.version}'
 
   plugin(:compiler,
-         'encoding' => 'utf-8',
-         'debug' => 'true',
-         'verbose' => 'true',
-         'fork' => 'true',
-         'compilerArgs' => { 'arg' => '-J-Xmx1G' },
-         'showWarnings' => 'true',
-         'showDeprecation' => 'true',
-         'source' => ['${base.java.version}', '1.8'],
-         'target' => ['${base.javac.version}', '1.8'],
-         'useIncrementalCompilation' => 'false')
+         encoding: 'utf-8',
+         debug: 'true',
+         verbose: 'true',
+         fork: 'true',
+         compilerArgs: { arg: '-J-Xmx1G' },
+         showWarnings: 'true',
+         showDeprecation: 'true',
+         source: ['${base.java.version}', '1.8'],
+         target: ['${base.javac.version}', '1.8'],
+         useIncrementalCompilation: 'false')
 
   plugin :shade do
     execute_goals('shade',
-                  :id => 'create jruby-benchmark.jar',
-                  :phase => 'package',
-                  'outputFile' => '${project.build.directory}/jruby-benchmark.jar',
-                  'transformers' => [{ '@implementation' => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
-                                       'mainClass' => 'org.openjdk.jmh.Main' }]
-    )
+                  id: 'create jruby-benchmark.jar',
+                  phase: 'package',
+                  outputFile: '${project.build.directory}/jruby-benchmark.jar',
+                  transformers: [{ :@implementation => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
+                                   :mainClass => 'org.openjdk.jmh.Main' }])
   end
 end

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -249,8 +249,9 @@ project 'JRuby Base' do
            "jruby.home": '${basedir}/..'
          },
          argLine: '-Xmx${jruby.test.memory} -Dfile.encoding=UTF-8 -Djava.awt.headless=true',
+         # rubocop:disable Style/StringHashKeys
          environmentVariables: {
-           JDK_JAVA_OPTIONS: '--add-modules java.scripting --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED'
+           'JDK_JAVA_OPTIONS' => '--add-modules java.scripting --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED'
          },
          includes: [
            'org/jruby/test/**/*Test*.java',
@@ -311,7 +312,7 @@ project 'JRuby Base' do
                       id: 'default-compile_with_error_prone',
                       phase: 'compile',
                       fork: 'true',
-                      compilerArgs: default_compile_configuration['compilerArgs'] + [
+                      compilerArgs: default_compile_configuration[:compilerArgs] + [
                         '-XDcompilePolicy=simple', '-Xplugin:ErrorProne'
                       ],
                       annotationProcessorPaths: { path: [{

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -1,39 +1,41 @@
-version = ENV['JRUBY_VERSION'] ||
-  File.read( File.join( basedir, '..', 'VERSION' ) ).strip
+# frozen_string_literal: true
 
-# note: we keep the legacy name since a lot of tests depends on it but
+version = ENV['JRUBY_VERSION'] ||
+          File.read(File.join(basedir, '..', 'VERSION')).strip
+
+# NOTE: we keep the legacy name since a lot of tests depends on it but
 #       rename artifact
 project 'JRuby Base' do
-
   model_version '4.0.0'
   inherit 'org.jruby:jruby-parent', version
   id 'org.jruby:jruby-base'
 
-  properties( 'polyglot.dump.pom' => 'pom.xml',
-              'polyglot.dump.readonly' => true,
+  properties("polyglot.dump.pom": 'pom.xml',
+             "polyglot.dump.readonly": true,
 
-              'tzdata.version' => '2019c',
-              'tzdata.scope' => 'provided',
+             "tzdata.version": '2019c',
+             "tzdata.scope": 'provided',
 
-              'maven.build.timestamp.format' => 'yyyy-MM-dd',
-              'maven.test.skip' => 'true',
-              'build.date' => '${maven.build.timestamp}',
-              'main.basedir' => '${project.parent.basedir}',
-              'Constants.java' => 'org/jruby/runtime/Constants.java',
-              'anno.sources' => '${project.basedir}/target/generated-sources',
+             "maven.build.timestamp.format": 'yyyy-MM-dd',
+             "maven.test.skip": 'true',
+             "build.date": '${maven.build.timestamp}',
+             "main.basedir": '${project.parent.basedir}',
+             "Constants.java": 'org/jruby/runtime/Constants.java',
+             "anno.sources": '${project.basedir}/target/generated-sources',
 
-              'jruby.basedir' => '${basedir}/..',
-              'jruby.test.memory' => '3G',
-              'jruby.compile.memory' => '2G',
+             "jruby.basedir": '${basedir}/..',
+             "jruby.test.memory": '3G',
+             "jruby.compile.memory": '2G',
 
-              'create.sources.jar' => false )
+             "create.sources.jar": false)
 
   IO.foreach(File.join(basedir, '..', 'default.build.properties')) do |line|
     line.chomp!
     # skip comments
     next if line =~ /(^\W*#|^$)/
+
     # build const name
-    name, value = line.split("=", 2)
+    name, value = line.split('=', 2)
     properties name => value
   end
 
@@ -42,11 +44,11 @@ project 'JRuby Base' do
   jar 'org.ow2.asm:asm-util:${asm.version}'
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages
-  jar 'com.github.jnr:jnr-netdb:1.2.0', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-enxio:0.32.18', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-unixsocket:0.38.23', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-posix:3.1.20', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-constants:0.10.4', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-netdb:1.2.0', exclusions: ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-enxio:0.32.18', exclusions: ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-unixsocket:0.38.23', exclusions: ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-posix:3.1.20', exclusions: ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-constants:0.10.4', exclusions: ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-ffi:2.2.17'
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
@@ -59,207 +61,207 @@ project 'JRuby Base' do
   jar 'com.headius:options:1.6'
 
   jar 'org.jruby:jzlib:1.1.5'
-  jar 'junit:junit', :scope => 'test'
-  jar 'org.awaitility:awaitility', :scope => 'test'
-  jar 'org.apache.ant:ant:${ant.version}', :scope => 'provided'
-  jar 'org.osgi:org.osgi.core:5.0.0', :scope => 'provided'
+  jar 'junit:junit', scope: 'test'
+  jar 'org.awaitility:awaitility', scope: 'test'
+  jar 'org.apache.ant:ant:${ant.version}', scope: 'provided'
+  jar 'org.osgi:org.osgi.core:5.0.0', scope: 'provided'
 
   # joda timezone must be before joda-time to be packed correctly
   # jar 'org.jruby:joda-timezones:${tzdata.version}', :scope => '${tzdata.scope}'
   jar 'joda-time:joda-time:${joda.time.version}'
 
   # SLF4J only used within SLF4JLogger (JRuby logger impl) class
-  jar 'org.slf4j:slf4j-api:1.7.12', :scope => 'provided', :optional => true
-  jar 'org.slf4j:slf4j-simple:1.7.12', :scope => 'test'
+  jar 'org.slf4j:slf4j-api:1.7.12', scope: 'provided', optional: true
+  jar 'org.slf4j:slf4j-simple:1.7.12', scope: 'test'
 
-  jar 'me.qmx.jitescript:jitescript:0.4.1', :exclusions => ['org.ow2.asm:asm-all']
+  jar 'me.qmx.jitescript:jitescript:0.4.1', exclusions: ['org.ow2.asm:asm-all']
 
   jar 'com.headius:backport9:1.13'
 
   jar 'org.crac:crac:1.5.0'
 
   plugin_management do
-    plugin( 'org.eclipse.m2e:lifecycle-mapping:1.0.0',
-            'lifecycleMappingMetadata' => {
-              'pluginExecutions' => [ { 'pluginExecutionFilter' => {
-                                          'groupId' =>  'org.codehaus.mojo',
-                                          'artifactId' =>  'properties-maven-plugin',
-                                          'versionRange' =>  '[1.0-alpha-2,)',
-                                          'goals' => [ 'read-project-properties' ]
-                                        },
-                                        'action' => {
-                                          'ignore' =>  ''
-                                        } },
-                                      { 'pluginExecutionFilter' => {
-                                          'groupId' =>  'org.codehaus.mojo',
-                                          'artifactId' =>  'build-helper-maven-plugin',
-                                          'versionRange' =>  '[1.8,)',
-                                          'goals' => [ 'add-source' ]
-                                        },
-                                        'action' => {
-                                          'ignore' =>  ''
-                                        } },
-                                      { 'pluginExecutionFilter' => {
-                                          'groupId' =>  'org.codehaus.mojo',
-                                          'artifactId' =>  'exec-maven-plugin',
-                                          'versionRange' =>  '[1.2.1,)',
-                                          'goals' => [ 'exec' ]
-                                        },
-                                        'action' => {
-                                          'ignore' =>  ''
-                                        } },
-                                      { 'pluginExecutionFilter' => {
-                                          'groupId' =>  'org.apache.maven.plugins',
-                                          'artifactId' =>  'maven-dependency-plugin',
-                                          'versionRange' =>  '[2.8,)',
-                                          'goals' => [ 'copy' ]
-                                        },
-                                        'action' => {
-                                          'ignore' =>  ''
-                                        } },
-                                      { 'pluginExecutionFilter' => {
-                                          'groupId' =>  'org.apache.maven.plugins',
-                                          'artifactId' =>  'maven-clean-plugin',
-                                          'versionRange' =>  '[2.5,)',
-                                          'goals' => [ 'clean' ]
-                                        },
-                                        'action' => {
-                                          'ignore' =>  ''
-                                        } } ]
-            } )
+    plugin('org.eclipse.m2e:lifecycle-mapping:1.0.0',
+           lifecycleMappingMetadata: {
+             pluginExecutions: [{ pluginExecutionFilter: {
+                                    groupId: 'org.codehaus.mojo',
+                                    artifactId: 'properties-maven-plugin',
+                                    versionRange: '[1.0-alpha-2,)',
+                                    goals: ['read-project-properties']
+                                  },
+                                  action: {
+                                    ignore: ''
+                                  } },
+                                { pluginExecutionFilter: {
+                                    groupId: 'org.codehaus.mojo',
+                                    artifactId: 'build-helper-maven-plugin',
+                                    versionRange: '[1.8,)',
+                                    goals: ['add-source']
+                                  },
+                                  action: {
+                                    ignore: ''
+                                  } },
+                                { pluginExecutionFilter: {
+                                    groupId: 'org.codehaus.mojo',
+                                    artifactId: 'exec-maven-plugin',
+                                    versionRange: '[1.2.1,)',
+                                    goals: ['exec']
+                                  },
+                                  action: {
+                                    ignore: ''
+                                  } },
+                                { pluginExecutionFilter: {
+                                    groupId: 'org.apache.maven.plugins',
+                                    artifactId: 'maven-dependency-plugin',
+                                    versionRange: '[2.8,)',
+                                    goals: ['copy']
+                                  },
+                                  action: {
+                                    ignore: ''
+                                  } },
+                                { pluginExecutionFilter: {
+                                    groupId: 'org.apache.maven.plugins',
+                                    artifactId: 'maven-clean-plugin',
+                                    versionRange: '[2.5,)',
+                                    goals: ['clean']
+                                  },
+                                  action: {
+                                    ignore: ''
+                                  } }]
+           })
   end
 
   plugin 'org.codehaus.mojo:buildnumber-maven-plugin:1.2' do
-    execute_goals( 'create',
-                   :id => 'jruby-revision',
-                   :phase => 'generate-sources',
-                   'buildNumberPropertyName' =>  'jruby.revision' )
+    execute_goals('create',
+                  id: 'jruby-revision',
+                  phase: 'generate-sources',
+                  buildNumberPropertyName: 'jruby.revision')
   end
 
   phase 'process-classes' do
     plugin 'org.codehaus.mojo:build-helper-maven-plugin' do
-      execute_goals( 'add-source',
-                     :id => 'add-populators',
-                     'sources' => [ '${anno.sources}' ] )
+      execute_goals('add-source',
+                    id: 'add-populators',
+                    sources: ['${anno.sources}'])
     end
 
     plugin 'org.codehaus.mojo:exec-maven-plugin' do
-      execute_goals( 'exec',
-                     :id => 'invoker-generator',
-                     'arguments' => [ '-Djruby.bytecode.version=${base.java.version}',
-                                      '-classpath',
-                                      xml( '<classpath/>' ),
-                                      'org.jruby.anno.InvokerGenerator',
-                                      '${anno.sources}/annotated_classes.txt',
-                                      '${project.build.outputDirectory}' ],
-                     'executable' =>  'java',
-                     'classpathScope' =>  'compile' )
+      execute_goals('exec',
+                    id: 'invoker-generator',
+                    arguments: ['-Djruby.bytecode.version=${base.java.version}',
+                                '-classpath',
+                                xml('<classpath/>'),
+                                'org.jruby.anno.InvokerGenerator',
+                                '${anno.sources}/annotated_classes.txt',
+                                '${project.build.outputDirectory}'],
+                    executable: 'java',
+                    classpathScope: 'compile')
 
-      execute_goals( 'exec',
-                     :id => 'scope-generator',
-                     'arguments' => [ '-Djruby.bytecode.version=${base.java.version}',
-                                      '-classpath',
-                                      xml( '<classpath/>' ),
-                                      'org.jruby.runtime.scope.DynamicScopeGenerator',
-                                      '${project.build.outputDirectory}' ],
-                     'executable' =>  'java',
-                     'classpathScope' =>  'compile' )
+      execute_goals('exec',
+                    id: 'scope-generator',
+                    arguments: ['-Djruby.bytecode.version=${base.java.version}',
+                                '-classpath',
+                                xml('<classpath/>'),
+                                'org.jruby.runtime.scope.DynamicScopeGenerator',
+                                '${project.build.outputDirectory}'],
+                    executable: 'java',
+                    classpathScope: 'compile')
 
-      execute_goals( 'exec',
-                     :id => 'specialized-object-generator',
-                     'arguments' => [ '-Djruby.bytecode.version=${base.java.version}',
-                                      '-classpath',
-                                      xml( '<classpath/>' ),
-                                      'org.jruby.specialized.RubyObjectSpecializer',
-                                      '${project.build.outputDirectory}' ],
-                     'executable' =>  'java',
-                     'classpathScope' =>  'compile' )
+      execute_goals('exec',
+                    id: 'specialized-object-generator',
+                    arguments: ['-Djruby.bytecode.version=${base.java.version}',
+                                '-classpath',
+                                xml('<classpath/>'),
+                                'org.jruby.specialized.RubyObjectSpecializer',
+                                '${project.build.outputDirectory}'],
+                    executable: 'java',
+                    classpathScope: 'compile')
     end
   end
 
-  fork_compiler_args = [ '-XDignore.symbol.file=true',
-                         '-J-Duser.language=en',
-                         '-J-Dfile.encoding=UTF-8',
-                         '-J-Xmx${jruby.compile.memory}' ]
+  fork_compiler_args = ['-XDignore.symbol.file=true',
+                        '-J-Duser.language=en',
+                        '-J-Dfile.encoding=UTF-8',
+                        '-J-Xmx${jruby.compile.memory}']
 
   default_compile_configuration = {
-    'fork' => 'true',
-    'annotationProcessors' => [ 'org.jruby.anno.AnnotationBinder' ],
-    'generatedSourcesDirectory' =>  'target/generated-sources',
-    'compilerArgs' => fork_compiler_args
+    fork: 'true',
+    annotationProcessors: ['org.jruby.anno.AnnotationBinder'],
+    generatedSourcesDirectory: 'target/generated-sources',
+    compilerArgs: fork_compiler_args
   }
 
-  plugin( :compiler,
-          'encoding' => 'utf-8',
-          'verbose' => 'false',
-          'showWarnings' => 'true',
-          'showDeprecation' => 'true',
-          'source' => [ '${base.java.version}', '1.8' ],
-          'target' => [ '${base.javac.version}', '1.8' ],
-          'useIncrementalCompilation' =>  'false' ) do
-    execute_goals( 'compile',
-                   :id => 'anno',
-                   :phase => 'process-resources',
-                   'includes' => [ 'org/jruby/anno/FrameField.java',
-                                   'org/jruby/anno/AnnotationBinder.java',
-                                   'org/jruby/anno/JRubyMethod.java',
-                                   'org/jruby/anno/FrameField.java',
-                                   'org/jruby/CompatVersion.java',
-                                   'org/jruby/runtime/Visibility.java',
-                                   'org/jruby/util/CodegenUtils.java',
-                                   'org/jruby/util/SafePropertyAccessor.java' ] )
-    execute_goals( 'compile',
-                   default_compile_configuration.merge(
-                     :id => 'default-compile',
-                     :phase => 'compile'
-                   ))
+  plugin(:compiler,
+         encoding: 'utf-8',
+         verbose: 'false',
+         showWarnings: 'true',
+         showDeprecation: 'true',
+         source: ['${base.java.version}', '1.8'],
+         target: ['${base.javac.version}', '1.8'],
+         useIncrementalCompilation: 'false') do
+    execute_goals('compile',
+                  id: 'anno',
+                  phase: 'process-resources',
+                  includes: ['org/jruby/anno/FrameField.java',
+                             'org/jruby/anno/AnnotationBinder.java',
+                             'org/jruby/anno/JRubyMethod.java',
+                             'org/jruby/anno/FrameField.java',
+                             'org/jruby/CompatVersion.java',
+                             'org/jruby/runtime/Visibility.java',
+                             'org/jruby/util/CodegenUtils.java',
+                             'org/jruby/util/SafePropertyAccessor.java'])
+    execute_goals('compile',
+                  default_compile_configuration.merge(
+                    id: 'default-compile',
+                    phase: 'compile'
+                  ))
 
-    execute_goals( 'compile',
-                   :id => 'populators',
-                   :phase => 'process-classes',
-                   'debug' => 'false',
-                   'fork' => 'true',
-                   'compilerArgs' => fork_compiler_args,
-                   'includes' => [ 'org/jruby/gen/**/*.java' ] )
+    execute_goals('compile',
+                  id: 'populators',
+                  phase: 'process-classes',
+                  debug: 'false',
+                  fork: 'true',
+                  compilerArgs: fork_compiler_args,
+                  includes: ['org/jruby/gen/**/*.java'])
 
-    execute_goals( 'compile',
-                   :id => 'eclipse-hack',
-                   :phase => 'process-classes',
-                   'skipMain' =>  'true',
-                   'includes' => [ '**/*.java' ] )
+    execute_goals('compile',
+                  id: 'eclipse-hack',
+                  phase: 'process-classes',
+                  skipMain: 'true',
+                  includes: ['**/*.java'])
   end
 
   plugin :clean do
-    execute_goals( 'clean',
-                   :id => 'default-clean',
-                   :phase => 'clean',
-                   'filesets' => [ { 'directory' =>  '${project.build.sourceDirectory}',
-                                     'includes' => [ '${Constants.java}' ] },
-                                   { 'directory' =>  '${project.basedir}/..',
-                                     'includes' => [ 'lib/jni/**' ] } ],
-                   'failOnError' =>  'false' )
+    execute_goals('clean',
+                  id: 'default-clean',
+                  phase: 'clean',
+                  filesets: [{ directory: '${project.build.sourceDirectory}',
+                               includes: ['${Constants.java}'] },
+                             { directory: '${project.basedir}/..',
+                               includes: ['lib/jni/**'] }],
+                  failOnError: 'false')
   end
 
-  plugin( :surefire,
-          'forkCount' =>  '1',
-          'reuseForks' =>  'false',
-          'systemProperties' => {
-            'jruby.home' =>  '${basedir}/..'
-          },
-          'argLine' =>  '-Xmx${jruby.test.memory} -Dfile.encoding=UTF-8 -Djava.awt.headless=true',
-          'environmentVariables' => {
-              'JDK_JAVA_OPTIONS' => '--add-modules java.scripting --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED'
-          },
-          includes: [
-            'org/jruby/test/**/*Test*.java',
-            'org/jruby/embed/**/*Test*.java',
-            'org/jruby/util/**/*Test*.java',
-            'org/jruby/runtime/**/*Test*.java'
-          ],
-          'additionalClasspathElements' => [ '${basedir}/src/test/ruby' ] )
+  plugin(:surefire,
+         forkCount: '1',
+         reuseForks: 'false',
+         systemProperties: {
+           "jruby.home": '${basedir}/..'
+         },
+         argLine: '-Xmx${jruby.test.memory} -Dfile.encoding=UTF-8 -Djava.awt.headless=true',
+         environmentVariables: {
+           JDK_JAVA_OPTIONS: '--add-modules java.scripting --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED'
+         },
+         includes: [
+           'org/jruby/test/**/*Test*.java',
+           'org/jruby/embed/**/*Test*.java',
+           'org/jruby/util/**/*Test*.java',
+           'org/jruby/runtime/**/*Test*.java'
+         ],
+         additionalClasspathElements: ['${basedir}/src/test/ruby'])
 
   plugin(:jar,
-         archive: {manifestEntries: {'Automatic-Module-Name' => 'org.jruby'}})
+         archive: { manifestEntries: { "Automatic-Module-Name": 'org.jruby' } })
 
   build do
     default_goal 'package'
@@ -273,25 +275,24 @@ project 'JRuby Base' do
       directory 'src/main/resources'
       includes 'META-INF/**/*'
     end
-
   end
 
   plugin :resources do
     execute_goals('copy-resources', phase: 'process-resources',
-                  outputDirectory: '${basedir}',
-                  resources: [
-                    {
-                      directory: 'src/main/resources',
-                      includes: '${Constants.java}',
-                      target_path: '${project.build.sourceDirectory}',
-                      filtering: 'true'
-                    },
-                    {
-                      directory: '..',
-                      includes: [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY', 'VERSION' ],
-                      target_path: '${project.build.sourceDirectory}/META-INF/'
-                    }
-                  ])
+                                    outputDirectory: '${basedir}',
+                                    resources: [
+                                      {
+                                        directory: 'src/main/resources',
+                                        includes: '${Constants.java}',
+                                        target_path: '${project.build.sourceDirectory}',
+                                        filtering: 'true'
+                                      },
+                                      {
+                                        directory: '..',
+                                        includes: ['BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY', 'VERSION'],
+                                        target_path: '${project.build.sourceDirectory}/META-INF/'
+                                      }
+                                    ])
   end
 
   profile 'error-prone' do
@@ -301,104 +302,96 @@ project 'JRuby Base' do
     end
 
     plugin :compiler do
-      execute_goals( 'compile',
-                     :id => 'default-compile',
-                     :phase => 'none' ) # do not execute default-compile, we have a replacement bellow
+      execute_goals('compile',
+                    id: 'default-compile',
+                    phase: 'none') # do not execute default-compile, we have a replacement bellow
 
-      execute_goals( 'compile',
-                     default_compile_configuration.merge(
-                       :id => 'default-compile_with_error_prone',
-                       :phase => 'compile',
-                       'fork' => 'true',
-                       'compilerArgs' => default_compile_configuration['compilerArgs'] + [
-                         '-XDcompilePolicy=simple', '-Xplugin:ErrorProne'
-                       ],
-                        'annotationProcessorPaths' => { 'path' => [ {
-                                                                      'groupId' => 'com.google.errorprone',
-                                                                      'artifactId' => 'error_prone_core',
-                                                                      'version' => '2.18.0'
-                                                                    },
-                                                                    {
-                                                                      'groupId' => 'org.jruby',
-                                                                      'artifactId' => 'jruby-base',
-                                                                      'version' => version
-                                                                    } ]
-                        }
-                    ) )
+      execute_goals('compile',
+                    default_compile_configuration.merge(
+                      id: 'default-compile_with_error_prone',
+                      phase: 'compile',
+                      fork: 'true',
+                      compilerArgs: default_compile_configuration['compilerArgs'] + [
+                        '-XDcompilePolicy=simple', '-Xplugin:ErrorProne'
+                      ],
+                      annotationProcessorPaths: { path: [{
+                        groupId: 'com.google.errorprone',
+                        artifactId: 'error_prone_core',
+                        version: '2.18.0'
+                      },
+                                                         {
+                                                           groupId: 'org.jruby',
+                                                           artifactId: 'jruby-base',
+                                                           version: version
+                                                         }] }
+                    ))
     end
   end
 
-  jni_config = [ 'unpack', { :id => 'unzip native',
-                             'excludes' =>  'META-INF,META-INF/*',
-                             'artifactItems' => [ { 'groupId' =>  'com.github.jnr',
-                                                    'artifactId' =>  'jffi',
-                                                    'version' =>  '${jffi.version}',
-                                                    'type' =>  'jar',
-                                                    'classifier' =>  'native',
-                                                    'overWrite' =>  'false',
-                                                    'outputDirectory' =>  '${jruby.basedir}/lib' } ] } ]
+  jni_config = ['unpack', { id: 'unzip native',
+                            excludes: 'META-INF,META-INF/*',
+                            artifactItems: [{ groupId: 'com.github.jnr',
+                                              artifactId: 'jffi',
+                                              version: '${jffi.version}',
+                                              type: 'jar',
+                                              classifier: 'native',
+                                              overWrite: 'false',
+                                              outputDirectory: '${jruby.basedir}/lib' }] }]
 
   phase :clean do
     plugin :dependency do
-      execute_goals( *jni_config  )
+      execute_goals(*jni_config)
     end
   end
 
   profile 'native' do
-
     activation do
-      file( :missing => '../lib/jni' )
+      file(missing: '../lib/jni')
     end
 
     phase 'process-classes' do
       plugin :dependency do
-        execute_goals( *jni_config  )
+        execute_goals(*jni_config)
       end
     end
   end
 
   profile 'test' do
-
-    properties( 'maven.test.skip' => 'false' )
-
+    properties("maven.test.skip": 'false')
   end
 
   profile 'build.properties' do
-
     activation do
-      file( :exists => '../build.properties' )
+      file(exists: '../build.properties')
     end
 
     plugin 'org.codehaus.mojo:properties-maven-plugin:1.0-alpha-2' do
-      execute_goals( 'read-project-properties',
-                     :id => 'properties',
-                     :phase => 'initialize',
-                     'files' => [ '${jruby.basedir}/build.properties' ],
-                     'quiet' =>  'true' )
+      execute_goals('read-project-properties',
+                    id: 'properties',
+                    phase: 'initialize',
+                    files: ['${jruby.basedir}/build.properties'],
+                    quiet: 'true')
     end
-
   end
 
   profile 'tzdata' do
-
     activation do
-      property( :name => 'tzdata.version' )
+      property(name: 'tzdata.version')
     end
 
-    properties( 'tzdata.jar.version' => '${tzdata.version}',
-                'tzdata.scope' => 'runtime' )
-
+    properties("tzdata.jar.version": '${tzdata.version}',
+               "tzdata.scope": 'runtime')
   end
 
   profile 'generate sources jar' do
     activation do
-      property( :name => 'create.sources.jar', :value => 'true' )
+      property(name: 'create.sources.jar', value: 'true')
     end
 
     plugin :source do
-      execute_goals( 'jar-no-fork',
-                     id: 'pack core sources',
-                     phase: 'prepare-package') # Needs to run before the shade plugin
+      execute_goals('jar-no-fork',
+                    id: 'pack core sources',
+                    phase: 'prepare-package') # Needs to run before the shade plugin
     end
   end
 end

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -1,226 +1,229 @@
+# frozen_string_literal: true
+
 MORE_QUIET = ENV['JRUBY_BUILD_MORE_QUIET']
 
 if MORE_QUIET
-  class Gem::Installer
-    def say(message)
-      if message != spec.post_install_message || !MORE_QUIET
+  module Gem
+    class Installer
+      def say(message)
+        return unless message != spec.post_install_message || !MORE_QUIET
+
         super
       end
     end
   end
 end
 
-def log(message=nil)
+def log(message = nil)
   puts message unless MORE_QUIET
 end
 
 default_gems = [
-    # treat RGs update special:
-    # - we do not want bin/update_rubygems or bin/gem overrides
-    ['rubygems-update', '3.6.3', { bin: false, require_paths: ['lib'] }],
-    ['abbrev', '0.1.0'],
-    ['base64', '0.1.1'],
-    ['benchmark', '0.2.0'],
-    # Extension still lives in JRuby. See https://github.com/ruby/bigdecimal/issues/268
-    ['bigdecimal', '3.1.4'],
-    ['bundler', '2.6.3'],
-    ['cgi', '0.3.7'],
-    ['csv', '3.2.5'],
-    # Currently using a stub gem for JRuby until we can incorporate our code.
-    # https://github.com/ruby/date/issues/48
-    ['date', '3.3.3'],
-    # Newer versions require deep control over CRuby, needs work to support JRuby.
-    # See bundled gems below.
-    ['debug', '0.2.1'],
-    ['delegate', '0.2.0'],
-    ['did_you_mean', '1.6.1'],
-    ['digest', '3.1.0'],
-    ['drb', '2.1.0'],
-    ['english', '0.7.1'],
-    ['erb', '2.2.3'],
-    ['error_highlight', '0.3.0'],
-    # https://github.com/ruby/etc/issues/19
-    # ['etc', '1.3.0'],
-    # https://github.com/ruby/fcntl/issues/9
-    # ['fcntl', '1.0.1'],
-    ['ffi', '1.16.3'],
-    ['fiddle', '1.1.4'],
-    ['fileutils', '1.6.0'],
-    ['find', '0.1.1'],
-    ['forwardable', '1.3.2'],
-    # ['gdbm', '2.1.0'],
-    ['getoptlong', '0.1.1'],
-    ['io-console', '0.7.2'],
-    # https://github.com/ruby/io-nonblock/issues/4
-    # ['io-nonblock', '0.1.0'],
-    ['io-wait', '0.3.0'],
-    ['ipaddr', '1.2.4'],
-    ['irb', '1.4.2'],
-    ['jar-dependencies', '0.5.4'],
-    ['jruby-readline', '1.3.7'],
-    ['jruby-openssl', '0.15.4'],
-    ['json', '2.7.1'],
-    ['logger', '1.5.1'],
-    ['mutex_m', '0.1.1'],
-    ['net-http', '0.3.0'],
-    ['net-protocol', '0.1.2'],
-    ['nkf', '0.2.0'],
-    ['observer', '0.1.1'],
-    ['open3', '0.1.2'],
-    # https://github.com/ruby/openssl/issues/20#issuecomment-1022872855
-    # ['openssl', '3.0.0'],
-    ['open-uri', '0.3.0'],
-    ['optparse', '0.2.0'],
-    ['ostruct', '0.5.5'],
-    # https://github.com/ruby/pathname/issues/17
-    # ['pathname', '0.2.0'],
-    ['pp', '0.3.0'],
-    ['prettyprint', '0.1.1'],
-    ['pstore', '0.1.1'],
-    ['psych', '5.2.3'],
-    ['racc', '1.6.0'],
-    ['rake-ant', '1.0.6'],
-    ['rdoc', '6.4.1.1'],
-    # https://github.com/ruby/readline/issues/5
-    # ['readline', '0.0.3'],
-    # Will be solved with readline
-    # ['readline-ext', '0.1.4'],
-    ['reline', '0.5.12'],
-    # https://github.com/ruby/resolv/issues/19
-    # https://github.com/ruby/resolv/pull/75
-    # ['resolv', '0.2.1'],
-    ['resolv-replace', '0.1.0'],
-    ['rinda', '0.1.1'],
-    ['ruby2_keywords', '0.0.5'],
-    ['securerandom', '0.2.0'],
-    # https://github.com/ruby/set/issues/21
-    # ['set', '1.0.2'],
-    ['shellwords', '0.1.0'],
-    ['singleton', '0.1.1'],
-    ['stringio', '3.1.5'],
-    ['strscan', '3.1.5'],
-    ['subspawn', '0.1.1'], # has 3 transitive deps:
-      ['subspawn-posix', '0.1.1'],
-      ['ffi-binary-libfixposix', '0.5.1.1'],
-      ['ffi-bindings-libfixposix', '0.5.1.0'],
-    # https://github.com/ruby/syslog/issues/1
-    # ['syslog', '0.1.0'],
-    # https://github.com/ruby/tempfile/issues/7
-    # ['tempfile', '0.1.2'],
-    ['time', '0.2.2'],
-    ['timeout', '0.3.2'],
-    # https://github.com/ruby/tmpdir/issues/13
-    # ['tmpdir', '0.1.2'],
-    ['tsort', '0.1.0'],
-    ['un', '0.2.0'],
-    ['uri', '0.12.4'],
-    ['weakref', '0.1.1'],
-    # https://github.com/ruby/win32ole/issues/12
-    # ['win32ole', '1.8.8'],
-    ['yaml', '0.2.0'],
-    # https://github.com/ruby/zlib/issues/38
-    # ['zlib', '2.1.1'],
+  # treat RGs update special:
+  # - we do not want bin/update_rubygems or bin/gem overrides
+  ['rubygems-update', '3.6.3', { bin: false, require_paths: ['lib'] }],
+  ['abbrev', '0.1.0'],
+  ['base64', '0.1.1'],
+  ['benchmark', '0.2.0'],
+  # Extension still lives in JRuby. See https://github.com/ruby/bigdecimal/issues/268
+  ['bigdecimal', '3.1.4'],
+  ['bundler', '2.6.3'],
+  ['cgi', '0.3.7'],
+  ['csv', '3.2.5'],
+  # Currently using a stub gem for JRuby until we can incorporate our code.
+  # https://github.com/ruby/date/issues/48
+  ['date', '3.3.3'],
+  # Newer versions require deep control over CRuby, needs work to support JRuby.
+  # See bundled gems below.
+  ['debug', '0.2.1'],
+  ['delegate', '0.2.0'],
+  ['did_you_mean', '1.6.1'],
+  ['digest', '3.1.0'],
+  ['drb', '2.1.0'],
+  ['english', '0.7.1'],
+  ['erb', '2.2.3'],
+  ['error_highlight', '0.3.0'],
+  # https://github.com/ruby/etc/issues/19
+  # ['etc', '1.3.0'],
+  # https://github.com/ruby/fcntl/issues/9
+  # ['fcntl', '1.0.1'],
+  ['ffi', '1.16.3'],
+  ['fiddle', '1.1.4'],
+  ['fileutils', '1.6.0'],
+  ['find', '0.1.1'],
+  ['forwardable', '1.3.2'],
+  # ['gdbm', '2.1.0'],
+  ['getoptlong', '0.1.1'],
+  ['io-console', '0.7.2'],
+  # https://github.com/ruby/io-nonblock/issues/4
+  # ['io-nonblock', '0.1.0'],
+  ['io-wait', '0.3.0'],
+  ['ipaddr', '1.2.4'],
+  ['irb', '1.4.2'],
+  ['jar-dependencies', '0.5.4'],
+  ['jruby-readline', '1.3.7'],
+  ['jruby-openssl', '0.15.4'],
+  ['json', '2.7.1'],
+  ['logger', '1.5.1'],
+  ['mutex_m', '0.1.1'],
+  ['net-http', '0.3.0'],
+  ['net-protocol', '0.1.2'],
+  ['nkf', '0.2.0'],
+  ['observer', '0.1.1'],
+  ['open3', '0.1.2'],
+  # https://github.com/ruby/openssl/issues/20#issuecomment-1022872855
+  # ['openssl', '3.0.0'],
+  ['open-uri', '0.3.0'],
+  ['optparse', '0.2.0'],
+  ['ostruct', '0.5.5'],
+  # https://github.com/ruby/pathname/issues/17
+  # ['pathname', '0.2.0'],
+  ['pp', '0.3.0'],
+  ['prettyprint', '0.1.1'],
+  ['pstore', '0.1.1'],
+  ['psych', '5.2.3'],
+  ['racc', '1.6.0'],
+  ['rake-ant', '1.0.6'],
+  ['rdoc', '6.4.1.1'],
+  # https://github.com/ruby/readline/issues/5
+  # ['readline', '0.0.3'],
+  # Will be solved with readline
+  # ['readline-ext', '0.1.4'],
+  ['reline', '0.5.12'],
+  # https://github.com/ruby/resolv/issues/19
+  # https://github.com/ruby/resolv/pull/75
+  # ['resolv', '0.2.1'],
+  ['resolv-replace', '0.1.0'],
+  ['rinda', '0.1.1'],
+  ['ruby2_keywords', '0.0.5'],
+  ['securerandom', '0.2.0'],
+  # https://github.com/ruby/set/issues/21
+  # ['set', '1.0.2'],
+  ['shellwords', '0.1.0'],
+  ['singleton', '0.1.1'],
+  ['stringio', '3.1.5'],
+  ['strscan', '3.1.5'],
+  ['subspawn', '0.1.1'], # has 3 transitive deps:
+  ['subspawn-posix', '0.1.1'],
+  ['ffi-binary-libfixposix', '0.5.1.1'],
+  ['ffi-bindings-libfixposix', '0.5.1.0'],
+  # https://github.com/ruby/syslog/issues/1
+  # ['syslog', '0.1.0'],
+  # https://github.com/ruby/tempfile/issues/7
+  # ['tempfile', '0.1.2'],
+  ['time', '0.2.2'],
+  ['timeout', '0.3.2'],
+  # https://github.com/ruby/tmpdir/issues/13
+  # ['tmpdir', '0.1.2'],
+  ['tsort', '0.1.0'],
+  ['un', '0.2.0'],
+  ['uri', '0.12.4'],
+  ['weakref', '0.1.1'],
+  # https://github.com/ruby/win32ole/issues/12
+  # ['win32ole', '1.8.8'],
+  ['yaml', '0.2.0']
+  # https://github.com/ruby/zlib/issues/38
+  # ['zlib', '2.1.1'],
 ]
 
 bundled_gems = [
-    # Depends on many CRuby internals
-    # ['debug', '1.4.0'],
-    ['matrix', '0.4.2'],
-    ['minitest', '5.15.0'],
-    ['net-ftp', '0.3.7'],
-    ['net-imap', '0.2.5'],
-    ['net-pop', '0.1.1'],
-    ['net-smtp', '0.3.1.1'],
-    ['prime', '0.1.2'],
-    ['power_assert', '2.0.1'],
-    ['rake', '${rake.version}'],
-    # Depends on many CRuby internals
-    # ['rbs', '2.0.0'],
-    ['rexml', '3.3.9'],
-    ['rss', '0.3.1'],
-    ['test-unit', '3.5.3'],
-    # Depends on many CRuby internals
-    # ['typeprof', '0.21.1'],
+  # Depends on many CRuby internals
+  # ['debug', '1.4.0'],
+  ['matrix', '0.4.2'],
+  ['minitest', '5.15.0'],
+  ['net-ftp', '0.3.7'],
+  ['net-imap', '0.2.5'],
+  ['net-pop', '0.1.1'],
+  ['net-smtp', '0.3.1.1'],
+  ['prime', '0.1.2'],
+  ['power_assert', '2.0.1'],
+  ['rake', '${rake.version}'],
+  # Depends on many CRuby internals
+  # ['rbs', '2.0.0'],
+  ['rexml', '3.3.9'],
+  ['rss', '0.3.1'],
+  ['test-unit', '3.5.3']
+  # Depends on many CRuby internals
+  # ['typeprof', '0.21.1'],
 ]
 
 project 'JRuby Lib Setup' do
-
   version = ENV['JRUBY_VERSION'] ||
-    File.read( File.join( basedir, '..', 'VERSION' ) ).strip
+            File.read(File.join(basedir, '..', 'VERSION')).strip
 
   model_version '4.0.0'
   id 'jruby-stdlib'
-  inherit "org.jruby:jruby-parent", version
+  inherit 'org.jruby:jruby-parent', version
 
-  properties( 'polyglot.dump.pom' => 'pom.xml',
-              'polyglot.dump.readonly' => true,
-              'gem.home' => '${basedir}/ruby/gems/shared',
-              # we copy everything into the target/classes/META-INF
-              # so the jar plugin just packs it - see build/resources below
-              'jruby.complete.home' => '${project.build.outputDirectory}/META-INF/jruby.home',
-              'jruby.complete.gems' => '${jruby.complete.home}/lib/ruby/gems/shared' )
+  properties("polyglot.dump.pom": 'pom.xml',
+             "polyglot.dump.readonly": true,
+             "gem.home": '${basedir}/ruby/gems/shared',
+             # we copy everything into the target/classes/META-INF
+             # so the jar plugin just packs it - see build/resources below
+             "jruby.complete.home": '${project.build.outputDirectory}/META-INF/jruby.home',
+             "jruby.complete.gems": '${jruby.complete.home}/lib/ruby/gems/shared')
 
   # just depends on jruby-core so we are sure the jruby.jar is in place
-  jar "org.jruby:jruby-core:#{version}", :scope => 'test'
+  jar "org.jruby:jruby-core:#{version}", scope: 'test'
 
   extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 
-  repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+  repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
   # for testing out jruby-ossl before final release :
   # repository :id => 'gem-snaphots', :url => 'https://oss.sonatype.org/content/repositories/snapshots'
   # repository :id => 'gem-staging', :url => 'http://oss.sonatype.org/content/repositories/staging'
 
-  plugin( :clean,
-          :filesets => [ { :directory => '${basedir}/ruby/gems/shared/specifications/default',
-                           :includes => [ '*' ] },
-                         { :directory => '${basedir}/ruby/stdlib',
-                           :includes => [ 'org/**/*.jar' ] } ] )
+  plugin(:clean,
+         filesets: [{ directory: '${basedir}/ruby/gems/shared/specifications/default',
+                      includes: ['*'] },
+                    { directory: '${basedir}/ruby/stdlib',
+                      includes: ['org/**/*.jar'] }])
 
   # tell maven to download the respective gem artifacts
   default_gems.each do |name, version|
     # use provided scope so it is not a real dependency for runtime
-    dependency 'rubygems', name, version, :type => 'gem', :scope => :provided do
+    dependency 'rubygems', name, version, type: 'gem', scope: :provided do
       exclusion 'rubygems:jar-dependencies'
     end
   end
 
   bundled_gems.each do |name, version|
     # use provided scope so it is not a real dependency for runtime
-    dependency 'rubygems', name, version, :type => 'gem', :scope => :provided do
+    dependency 'rubygems', name, version, type: 'gem', scope: :provided do
       exclusion 'rubygems:jar-dependencies'
     end
   end
 
   default_gemnames = default_gems.collect(&:first)
-  all_gems     = default_gems + bundled_gems
+  all_gems = default_gems + bundled_gems
 
   plugin :dependency,
-    :useRepositoryLayout => true,
-    :outputDirectory => 'ruby/stdlib',
-    :excludeGroupIds => 'rubygems',
-    :includeScope => :provided do
-    execute_goal 'copy-dependencies', :phase => 'generate-resources'
+         useRepositoryLayout: true,
+         outputDirectory: 'ruby/stdlib',
+         excludeGroupIds: 'rubygems',
+         includeScope: :provided do
+    execute_goal 'copy-dependencies', phase: 'generate-resources'
   end
 
-  execute :install_gems, :'initialize' do |ctx|
+  execute :install_gems, :initialize do |ctx|
     require 'fileutils'
 
     log "using jruby #{JRUBY_VERSION}"
 
     target = ctx.project.build.directory.to_pathname
-    gem_home = File.join( target, 'rubygems' )
-    gems = File.join( gem_home, 'gems' )
-    specs = File.join( gem_home, 'specifications' )
-    cache = File.join( gem_home, 'cache' )
-    jruby_gems = File.join( ctx.project.basedir.to_pathname, 'ruby', 'gems', 'shared' )
-    bin_stubs = File.join( jruby_gems, 'gems' )
-    default_specs = File.join( jruby_gems, 'specifications', 'default' )
-    ruby_dir = File.join( ctx.project.basedir.to_pathname, 'ruby' )
-    stdlib_dir = File.join( ruby_dir, 'stdlib' )
+    gem_home = File.join(target, 'rubygems')
+    gems = File.join(gem_home, 'gems')
+    specs = File.join(gem_home, 'specifications')
+    cache = File.join(gem_home, 'cache')
+    jruby_gems = File.join(ctx.project.basedir.to_pathname, 'ruby', 'gems', 'shared')
+    bin_stubs = File.join(jruby_gems, 'gems')
+    default_specs = File.join(jruby_gems, 'specifications', 'default')
+    ruby_dir = File.join(ctx.project.basedir.to_pathname, 'ruby')
+    stdlib_dir = File.join(ruby_dir, 'stdlib')
     jruby_home = ctx.project.parent.basedir.to_pathname
 
-    FileUtils.mkdir_p( default_specs )
+    FileUtils.mkdir_p(default_specs)
 
     # now we can require the rubygems staff
     require 'rubygems/installer'
@@ -230,7 +233,7 @@ project 'JRuby Lib Setup' do
     ENV_JAVA['jars.skip'] = 'true'
 
     # bin location for global binstubs
-    global_bin = File.join( jruby_home, "bin" )
+    global_bin = File.join(jruby_home, 'bin')
 
     # force Ruby command to "jruby" for the generated Windows bat files since we install using 9.1.17.0 jar file
     Gem.singleton_class.send(:define_method, :ruby) do
@@ -238,35 +241,39 @@ project 'JRuby Lib Setup' do
     end
 
     # Disable extension build for gems (none of ours require a build)
-    class Gem::Ext::Builder
-      def build_extensions
-        return if @spec.extensions.empty?
+    module Gem
+      module Ext
+        class Builder
+          def build_extensions
+            return if @spec.extensions.empty?
 
-        say "Skipping native extensions."
+            say 'Skipping native extensions.'
 
-        FileUtils.mkdir_p File.dirname(@spec.gem_build_complete_path)
-        FileUtils.touch @spec.gem_build_complete_path
+            FileUtils.mkdir_p File.dirname(@spec.gem_build_complete_path)
+            FileUtils.touch @spec.gem_build_complete_path
+          end
+        end
       end
     end
 
     ctx.project.artifacts.select do |a|
-      a.group_id == 'rubygems' || a.group_id == 'org.jruby.gems'
+      ['rubygems', 'org.jruby.gems'].include?(a.group_id)
     end.each do |a|
-      ghome = default_gemnames.member?( a.artifact_id ) ? gem_home : jruby_gems
-      if Dir[ File.join( ghome, 'cache', File.basename( a.file.to_pathname ).sub( /.gem/, '*.gem' ) ) ].empty?
-        log a.file.to_pathname
-        installer = Gem::Installer.new( Gem::Package.new(a.file.to_pathname),
-                                        wrappers: true,
-                                        ignore_dependencies: true,
-                                        install_dir: ghome,
-                                        env_shebang: true )
-        def installer.ensure_required_ruby_version_met; end
-        installer.install
-      end
+      ghome = default_gemnames.member?(a.artifact_id) ? gem_home : jruby_gems
+      next unless Dir[File.join(ghome, 'cache', File.basename(a.file.to_pathname).sub(/.gem/, '*.gem'))].empty?
+
+      log a.file.to_pathname
+      installer = Gem::Installer.new(Gem::Package.new(a.file.to_pathname),
+                                     wrappers: true,
+                                     ignore_dependencies: true,
+                                     install_dir: ghome,
+                                     env_shebang: true)
+      def installer.ensure_required_ruby_version_met; end
+      installer.install
     end
 
     copy_gem_executables = lambda do |spec, gem_home|
-      if !spec.executables.empty?
+      unless spec.executables.empty?
         bin_source = Gem.bindir(gem_home) # Gem::Installer generated bin scripts here
         spec.executables.each do |file|
           source = File.expand_path(file, bin_source)
@@ -279,118 +286,129 @@ project 'JRuby Lib Setup' do
 
     default_gems.each do |name, version, options|
       version = ctx.project.properties.get(version[2..-2]) || version # resolve ${xyz.version} declarations
-      version = version.sub( /-SNAPSHOT/, '' )
+      version = version.sub(/-SNAPSHOT/, '')
       gem_name = "#{name}-#{version}"
       options = { bin: true, spec: true }.merge(options || {})
 
       # install the gem unless already installed
-      if Dir[ File.join( default_specs, "#{gem_name}*.gemspec" ) ].empty?
+      next unless Dir[File.join(default_specs, "#{gem_name}*.gemspec")].empty?
 
-        log
-        log "--- gem #{gem_name} ---"
+      log
+      log "--- gem #{gem_name} ---"
 
-        # copy the gem content to stdlib
+      # copy the gem content to stdlib
 
-        log "copy gem content to #{stdlib_dir}"
+      log "copy gem content to #{stdlib_dir}"
 
-        spec = Gem::Package.new( Dir[ File.join( cache, "#{gem_name}*.gem" ) ].first ).spec
+      spec = Gem::Package.new(Dir[File.join(cache, "#{gem_name}*.gem")].first).spec
 
-        require_paths = options[:require_paths] || spec.require_paths
+      require_paths = options[:require_paths] || spec.require_paths
 
-        require_paths.each do |require_path|
-          require_base = File.join( gems, "#{gem_name}*", require_path )
-          require_files = File.join( require_base, '*' )
+      require_paths.each do |require_path|
+        require_base = File.join(gems, "#{gem_name}*", require_path)
+        require_files = File.join(require_base, '*')
 
-          # copy in new ones and mark writable for future updates (e.g. minitest)
-          stdlib_locs = Dir[ require_files ].map do |f|
-            log " copying: #{f} to #{stdlib_dir}"# if $VERBOSE
-            FileUtils.cp_r( f, stdlib_dir )
+        # copy in new ones and mark writable for future updates (e.g. minitest)
+        stdlib_locs = Dir[require_files].map do |f|
+          log " copying: #{f} to #{stdlib_dir}" # if $VERBOSE
+          FileUtils.cp_r(f, stdlib_dir)
 
-            stdlib_loc = f.sub( File.dirname(f), stdlib_dir )
-            File.directory?(stdlib_loc) ? Dir[stdlib_loc + "/*"].to_a : stdlib_loc
-          end
-          stdlib_locs.flatten!
-
-          # fix permissions on copied files
-          stdlib_locs.each do |f|
-            next if File.writable? f
-            log " fixing permissions: #{f}" if $VERBOSE
-            # TODO: better way to just set it writable without changing all modes?
-            FileUtils.chmod_R(0644, f)
-          end
+          stdlib_loc = f.sub(File.dirname(f), stdlib_dir)
+          File.directory?(stdlib_loc) ? Dir["#{stdlib_loc}/*"].to_a : stdlib_loc
         end
+        stdlib_locs.flatten!
 
-        # get gemspec
-        specfile_wildcard = "#{gem_name}*.gemspec"
-        specfile = Dir[ File.join( specs,  specfile_wildcard ) ].first
+        # fix permissions on copied files
+        stdlib_locs.each do |f|
+          next if File.writable? f
 
-        unless specfile
-          raise Errno::ENOENT, "gemspec #{specfile_wildcard} not found in #{specs}; dependency unspecified in lib/pom.xml?"
+          log " fixing permissions: #{f}" if $VERBOSE
+          # TODO: better way to just set it writable without changing all modes?
+          FileUtils.chmod_R(0o644, f)
         end
+      end
 
-        # copy bin files if the gem has any
-        copy_gem_executables.call(spec, gem_home) if options[:bin]
+      # get gemspec
+      specfile_wildcard = "#{gem_name}*.gemspec"
+      specfile = Dir[File.join(specs, specfile_wildcard)].first
 
-        # TODO: try avoiding these binstub of gems - should use a full gem location
-        spec.executables.each do |f|
-          bin = Dir.glob(File.join( gems, "#{gem_name}*", spec.bindir ))[0]
-          source = File.join( bin, f )
-          target = File.join( bin_stubs, source.sub( gems, '' ) )
-          log "copy #{f} to #{target}"
-          FileUtils.mkdir_p( File.dirname( target ) )
-          FileUtils.cp_r( source, target )
-        end
+      unless specfile
+        raise Errno::ENOENT,
+              "gemspec #{specfile_wildcard} not found in #{specs}; dependency unspecified in lib/pom.xml?"
+      end
 
-        if options[:spec]
-          specname = File.basename( specfile )
-          log "copy to specifications/default: #{specname}"
-          File.open( File.join( default_specs, specname ), 'w' ) do |f|
-            f.print( spec.to_ruby )
-          end
-        end
+      # copy bin files if the gem has any
+      copy_gem_executables.call(spec, gem_home) if options[:bin]
+
+      # TODO: try avoiding these binstub of gems - should use a full gem location
+      spec.executables.each do |f|
+        bin = Dir.glob(File.join(gems, "#{gem_name}*", spec.bindir))[0]
+        source = File.join(bin, f)
+        target = File.join(bin_stubs, source.sub(gems, ''))
+        log "copy #{f} to #{target}"
+        FileUtils.mkdir_p(File.dirname(target))
+        FileUtils.cp_r(source, target)
+      end
+
+      next unless options[:spec]
+
+      specname = File.basename(specfile)
+      log "copy to specifications/default: #{specname}"
+      File.open(File.join(default_specs, specname), 'w') do |f|
+        f.print(spec.to_ruby)
       end
     end
 
     bundled_gems.each do |name, version| # copy bin files for bundled gems (e.g. rake) as well
       version = ctx.project.properties.get(version[2..-2]) || version # e.g. resolve '${rake.version}' from properties
       gem_name = "#{name}-#{version}"
-      spec = Gem::Package.new( Dir[ File.join(jruby_gems, "cache", "#{gem_name}*.gem" ) ].first ).spec
+      spec = Gem::Package.new(Dir[File.join(jruby_gems, 'cache', "#{gem_name}*.gem")].first).spec
       copy_gem_executables.call(spec, jruby_gems)
     end
 
     # patch jruby-openssl - remove file which should be only inside gem
     # use this instead of FileUtils.rm_f - issue #1698
-    f = File.join( stdlib_dir, 'jruby-openssl.rb' )
-    File.delete( f ) if File.exists?( f )
+    f = File.join(stdlib_dir, 'jruby-openssl.rb')
+    File.delete(f) if File.exist?(f)
 
     # we do not want rubygems_plugin.rb within jruby
-    f = File.join( stdlib_dir, 'rubygems_plugin.rb' )
-    File.delete( f ) if File.exists?( f )
+    f = File.join(stdlib_dir, 'rubygems_plugin.rb')
+    File.delete(f) if File.exist?(f)
 
     # axiom-types appears to be a dead project but a transitive dep we still
     # have.  It contains unreadable files which messes up some upstream
     # maintainers like OpenBSD (see #1989).
     hack = File.join jruby_gems, 'gems', 'axiom-types-*'
-    (Dir[File.join(hack, '**/*')] + Dir[File.join(hack, '**/.*' )]).each do |f|
-      FileUtils.chmod 'u+rw,go+r' rescue nil if File.file?(f)
+    (Dir[File.join(hack, '**/*')] + Dir[File.join(hack, '**/.*')]).each do |f|
+      next unless File.file?(f)
+
+      begin
+        FileUtils.chmod 'u+rw,go+r'
+      rescue StandardError
+        nil
+      end
     end
   end
 
-  execute( 'fix shebang on gem bin files and add *.bat files',
-           'generate-resources' ) do |ctx|
-
+  execute('fix shebang on gem bin files and add *.bat files',
+          'generate-resources') do |ctx|
     log 'generating missing .bat files'
     jruby_home = ctx.project.parent.basedir.to_pathname
-    Dir[File.join( jruby_home, 'bin', '*' )].each do |fn|
+    Dir[File.join(jruby_home, 'bin', '*')].each do |fn|
       next unless File.file?(fn)
       next if fn =~ /.bat$/
       next if File.exist?("#{fn}.bat")
-      next unless File.open(fn, 'r', :internal_encoding => 'ASCII-8BIT') do |io|
-        line = io.readline rescue ""
+      next unless File.open(fn, 'r', internal_encoding: 'ASCII-8BIT') do |io|
+        line = begin
+          io.readline
+        rescue StandardError
+          ''
+        end
         line =~ /^#!.*ruby/
       end
+
       log " generating #{File.basename(fn)}.bat" if $VERBOSE
-      File.open("#{fn}.bat", "wb") do |f|
+      File.open("#{fn}.bat", 'wb') do |f|
         f.print "@ECHO OFF\r\n"
         f.print "@\"%~dp0jruby.exe\" -S #{File.basename(fn)} %*\r\n"
       end
@@ -398,27 +416,27 @@ project 'JRuby Lib Setup' do
   end
 
   execute 'jrubydir', 'prepare-package' do |ctx|
-    require( ctx.project.basedir.to_pathname + '/../core/src/main/ruby/jruby/commands.rb' )
-    JRuby::Commands.generate_dir_info( ctx.project.build.output_directory.to_pathname + '/META-INF/jruby.home' )
+    require("#{ctx.project.basedir.to_pathname}/../core/src/main/ruby/jruby/commands.rb")
+    JRuby::Commands.generate_dir_info("#{ctx.project.build.output_directory.to_pathname}/META-INF/jruby.home")
   end
 
   # we have no sources and attach an empty jar later in the build to
   # satisfy oss.sonatype.org upload
 
-  plugin( :source, 'skipSource' => 'true' )
+  plugin(:source, skipSource: 'true')
 
   # this plugin is configured to attach empty jars for sources and javadocs
-  plugin( 'org.codehaus.mojo:build-helper-maven-plugin' )
+  plugin('org.codehaus.mojo:build-helper-maven-plugin')
 
   build do
     resource do
       directory '${gem.home}'
       includes [
-                   'specifications/default/*',
-                   *all_gems.map {|name,version| "specifications/#{name}-#{version}*"},
-                   *all_gems.map {|name,version| "gems/#{name}-#{version}*/**/*"},
-                   *all_gems.map {|name,version| "cache/#{name}-#{version}*"},
-               ]
+        'specifications/default/*',
+        *all_gems.map { |name, version| "specifications/#{name}-#{version}*" },
+        *all_gems.map { |name, version| "gems/#{name}-#{version}*/**/*" },
+        *all_gems.map { |name, version| "cache/#{name}-#{version}*" }
+      ]
       target_path '${jruby.complete.gems}'
     end
 
@@ -426,14 +444,14 @@ project 'JRuby Lib Setup' do
       directory '${basedir}/..'
       includes 'bin/*', 'lib/ruby/include/**', 'lib/ruby/stdlib/**'
       excludes 'bin/ruby', 'bin/jruby', 'bin/jruby*_*', 'bin/jruby*-*', '**/.*',
-        'lib/ruby/stdlib/rubygems/defaults/jruby_native.rb',
-        'lib/ruby/stdlib/gauntlet*.rb' # gauntlet_rdoc.rb, gauntlet_rubygems.rb
+               'lib/ruby/stdlib/rubygems/defaults/jruby_native.rb',
+               'lib/ruby/stdlib/gauntlet*.rb' # gauntlet_rdoc.rb, gauntlet_rubygems.rb
       target_path '${jruby.complete.home}'
     end
 
     resource do
       directory '${project.basedir}/..'
-      includes [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY', 'VERSION' ]
+      includes ['BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY', 'VERSION']
       target_path '${project.build.outputDirectory}/META-INF/'
     end
   end

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -241,18 +241,15 @@ project 'JRuby Lib Setup' do
     end
 
     # Disable extension build for gems (none of ours require a build)
-    module Gem
-      module Ext
-        class Builder
-          def build_extensions
-            return if @spec.extensions.empty?
+    # rubocop:disable Style/ClassAndModuleChildren
+    class Gem::Ext::Builder
+      def build_extensions
+        return if @spec.extensions.empty?
 
-            say 'Skipping native extensions.'
+        say 'Skipping native extensions.'
 
-            FileUtils.mkdir_p File.dirname(@spec.gem_build_complete_path)
-            FileUtils.touch @spec.gem_build_complete_path
-          end
-        end
+        FileUtils.mkdir_p File.dirname(@spec.gem_build_complete_path)
+        FileUtils.touch @spec.gem_build_complete_path
       end
     end
 

--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -1,148 +1,147 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 project 'JRuby Complete' do
-
   version = ENV['JRUBY_VERSION'] ||
-    File.read( File.join( basedir, '..', '..', 'VERSION' ) ).strip
+            File.read(File.join(basedir, '..', '..', 'VERSION')).strip
 
   model_version '4.0.0'
   id "org.jruby:jruby-complete:#{version}"
   inherit "org.jruby:jruby-artifacts:#{version}"
   packaging 'bundle'
 
-
   extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 
-  plugin_repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+  plugin_repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
-  properties( 'polyglot.dump.pom' => 'pom.xml',
-              'polyglot.dump.readonly' => true,
-              'jruby.home' => '${basedir}/../..',
-              'main.basedir' => '${project.parent.parent.basedir}',
-              'jruby.complete.home' => '${project.build.outputDirectory}/META-INF/jruby.home' )
+  properties("polyglot.dump.pom": 'pom.xml',
+             "polyglot.dump.readonly": true,
+             "jruby.home": '${basedir}/../..',
+             "main.basedir": '${project.parent.parent.basedir}',
+             "jruby.complete.home": '${project.build.outputDirectory}/META-INF/jruby.home')
 
   scope :provided do
     jar 'org.jruby:jruby-core:${project.version}' do
       # this needs to match the Embed-Dependency on the maven-bundle-plugin
       exclusion 'com.github.jnr:jnr-ffi'
       exclusion 'me.qmx.jitescript:jitescript'
-      # HACK workaround a bug in maven + ruby-dsl + felix-plugin
-      ['asm', 'asm-commons', 'asm-tree', 'asm-analysis', 'asm-util' ].each do |e|
+      # HACK: workaround a bug in maven + ruby-dsl + felix-plugin
+      %w[asm asm-commons asm-tree asm-analysis asm-util].each do |e|
         exclusion "org.ow2.asm:#{e}"
       end
-      exclusion "org.jruby:jruby-base"
+      exclusion 'org.jruby:jruby-base'
     end
     jar 'org.jruby:jruby-stdlib:${project.version}'
   end
 
-  plugin( 'org.apache.felix:maven-bundle-plugin',
-          :archive => {
-            :manifest => {
-              :mainClass => 'org.jruby.Main'
-            },
-            manifestEntries: {
-              'Automatic-Module-Name' => 'org.jruby.complete',
-              'Add-Opens' => 'java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management'
-            }
-          },
-          :instructions => {
-            'Export-Package' => 'org.jruby.*;version=${project.version}',
-            'Import-Package' => '!org.jruby.*, *;resolution:=optional',
-            'DynamicImport-Package' => 'javax.*',
-            'Private-Package' => '*,.',
-            'Bundle-Name' => 'JRuby ${project.version}',
-            'Bundle-Description' => 'JRuby ${project.version} OSGi bundle',
-            'Bundle-SymbolicName' => 'org.jruby.jruby',
-            # the artifactId exclusion needs to match the jruby-core from above
-            'Embed-Dependency' => '*;type=jar;scope=provided;inline=true;artifactId=!jnr-ffi|jitescript',
-            'Embed-Transitive' => true
-          } ) do
-    # TODO fix DSL
+  plugin('org.apache.felix:maven-bundle-plugin',
+         archive: {
+           manifest: {
+             mainClass: 'org.jruby.Main'
+           },
+           manifestEntries: {
+             "Automatic-Module-Name": 'org.jruby.complete',
+             "Add-Opens": 'java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management'
+           }
+         },
+         instructions: {
+           "Export-Package": 'org.jruby.*;version=${project.version}',
+           "Import-Package": '!org.jruby.*, *;resolution:=optional',
+           "DynamicImport-Package": 'javax.*',
+           "Private-Package": '*,.',
+           "Bundle-Name": 'JRuby ${project.version}',
+           "Bundle-Description": 'JRuby ${project.version} OSGi bundle',
+           "Bundle-SymbolicName": 'org.jruby.jruby',
+           # the artifactId exclusion needs to match the jruby-core from above
+           "Embed-Dependency": '*;type=jar;scope=provided;inline=true;artifactId=!jnr-ffi|jitescript',
+           "Embed-Transitive": true
+         }) do
+    # TODO: fix DSL
     @current.extensions = true
   end
 
-  plugin( 'org.codehaus.mojo:truezip-maven-plugin', '1.2' ) do
+  plugin('org.codehaus.mojo:truezip-maven-plugin', '1.2') do
     execute_goals(:remove,
                   phase: :package,
-                  filesets: [ { directory: '${build.directory}/${project.artifactId}-${project.version}.jar',
-                                includes: ['module-info.class'] } ]
-                 )
+                  filesets: [{ directory: '${build.directory}/${project.artifactId}-${project.version}.jar',
+                               includes: ['module-info.class'] }])
   end
 
-  plugin( :invoker )
+  plugin(:invoker)
 
   # we have no sources and attach the sources and javadocs from jruby-core
   # later in the build so IDE can use them
-  plugin( :source, 'skipSource' =>  'true' )
+  plugin(:source, skipSource: 'true')
 
-  execute 'setup other osgi frameworks', :phase => 'pre-integration-test' do |ctx|
+  execute 'setup other osgi frameworks', phase: 'pre-integration-test' do |ctx|
     require 'fileutils'
-    source = File.join( ctx.basedir.to_pathname, 'src', 'templates', 'osgi_many_bundles_with_embedded_gems' )
-    [ 'knoplerfish', 'equinox-3.6', 'equinox-3.7', 'felix-3.2', 'felix-4.4' ].each do |m|
-      target = File.join( ctx.basedir.to_pathname, 'src', 'it', 'osgi_many_bundles_with_embedded_gems_' + m )
-      FileUtils.rm_rf( target )
-      FileUtils.cp_r( source, target )
-      File.open( File.join( target, 'invoker.properties' ), 'w' ) do |f|
-        f.puts 'invoker.profiles = ' + m
+    source = File.join(ctx.basedir.to_pathname, 'src', 'templates', 'osgi_many_bundles_with_embedded_gems')
+    ['knoplerfish', 'equinox-3.6', 'equinox-3.7', 'felix-3.2', 'felix-4.4'].each do |m|
+      target = File.join(ctx.basedir.to_pathname, 'src', 'it', "osgi_many_bundles_with_embedded_gems_#{m}")
+      FileUtils.rm_rf(target)
+      FileUtils.cp_r(source, target)
+      File.open(File.join(target, 'invoker.properties'), 'w') do |f|
+        f.puts "invoker.profiles = #{m}"
       end
     end
   end
 
-  plugin( :clean ) do
-    execute_goals( :clean,
-                   :phase => :clean,
-                   :id => 'clean-extra-osgi-ITs',
-                   :filesets => [ { :directory => '${basedir}/src/it',
-                                    :includes => ['osgi*/**'] } ],
-                   :failOnError => false )
+  plugin(:clean) do
+    execute_goals(:clean,
+                  phase: :clean,
+                  id: 'clean-extra-osgi-ITs',
+                  filesets: [{ directory: '${basedir}/src/it',
+                               includes: ['osgi*/**'] }],
+                  failOnError: false)
   end
 
-  plugin( 'net.ju-n.maven.plugins:checksum-maven-plugin' )
+  plugin('net.ju-n.maven.plugins:checksum-maven-plugin')
 
-  ['sonatype-oss-release', 'snapshots'].each do |name|
+  %w[sonatype-oss-release snapshots].each do |name|
     profile name do
-
       # use the javadocs and sources from jruby-core !!!
       phase :package do
-        set = ['sources', 'javadoc' ]
+        set = %w[sources javadoc]
         plugin :dependency do
           items = set.collect do |classifier|
-            { 'groupId' =>  '${project.groupId}',
-              'artifactId' =>  'jruby-base',
-              'version' =>  '${project.version}',
-              'classifier' =>  classifier,
-              'overWrite' =>  'false',
-              'outputDirectory' =>  '${project.build.directory}' }
+            { groupId: '${project.groupId}',
+              artifactId: 'jruby-base',
+              version: '${project.version}',
+              classifier: classifier,
+              overWrite: 'false',
+              outputDirectory: '${project.build.directory}' }
           end
-          execute_goals( 'copy',
-                         :id => 'copy javadocs and sources from jruby-base',
-                         'artifactItems' => items )
+          execute_goals('copy',
+                        id: 'copy javadocs and sources from jruby-base',
+                        artifactItems: items)
         end
 
         plugin 'org.codehaus.mojo:build-helper-maven-plugin' do
           artifacts = set.collect do |classifier|
-            { 'file' =>  "${project.build.directory}/jruby-base-${project.version}-#{classifier}.jar", 'classifier' =>  classifier }
+            { file: "${project.build.directory}/jruby-base-${project.version}-#{classifier}.jar",
+              classifier: classifier }
           end
-          execute_goals( 'attach-artifact',
-                         :id => 'attach-artifacts',
-                         'artifacts' => artifacts )
+          execute_goals('attach-artifact',
+                        id: 'attach-artifacts',
+                        artifacts: artifacts)
 
-          execute_goals( 'attach-artifact',
-                         :id => 'attach-checksums',
-                         'artifacts' => [ { file: '${project.build.directory}/jruby-complete-${project.version}.jar.sha256',
-                                            type: 'jar.sha256'},
-                                          { file: '${project.build.directory}/jruby-complete-${project.version}.jar.sha512',
-                                            type: 'jar.sha512'} ] )
-
+          execute_goals('attach-artifact',
+                        id: 'attach-checksums',
+                        artifacts: [{ file: '${project.build.directory}/jruby-complete-${project.version}.jar.sha256',
+                                      type: 'jar.sha256' },
+                                    { file: '${project.build.directory}/jruby-complete-${project.version}.jar.sha512',
+                                      type: 'jar.sha512' }])
         end
       end
     end
   end
 
-  profile :id => :jdk8 do
+  profile id: :jdk8 do
     activation do
       jdk '1.8'
     end
-    plugin :invoker, :pomExcludes => ['osgi_many_bundles_with_embedded_gems_felix-3.2/pom.xml', '${its.j2ee}', '${its.osgi}']
+    plugin :invoker,
+           pomExcludes: ['osgi_many_bundles_with_embedded_gems_felix-3.2/pom.xml', '${its.j2ee}', '${its.osgi}']
   end
 end

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/gems-bundle/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/gems-bundle/pom.rb
@@ -1,28 +1,30 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 gemfile
 
 model.repositories.clear
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
 id 'org.jruby.osgi:gems-bundle', '1.0'
 
 packaging 'bundle'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            # needed bundle plugin
-            'polyglot.dump.pom' => 'pom.xml' )
+properties("jruby.plugins.version": '3.0.5',
+           # needed bundle plugin
+           "polyglot.dump.pom": 'pom.xml')
 
-jruby_plugin! :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0'
+jruby_plugin! :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0'
 
-plugin( 'org.apache.felix:maven-bundle-plugin', '2.4.0',
-        :instructions => {
-          'Export-Package' => 'org.jruby.osgi.gems',
-          'Include-Resource' => '{maven-resources}'
-        } ) do
-  # TODO fix DSL
+plugin('org.apache.felix:maven-bundle-plugin', '2.4.0',
+       instructions: {
+         "Export-Package": 'org.jruby.osgi.gems',
+         "Include-Resource": '{maven-resources}'
+       }) do
+  # TODO: fix DSL
   @current.extensions = true
 end

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/pom.rb
@@ -1,11 +1,13 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 id 'org.jruby.test:osgi-complete:1'
 
 packaging :pom
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            'project.build.sourceEncoding' => 'utf-8' )
+properties("jruby.plugins.version": '3.0.5',
+           "project.build.sourceEncoding": 'utf-8')
 
-modules [ 'gems-bundle', 'scripts-bundle', 'test' ]
+modules %w[gems-bundle scripts-bundle test]

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/scripts-bundle/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/scripts-bundle/pom.rb
@@ -1,20 +1,23 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 id 'org.jruby.osgi:scripts-bundle', '1.0'
 
 packaging 'bundle'
 
 properties( # needed bundle plugin
-            'polyglot.dump.pom' => 'pom.xml' )
+  "polyglot.dump.pom": 'pom.xml'
+)
 
 # add some ruby scripts to bundle
-resource :directory => 'src/main/ruby'
+resource directory: 'src/main/ruby'
 
-plugin( 'org.apache.felix:maven-bundle-plugin', '2.4.0',
-        :instructions => {
-          'Export-Package' => 'org.jruby.osgi.scripts',
-          'Include-Resource' => '{maven-resources}'
-        } ) do
-  # TODO fix DSL
+plugin('org.apache.felix:maven-bundle-plugin', '2.4.0',
+       instructions: {
+         "Export-Package": 'org.jruby.osgi.scripts',
+         "Include-Resource": '{maven-resources}'
+       }) do
+  # TODO: fix DSL
   @current.extensions = true
 end

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/test/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/test/pom.rb
@@ -1,15 +1,17 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
 
-properties( 'exam.version' => '3.0.3',
-            'url.version' => '1.5.2',
-            'logback.version' => '1.0.13' )
+# -*- mode: ruby -*-
+
+properties("exam.version": '3.0.3',
+           "url.version": '1.5.2',
+           "logback.version": '1.0.13')
 
 bundle 'org.jruby:jruby-complete', '${jruby.version}'
 bundle 'org.jruby.osgi:gems-bundle', '1.0'
 bundle 'org.jruby.osgi:scripts-bundle', '1.0'
 
-plugin( 'org.apache.felix:maven-bundle-plugin', '2.4.0' ) do
-  # TODO fix DSL
+plugin('org.apache.felix:maven-bundle-plugin', '2.4.0') do
+  # TODO: fix DSL
   @current.extensions = true
 end
 
@@ -25,21 +27,21 @@ scope :test do
   jar 'ch.qos.logback:logback-core', '${logback.version}'
   jar 'ch.qos.logback:logback-classic', '${logback.version}'
 
-  profile :id => 'equinox-3.6' do
+  profile id: 'equinox-3.6' do
     jar 'org.eclipse.osgi:org.eclipse.osgi:3.6.0.v20100517'
   end
-  profile :id => 'equinox-3.7' do
+  profile id: 'equinox-3.7' do
     jar 'org.eclipse.osgi:org.eclipse.osgi:3.7.1'
   end
-  profile :id => 'felix-3.2' do
+  profile id: 'felix-3.2' do
     jar 'org.apache.felix:org.apache.felix.framework:3.2.2'
   end
-  profile :id => 'felix-4.4' do
+  profile id: 'felix-4.4' do
     jar 'org.apache.felix:org.apache.felix.framework:4.4.1'
   end
-  profile :id => 'knoplerfish' do
-    repository( :id => :knoplerfish, 
-                :url => 'http://www.knopflerfish.org/maven2' )
+  profile id: 'knoplerfish' do
+    repository(id: :knoplerfish,
+               url: 'http://www.knopflerfish.org/maven2')
     jar 'org.knopflerfish:framework:5.1.6'
   end
 end

--- a/maven/jruby-dist/pom.rb
+++ b/maven/jruby-dist/pom.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require 'rubygems/package'
 require 'fileutils'
 project 'JRuby Dist' do
-
   version = ENV['JRUBY_VERSION'] ||
-    File.read( File.join( basedir, '..', '..', 'VERSION' ) ).strip
+            File.read(File.join(basedir, '..', '..', 'VERSION')).strip
 
   model_version '4.0.0'
   id "org.jruby:jruby-dist:#{version}"
@@ -11,67 +12,69 @@ project 'JRuby Dist' do
   packaging 'pom'
 
   phase 'prepare-package' do
-
     plugin :dependency do
-      execute_goals( 'unpack',
-                     :id => 'unpack jruby-stdlib',
-                     'stripVersion' =>  'true',
-                     'artifactItems' => [ { 'groupId' =>  'org.jruby',
-                                            'artifactId' =>  'jruby-stdlib',
-                                            'version' =>  '${project.version}',
-                                            'type' =>  'jar',
-                                            'overWrite' =>  'false',
-                                            'outputDirectory' =>  '${project.build.directory}' } ] )
+      execute_goals('unpack',
+                    id: 'unpack jruby-stdlib',
+                    stripVersion: 'true',
+                    artifactItems: [{ groupId: 'org.jruby',
+                                      artifactId: 'jruby-stdlib',
+                                      version: '${project.version}',
+                                      type: 'jar',
+                                      overWrite: 'false',
+                                      outputDirectory: '${project.build.directory}' }])
     end
 
     execute :fix_executable_bits do |ctx|
-      Dir[ File.join( ctx.project.build.directory.to_pathname,
-                      'META-INF/jruby.home/bin/*' ) ].each do |f|
-        unless f.match /.(bat|exe|dll)$/
-          puts f
-          File.chmod( 0755, f ) rescue nil
+      Dir[ File.join(ctx.project.build.directory.to_pathname,
+                     'META-INF/jruby.home/bin/*') ].each do |f|
+        next if f.match(/.(bat|exe|dll)$/)
+
+        puts f
+        begin
+          File.chmod(0o755, f)
+        rescue StandardError
+          nil
         end
       end
     end
   end
 
   phase :package do
-    plugin( :assembly, '2.4',
-            :recompressZippedFiles => true,
-            :tarLongFileMode =>  'gnu' ) do
-      execute_goals( :single, :id => 'bin.tar.gz and bin.zip',
-                     :descriptors => [ 'src/main/assembly/bin.xml' ] )
+    plugin(:assembly, '2.4',
+           recompressZippedFiles: true,
+           tarLongFileMode: 'gnu') do
+      execute_goals(:single, id: 'bin.tar.gz and bin.zip',
+                             descriptors: ['src/main/assembly/bin.xml'])
     end
   end
 
-  plugin( :invoker )
+  plugin(:invoker)
 
-  plugin( 'net.ju-n.maven.plugins:checksum-maven-plugin' )
+  plugin('net.ju-n.maven.plugins:checksum-maven-plugin')
 
   profile 'sonatype-oss-release' do
-
     plugin 'org.codehaus.mojo:build-helper-maven-plugin' do
-      execute_goals( 'attach-artifact',
-                     id: 'attach-checksums',
-                     phase: :package,
-                     artifacts: [ { file: '${project.build.directory}/jruby-dist-${project.version}-bin.tar.gz.sha256',
-                                    classifier: :bin,
-                                    type: 'tar.gz.sha256'},
-                                  { file: '${project.build.directory}/jruby-dist-${project.version}-bin.tar.gz.sha512',
-                                    classifier: :bin,
-                                    type: 'tar.gz.sha512'},
-                                  { file: '${project.build.directory}/jruby-dist-${project.version}-bin.zip.sha256',
-                                    classifier: :bin,
-                                    type: 'zip.sha256'},
-                                  { file: '${project.build.directory}/jruby-dist-${project.version}-bin.zip.sha512',
-                                    classifier: :bin,
-                                    type: 'zip.sha512'},
-                                  { file: '${project.build.directory}/jruby-dist-${project.version}-src.zip.sha256',
-                                    classifier: :src,
-                                    type: 'zip.sha256'},
-                                  { file: '${project.build.directory}/jruby-dist-${project.version}-src.zip.sha512',
-                                    classifier: :src,
-                                    type: 'zip.sha512'} ] )
+      execute_goals('attach-artifact',
+                    id: 'attach-checksums',
+                    phase: :package,
+                    artifacts: [{ file: '${project.build.directory}/jruby-dist-${project.version}-bin.tar.gz.sha256',
+                                  classifier: :bin,
+                                  type: 'tar.gz.sha256' },
+                                { file: '${project.build.directory}/jruby-dist-${project.version}-bin.tar.gz.sha512',
+                                  classifier: :bin,
+                                  type: 'tar.gz.sha512' },
+                                { file: '${project.build.directory}/jruby-dist-${project.version}-bin.zip.sha256',
+                                  classifier: :bin,
+                                  type: 'zip.sha256' },
+                                { file: '${project.build.directory}/jruby-dist-${project.version}-bin.zip.sha512',
+                                  classifier: :bin,
+                                  type: 'zip.sha512' },
+                                { file: '${project.build.directory}/jruby-dist-${project.version}-src.zip.sha256',
+                                  classifier: :src,
+                                  type: 'zip.sha256' },
+                                { file: '${project.build.directory}/jruby-dist-${project.version}-src.zip.sha512',
+                                  classifier: :src,
+                                  type: 'zip.sha512' }])
     end
   end
 
@@ -81,9 +84,8 @@ project 'JRuby Dist' do
   # the source packages itself !!
 
   profile 'source dist' do
-
     activation do
-      file( :exists => '../../.git' )
+      file(exists: '../../.git')
     end
 
     phase 'prepare-package' do
@@ -94,20 +96,19 @@ project 'JRuby Dist' do
 
         basefile = "#{ctx.project.build.directory}/#{ctx.project.artifactId}-#{ctx.project.version}-src"
 
-        FileUtils.cd( File.join( ctx.project.basedir.to_s, '..', '..' ) ) do
-          [ 'tar.gz', 'zip' ].each do |format|
+        FileUtils.cd(File.join(ctx.project.basedir.to_s, '..', '..')) do
+          ['tar.gz', 'zip'].each do |format|
             puts "create #{basefile}.#{format}"
-            system( "git archive --prefix 'jruby-#{ctx.project.version}/' --format #{format} #{revision} . -o #{basefile}.#{format}" ) || raise( "error creating #{format}-file" )
+            system("git archive --prefix 'jruby-#{ctx.project.version}/' --format #{format} #{revision} . -o #{basefile}.#{format}") || raise("error creating #{format}-file")
           end
         end
       end
       plugin 'org.codehaus.mojo:build-helper-maven-plugin' do
-        execute_goal( 'attach-artifact',
-                      :id => 'attach-artifacts',
-                      :artifacts => [ { :file => '${project.build.directory}/${project.build.finalName}-src.zip',
-                                        :type => 'zip',
-                                        :classifier => 'src' } ] )
-
+        execute_goal('attach-artifact',
+                     id: 'attach-artifacts',
+                     artifacts: [{ file: '${project.build.directory}/${project.build.finalName}-src.zip',
+                                   type: 'zip',
+                                   classifier: 'src' }])
       end
     end
   end

--- a/maven/jruby-jars/src/it/extended/pom.rb
+++ b/maven/jruby-jars/src/it/extended/pom.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 # jruby scripting container
 jar 'org.jruby:jruby-core', '${jruby.version}'
 jar 'org.jruby:jruby-stdlib', '${jruby.version}'
 
 # unit tests
-jar 'junit:junit', '4.8.2', :scope => :test
+jar 'junit:junit', '4.8.2', scope: :test
 
-plugin :surefire, '2.15', :reuseForks => false, :additionalClasspathElements => [ '${basedir}/../../../../../core/target/test-classes', '${basedir}/../../../../../test/target/test-classes' ]
+plugin :surefire, '2.15', reuseForks: false,
+                          additionalClasspathElements: ['${basedir}/../../../../../core/target/test-classes', '${basedir}/../../../../../test/target/test-classes']

--- a/maven/jruby/pom.rb
+++ b/maven/jruby/pom.rb
@@ -1,7 +1,8 @@
-project 'JRuby Main Maven Artifact' do
+# frozen_string_literal: true
 
+project 'JRuby Main Maven Artifact' do
   version = ENV['JRUBY_VERSION'] ||
-    File.read( File.join( basedir, '..', '..', 'VERSION' ) ).strip
+            File.read(File.join(basedir, '..', '..', 'VERSION')).strip
 
   model_version '4.0.0'
   id "org.jruby:jruby:#{version}"
@@ -15,63 +16,63 @@ project 'JRuby Main Maven Artifact' do
 
   # we have no sources and attach an empty jar later in the build to
   # satisfy oss.sonatype.org upload
-  plugin( :source, 'skipSource' =>  'true' )
+  plugin(:source, skipSource: 'true')
 
   # this plugin is configured to attach empty jars for sources and javadocs
-  plugin( 'org.codehaus.mojo:build-helper-maven-plugin' )
+  plugin('org.codehaus.mojo:build-helper-maven-plugin')
 
-  plugin( :invoker, :properties => { 'localRepository' => '${settings.localRepository}' } )
+  plugin(:invoker, properties: { localRepository: '${settings.localRepository}' })
 
   build do
     resource do
       directory '${project.basedir}/../..'
-      includes [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY', 'VERSION' ]
+      includes ['BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY', 'VERSION']
       target_path '${project.build.outputDirectory}/META-INF/'
     end
   end
 
-  plugin( 'net.ju-n.maven.plugins:checksum-maven-plugin' )
+  plugin('net.ju-n.maven.plugins:checksum-maven-plugin')
 
   profile :apps do
     activation do
-      property :name => 'invoker.test'
+      property name: 'invoker.test'
     end
 
-    properties 'invoker.skip' => false, 'invoker.test' => 'hellowarld_*'
+    properties "invoker.skip": false, "invoker.test": 'hellowarld_*'
 
-    execute 'setup web applications', :phase => 'pre-integration-test' do |ctx|
+    execute 'setup web applications', phase: 'pre-integration-test' do |ctx|
       def setup(ctx, framework, package, type, server)
         puts [framework, package, server].join "\t"
 
-        source = File.join( ctx.basedir.to_pathname, 'src', 'templates', 'hellowarld' )
-        target = File.join( ctx.basedir.to_pathname, "src/it/hellowarld_#{server}_#{package}_#{framework}" )
+        source = File.join(ctx.basedir.to_pathname, 'src', 'templates', 'hellowarld')
+        target = File.join(ctx.basedir.to_pathname, "src/it/hellowarld_#{server}_#{package}_#{framework}")
 
-        FileUtils.rm_rf( target )
-        FileUtils.cp_r( source, target )
-        FileUtils.mv( "#{target}/config-#{framework}.ru", "#{target}/config.ru" )
-        FileUtils.mv( "#{target}/app-#{framework}", "#{target}/app" )
+        FileUtils.rm_rf(target)
+        FileUtils.cp_r(source, target)
+        FileUtils.mv("#{target}/config-#{framework}.ru", "#{target}/config.ru")
+        FileUtils.mv("#{target}/app-#{framework}", "#{target}/app")
         file = "#{target}/Gemfile-#{framework}"
-        FileUtils.mv( file, "#{target}/Gemfile" ) if File.exists?( file )
+        FileUtils.mv(file, "#{target}/Gemfile") if File.exist?(file)
         file = "#{target}/Gemfile-#{framework}.lock"
-        FileUtils.mv( file, "#{target}/Gemfile.lock" ) if File.exists?( file )
-        file = File.join( target, 'Mavenfile')
+        FileUtils.mv(file, "#{target}/Gemfile.lock") if File.exist?(file)
+        file = File.join(target, 'Mavenfile')
         File.write(file, File.read(file).sub(/pom/, type))
-        File.open( File.join( target, 'invoker.properties' ), 'w' ) do |f|
+        File.open(File.join(target, 'invoker.properties'), 'w') do |f|
           f.puts "invoker.profiles = #{package},#{server},#{framework}"
         end
       end
 
-      [ 'cuba', 'sinatra', 'rails4' ].each do |framework|
-        [ ['filesystem', 'pom'], ['runnable','jrubyJar'] ].each do |package|
-          [ 'webrick', 'puma', 'torquebox' ].each do |server|
+      %w[cuba sinatra rails4].each do |framework|
+        [%w[filesystem pom], %w[runnable jrubyJar]].each do |package|
+          %w[webrick puma torquebox].each do |server|
             setup(ctx, framework, *package, server)
           end
         end
-        [ ['warfile', 'jrubyWar'] ].each do  |package|
-          [ 'jetty', 'tomcat', 'wildfly_unpacked', 'wildfly_packed' ].each do |server|
-            #', 'websphere' ].each do |server|
+        [%w[warfile jrubyWar]].each do |package|
+          %w[jetty tomcat wildfly_unpacked wildfly_packed].each do |server|
+            # ', 'websphere' ].each do |server|
             # rails4 on wildfly complains about missing com.sun.org.apache.xpath.internal.VariableStack which are actually xalan classes used by nokogiri
-            setup(ctx, framework, *package, server) unless framework == 'rails4' and server =~ /wildfly/
+            setup(ctx, framework, *package, server) unless (framework == 'rails4') && server =~ /wildfly/
           end
         end
       end
@@ -80,48 +81,50 @@ project 'JRuby Main Maven Artifact' do
 
   profile :osgi do
     activation do
-      property :name => 'invoker.test'
+      property name: 'invoker.test'
     end
 
-    execute 'setup osgi integration tests', :phase => 'pre-integration-test' do |ctx|
-      source = File.join( ctx.basedir.to_pathname, 'src', 'templates', 'osgi_all_inclusive' )
-      [ 'knoplerfish', 'equinox-3.6', 'equinox-3.7', 'felix-3.2', 'felix-4.4'].each do |m|
-        target = File.join( ctx.basedir.to_pathname, 'src', 'it', 'osgi_all_inclusive_' + m )
-        FileUtils.rm_rf( target )
-        FileUtils.cp_r( source, target )
-        File.open( File.join( target, 'invoker.properties' ), 'w' ) do |f|
-          f.puts 'invoker.profiles = ' + m
+    execute 'setup osgi integration tests', phase: 'pre-integration-test' do |ctx|
+      source = File.join(ctx.basedir.to_pathname, 'src', 'templates', 'osgi_all_inclusive')
+      ['knoplerfish', 'equinox-3.6', 'equinox-3.7', 'felix-3.2', 'felix-4.4'].each do |m|
+        target = File.join(ctx.basedir.to_pathname, 'src', 'it', "osgi_all_inclusive_#{m}")
+        FileUtils.rm_rf(target)
+        FileUtils.cp_r(source, target)
+        File.open(File.join(target, 'invoker.properties'), 'w') do |f|
+          f.puts "invoker.profiles = #{m}"
         end
       end
     end
   end
 
-  plugin( :clean ) do
-    execute_goals( :clean,
-                   :phase => :clean,
-                   :id => 'clean-extra-osgi-ITs',
-                   :filesets => [ { :directory => '${basedir}/src/it',
-                                    :includes => ['osgi*/**'] } ],
-                   :failOnError => false )
+  plugin(:clean) do
+    execute_goals(:clean,
+                  phase: :clean,
+                  id: 'clean-extra-osgi-ITs',
+                  filesets: [{ directory: '${basedir}/src/it',
+                               includes: ['osgi*/**'] }],
+                  failOnError: false)
   end
 
-  profile :id => :jdk8 do
+  profile id: :jdk8 do
     activation do
       jdk '1.8'
     end
-    plugin :invoker, :pomExcludes => ['extended/pom.xml', 'osgi_all_inclusive_felix-3.2/pom.xml', '${its.j2ee}', '${its.osgi}']
+    plugin :invoker,
+           pomExcludes: ['extended/pom.xml', 'osgi_all_inclusive_felix-3.2/pom.xml', '${its.j2ee}', '${its.osgi}']
   end
 
-  profile :id => :wlp do
+  profile id: :wlp do
     activation do
-      property :name => 'wlp.jar'
+      property name: 'wlp.jar'
     end
-    execute :install_wlp, :phase => :'pre-integration-test' do |ctx|
-      wlp = ctx.project.properties[ 'wlp.jar' ] || java.lang.System.properties[ 'wlp.jar' ]
-      system( 'java -jar ' + wlp.to_pathname + ' --acceptLicense ' + ctx.project.build.directory.to_pathname )
-      system( File.join( ctx.project.build.directory.to_pathname,
-                         'wlp/bin/server' ) + 'create testing' )
-      FileUtils.cp_r( File.join( ctx.basedir.to_pathname, 'src/templates/j2ee_wlp'), File.join( ctx.basedir.to_pathname, 'src/it' ) )
+    execute :install_wlp, phase: :'pre-integration-test' do |ctx|
+      wlp = ctx.project.properties['wlp.jar'] || java.lang.System.properties['wlp.jar']
+      system("java -jar #{wlp.to_pathname} --acceptLicense #{ctx.project.build.directory.to_pathname}")
+      system(File.join(ctx.project.build.directory.to_pathname,
+                       'wlp/bin/server') + 'create testing')
+      FileUtils.cp_r(File.join(ctx.basedir.to_pathname, 'src/templates/j2ee_wlp'),
+                     File.join(ctx.basedir.to_pathname, 'src/it'))
     end
   end
 end

--- a/maven/jruby/src/it/extended/pom.rb
+++ b/maven/jruby/src/it/extended/pom.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 # jruby scripting container
 pom 'org.jruby:jruby', '${jruby.version}'
 
 # unit tests
-jar 'junit:junit', '4.8.2', :scope => :test
+jar 'junit:junit', '4.8.2', scope: :test
 
-properties 'tesla.dump.pom' => 'pom.xml', 'tesla.dump.readOnly' => true
+properties "tesla.dump.pom": 'pom.xml', "tesla.dump.readOnly": true
 
-plugin :surefire, '2.15', :reuseForks => false, :additionalClasspathElements => [ '${basedir}/../../../../../core/target/test-classes', '${basedir}/../../../../../test/target/test-classes' ]
+plugin :surefire, '2.15', reuseForks: false,
+                          additionalClasspathElements: ['${basedir}/../../../../../core/target/test-classes', '${basedir}/../../../../../test/target/test-classes']

--- a/maven/jruby/src/it/j2ee_jetty/pom.rb
+++ b/maven/jruby/src/it/j2ee_jetty/pom.rb
@@ -1,51 +1,49 @@
+# frozen_string_literal: true
+
 # it is war-file
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            'project.build.sourceEncoding' => 'utf-8' )
+properties("jruby.plugins.version": '3.0.5',
+           "project.build.sourceEncoding": 'utf-8')
 
-pom( 'org.jruby:jruby', '${jruby.version}' )
+pom('org.jruby:jruby', '${jruby.version}')
 
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
-jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do
+jruby_plugin :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0' do
   execute_goal :initialize
-end 
+end
 
 # start jetty for the tests
-plugin( 'org.eclipse.jetty:jetty-maven-plugin', '9.1.3.v20140225',
-        :path => '/',
-        :stopPort => 9999,
-        :stopKey => 'foo' ) do
-   execute_goal( 'start', :id => 'start jetty', :phase => 'pre-integration-test', :daemon => true )
-   execute_goal( 'stop', :id => 'stop jetty', :phase => 'post-integration-test' )
+plugin('org.eclipse.jetty:jetty-maven-plugin', '9.1.3.v20140225',
+       path: '/',
+       stopPort: 9999,
+       stopKey: 'foo') do
+  execute_goal('start', id: 'start jetty', phase: 'pre-integration-test', daemon: true)
+  execute_goal('stop', id: 'stop jetty', phase: 'post-integration-test')
 end
 
 # download files during the tests
 result = nil
-execute 'download', :phase => 'integration-test' do
+execute 'download', phase: 'integration-test' do
   require 'open-uri'
-  result = open( 'http://localhost:8080' ).string
+  result = open('http://localhost:8080').string
   puts result
 end
 
 # verify the downloads
-execute 'check download', :phase => :verify do
+execute 'check download', phase: :verify do
   expected = 'hello world:'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
   expected = 'uri:classloader:/gems/flickraw-0.9.7'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
   expected = 'snakeyaml-1.14.0'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
 end

--- a/maven/jruby/src/it/j2ee_tomcat/pom.rb
+++ b/maven/jruby/src/it/j2ee_tomcat/pom.rb
@@ -1,53 +1,51 @@
+# frozen_string_literal: true
+
 # it is war-file
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            'project.build.sourceEncoding' => 'utf-8' )
+properties("jruby.plugins.version": '3.0.5',
+           "project.build.sourceEncoding": 'utf-8')
 
-pom( 'org.jruby:jruby', '${jruby.version}' )
+pom('org.jruby:jruby', '${jruby.version}')
 
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
-jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do
+jruby_plugin :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0' do
   execute_goal :initialize
 end
 
 # start tomcat for the tests
-plugin( 'org.codehaus.mojo:tomcat-maven-plugin', '1.1',
-        :fork => true, :path => '/' ) do
-  execute_goals( 'run',
-                 :id => 'run-tomcat',
-                 :phase => 'pre-integration-test' )
-  execute_goals( 'shutdown',
-                 :id => 'shutdown-tomcat',
-                 :phase => 'post-integration-test' )
+plugin('org.codehaus.mojo:tomcat-maven-plugin', '1.1',
+       fork: true, path: '/') do
+  execute_goals('run',
+                id: 'run-tomcat',
+                phase: 'pre-integration-test')
+  execute_goals('shutdown',
+                id: 'shutdown-tomcat',
+                phase: 'post-integration-test')
 end
 
 # download files during the tests
-execute 'download', :phase => 'integration-test' do
+execute 'download', phase: 'integration-test' do
   require 'open-uri'
-  result = open( 'http://localhost:8080' ).string
-  File.open( 'result', 'w' ) { |f| f.puts result }
+  result = open('http://localhost:8080').string
+  File.open('result', 'w') { |f| f.puts result }
 end
 
 # verify the downloads
-execute 'check download', :phase => :verify do
-  result = File.read( 'result' )
+execute 'check download', phase: :verify do
+  result = File.read('result')
   expected = 'hello world:'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
   expected = 'uri:classloader:/gems/flickraw-0.9.7'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
   expected = 'snakeyaml-1.14.0'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
 end

--- a/maven/jruby/src/it/j2ee_wildfly/pom.rb
+++ b/maven/jruby/src/it/j2ee_wildfly/pom.rb
@@ -1,83 +1,80 @@
+# frozen_string_literal: true
+
 # it is war-file
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            'wildfly.version' => '9.0.2.Final',
-            'project.build.sourceEncoding' => 'utf-8' )
+properties("jruby.plugins.version": '3.0.5',
+           "wildfly.version": '9.0.2.Final',
+           "project.build.sourceEncoding": 'utf-8')
 
-pom( 'org.jruby:jruby', '${jruby.version}' )
+pom('org.jruby:jruby', '${jruby.version}')
 
 # a gem to be used
 gem 'virtus', '0.5.5'
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
-jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do
+jruby_plugin :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0' do
   execute_goal :initialize
 end
 
-plugin( 'org.wildfly.plugins:wildfly-maven-plugin:1.0.2.Final' ) do
-  execute_goals( :start,
-                 :id => 'wildfly-start',
-                 :phase => 'pre-integration-test' )
-  execute_goals( :shutdown,
-                 :id => 'wildfly-stop',
-                 :phase => 'post-integration-test' )
+plugin('org.wildfly.plugins:wildfly-maven-plugin:1.0.2.Final') do
+  execute_goals(:start,
+                id: 'wildfly-start',
+                phase: 'pre-integration-test')
+  execute_goals(:shutdown,
+                id: 'wildfly-stop',
+                phase: 'post-integration-test')
 end
-
 
 build do
   final_name '${project.artifactId}'
 end
 
 # download files during the tests
-execute 'download', :phase => 'integration-test' do
+execute 'download', phase: 'integration-test' do
   require 'open-uri'
-  dir = Dir[ 'target/wildfly-run/*' ].first
-  FileUtils.cp( 'target/j2ee_wildfly.war', dir + '/standalone/deployments/packed.war' )
-  FileUtils.cp_r( 'target/j2ee_wildfly', dir + '/standalone/deployments/unpacked.war' )
-  FileUtils.touch( dir + '/standalone/deployments/unpacked.war.dodeploy' )
+  dir = Dir['target/wildfly-run/*'].first
+  FileUtils.cp('target/j2ee_wildfly.war', "#{dir}/standalone/deployments/packed.war")
+  FileUtils.cp_r('target/j2ee_wildfly', "#{dir}/standalone/deployments/unpacked.war")
+  FileUtils.touch("#{dir}/standalone/deployments/unpacked.war.dodeploy")
 
   # packed application
   count = 10
   begin
     sleep 1
-    result = open( 'http://localhost:8080/packed/index.jsp' ).string
-  rescue
+    result = open('http://localhost:8080/packed/index.jsp').string
+  rescue StandardError
     count -= 1
-    retry if count > 0
+    retry if count.positive?
   end
-  File.open( 'result1', 'w' ) { |f| f.puts result }
+  File.open('result1', 'w') { |f| f.puts result }
 
   # unpacked application
   count = 10
   begin
     sleep 1
-    result = open( 'http://localhost:8080/unpacked/index.jsp' ).string
-  rescue
+    result = open('http://localhost:8080/unpacked/index.jsp').string
+  rescue StandardError
     count -= 1
-    retry if count > 0
+    retry if count.positive?
   end
-  File.open( 'result2', 'w' ) { |f| f.puts result }
+  File.open('result2', 'w') { |f| f.puts result }
 end
 
 # verify the downloads
-execute 'check download', :phase => :verify do
-  [ 'result1', 'result2' ].each do |r|
-    result = File.read( r )
+execute 'check download', phase: :verify do
+  %w[result1 result2].each do |r|
+    result = File.read(r)
     expected = 'hello world:'
-    unless result.match( /#{expected}/ )
-      raise "missed expected string in download: #{expected}"
-    end
+    raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
     expected = 'uri:classloader:/gems/backports-'
-    unless result.match( /#{expected}/ )
-      raise "missed expected string in download: #{expected}"
-    end
+    raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
     expected = 'snakeyaml-1.14.0'
-    unless result.match( /#{expected}/ )
-      raise "missed expected string in download: #{expected}"
-    end
+    raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
   end
 end

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/app/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/app/pom.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # two jars with embedded gems
 jar 'org.jruby.maven:maven-tools', '3.0.5'
 jar 'org.rubygems:zip', '2.0.2'
@@ -6,6 +8,6 @@ jar 'org.rubygems:zip', '2.0.2'
 pom 'org.jruby:jruby', '${jruby.version}'
 
 # unit tests
-jar 'junit:junit', '4.8.2', :scope => :test
+jar 'junit:junit', '4.8.2', scope: :test
 
-resource :directory => "src/main/ruby"
+resource directory: 'src/main/ruby'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/pom.rb
@@ -1,8 +1,10 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5' )
+properties("jruby.plugins.version": '3.0.5')
 
 packaging :pom
 
-modules [ 'zip_gem', 'app' ]
+modules %w[zip_gem app]

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/zip_gem/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/zip_gem/pom.rb
@@ -1,12 +1,14 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 gemfile
 
 model.repositories.clear
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:zip', VERSION
 
-jruby_plugin! :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0'
+jruby_plugin! :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/app/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/app/pom.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # two jars with embedded gems
 jar 'org.rubygems:gem1', '1'
 jar 'org.rubygems:gem2', '2'
@@ -6,6 +8,6 @@ jar 'org.rubygems:gem2', '2'
 pom 'org.jruby:jruby', '${jruby.version}'
 
 # unit tests
-jar 'junit:junit', '4.8.2', :scope => :test
+jar 'junit:junit', '4.8.2', scope: :test
 
-resource :directory => "src/main/ruby"
+resource directory: 'src/main/ruby'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem1/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem1/pom.rb
@@ -1,12 +1,14 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 gemfile
 
 model.repositories.clear
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:gem1', '1'
 
-jruby_plugin! :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0'
+jruby_plugin! :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/pom.rb
@@ -1,12 +1,14 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 gemfile
 
 model.repositories.clear
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:gem2', '2'
 
-jruby_plugin! :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0'
+jruby_plugin! :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/pom.rb
@@ -1,8 +1,10 @@
-#-*- mode: ruby -*-
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5' )
+properties("jruby.plugins.version": '3.0.5')
 
 packaging :pom
 
-modules [ 'gem1', 'gem2', 'app' ]
+modules %w[gem1 gem2 app]

--- a/maven/jruby/src/it/tomcat/pom.rb
+++ b/maven/jruby/src/it/tomcat/pom.rb
@@ -1,51 +1,51 @@
+# frozen_string_literal: true
+
 id 'dummy:tomcat:1.0-SNAPSHOT'
 
 # it is war-file
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            'project.build.sourceEncoding' => 'utf-8' )
+properties("jruby.plugins.version": '3.0.5',
+           "project.build.sourceEncoding": 'utf-8')
 
-pom( 'org.jruby:jruby', '${jruby.version}' )
+pom('org.jruby:jruby', '${jruby.version}')
 
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
-jruby_plugin :gem, :includeRubygemsInTestResources => false, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do
+jruby_plugin :gem, includeRubygemsInTestResources: false, includeRubygemsInResources: true,
+                   jrubyVersion: '9.0.0.0' do
   execute_goal :initialize
-end 
+end
 
 # start tomcat for the tests
-plugin( 'org.codehaus.mojo:tomcat-maven-plugin', '1.1',
-        :fork => true, :path => '/' ) do
-  execute_goals( 'run',
-                 :id => 'run-tomcat',
-                 :phase => 'pre-integration-test' )
-  execute_goals( 'shutdown',
-                 :id => 'shutdown-tomcat',
-                 :phase => 'post-integration-test' )
+plugin('org.codehaus.mojo:tomcat-maven-plugin', '1.1',
+       fork: true, path: '/') do
+  execute_goals('run',
+                id: 'run-tomcat',
+                phase: 'pre-integration-test')
+  execute_goals('shutdown',
+                id: 'shutdown-tomcat',
+                phase: 'post-integration-test')
 end
 
 # download files during the tests
 result = nil
-execute 'download', :phase => 'integration-test' do
+execute 'download', phase: 'integration-test' do
   require 'open-uri'
-  result = open( 'http://localhost:8080' ).string
+  result = open('http://localhost:8080').string
   puts result
 end
 
 # verify the downloads
-execute 'check download', :phase => :verify do
+execute 'check download', phase: :verify do
   expected = 'hello world:'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
   expected = 'uri:classloader:/gems/flickraw-0.9.7'
-  unless result.match( /#{expected}/ )
-    raise "missed expected string in download: #{expected}"
-  end
+  raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
 end

--- a/maven/jruby/src/templates/j2ee_wlp/pom.rb
+++ b/maven/jruby/src/templates/j2ee_wlp/pom.rb
@@ -1,63 +1,62 @@
+# frozen_string_literal: true
+
 # it is war-file
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            'project.build.sourceEncoding' => 'utf-8' )
+properties("jruby.plugins.version": '3.0.5',
+           "project.build.sourceEncoding": 'utf-8')
 
-pom( 'org.jruby:jruby', '${jruby.version}' )
+pom('org.jruby:jruby', '${jruby.version}')
 
 # a gem to be used
 gem 'virtus', '0.5.5'
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
-jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do
+jruby_plugin :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0' do
   execute_goal :initialize
 end
 
-execute 'deploy', :phase => 'pre-integration-test' do |ctx|
-  wlp_home = ctx.basedir.to_pathname + '/../../wlp'
-  FileUtils.cp( 'target/j2ee_wlp.war', "#{wlp_home}/usr/servers/testing/dropins/packed.war" )
-  FileUtils.cp_r( 'target/j2ee_wlp', "#{wlp_home}/usr/servers/testing/dropins/unpacked.war" )
+execute 'deploy', phase: 'pre-integration-test' do |ctx|
+  wlp_home = "#{ctx.basedir.to_pathname}/../../wlp"
+  FileUtils.cp('target/j2ee_wlp.war', "#{wlp_home}/usr/servers/testing/dropins/packed.war")
+  FileUtils.cp_r('target/j2ee_wlp', "#{wlp_home}/usr/servers/testing/dropins/unpacked.war")
 end
 
 build do
   final_name '${project.artifactId}'
 end
 
-plugin( 'net.wasdev.wlp.maven.plugins:liberty-maven-plugin:1.0',
-        :installDirectory => '${basedir}/../../wlp',
-        :serverName => 'testing' ) do
-  execute_goals( :'start-server',
-                 :id => 'wlp-start',
-                 :phase => 'pre-integration-test' )
-  execute_goals( :'stop-server',
-                 :id => 'wlp-stop',
-                 :phase => 'post-integration-test' )
+plugin('net.wasdev.wlp.maven.plugins:liberty-maven-plugin:1.0',
+       installDirectory: '${basedir}/../../wlp',
+       serverName: 'testing') do
+  execute_goals(:'start-server',
+                id: 'wlp-start',
+                phase: 'pre-integration-test')
+  execute_goals(:'stop-server',
+                id: 'wlp-stop',
+                phase: 'post-integration-test')
 end
 
 # download files during the tests
-execute 'download', :phase => 'pre-integration-test' do
+execute 'download', phase: 'pre-integration-test' do
   require 'open-uri'
-  result = open( 'http://localhost:9080/packed/index.jsp' ).string
-  File.open( 'result1', 'w' ) { |f| f.puts result }
-  result = open( 'http://localhost:9080/unpacked/index.jsp' ).string
-  File.open( 'result2', 'w' ) { |f| f.puts result }
+  result = open('http://localhost:9080/packed/index.jsp').string
+  File.open('result1', 'w') { |f| f.puts result }
+  result = open('http://localhost:9080/unpacked/index.jsp').string
+  File.open('result2', 'w') { |f| f.puts result }
 end
 
 # verify the downloads
-execute 'check download', :phase => :verify do
-  [ 'result1', 'result2' ].each do |r|
-    result = File.read( r )
+execute 'check download', phase: :verify do
+  %w[result1 result2].each do |r|
+    result = File.read(r)
     expected = 'hello world:'
-    unless result.match( /#{expected}/ )
-      raise "missed expected string in download: #{expected}"
-    end
+    raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
+
     expected = 'uri:classloader:/gems/backports-'
-    unless result.match( /#{expected}/ )
-      raise "missed expected string in download: #{expected}"
-    end
+    raise "missed expected string in download: #{expected}" unless result.match(/#{expected}/)
   end
 end

--- a/maven/jruby/src/templates/osgi_all_inclusive/pom.rb
+++ b/maven/jruby/src/templates/osgi_all_inclusive/pom.rb
@@ -1,41 +1,43 @@
+# frozen_string_literal: true
+
 gemfile
 
 packaging 'bundle'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.5',
-            'exam.version' => '3.0.3',
-            'url.version' => '1.5.2',
-            'logback.version' => '1.0.13',
-            # needed by felix-bundle-plugin
-            'polyglot.dump.pom' => 'pom.xml' )
+properties("jruby.plugins.version": '3.0.5',
+           "exam.version": '3.0.3',
+           "url.version": '1.5.2',
+           "logback.version": '1.0.13',
+           # needed by felix-bundle-plugin
+           "polyglot.dump.pom": 'pom.xml')
 
 pom 'org.jruby:jruby', '${jruby.version}'
 
 model.repositories.clear
 
 extension 'org.jruby.maven:mavengem-wagon:2.0.2'
-repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+repository id: :mavengems, url: 'mavengem:https://rubygems.org'
 
-jruby_plugin! :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0'
+jruby_plugin! :gem, includeRubygemsInResources: true, jrubyVersion: '9.0.0.0'
 
 # add some ruby scripts to bundle
-resource :directory => 'src/main/ruby'
+resource directory: 'src/main/ruby'
 
-plugin( 'org.apache.felix:maven-bundle-plugin', '2.4.0',
-        :instructions => {
-          # org.junit is needed for the test phase to run unit tests
-          'Export-Package' => 'org.jruby.*,org.junit.*',
-          # this is needed to find javax.* packages
-          'DynamicImport-Package' => '*',
-          'Include-Resource' => '{maven-resources}',
-          'Import-Package' => '!org.jruby.*,*;resolution:=optional',
-          'Embed-Dependency' => '*;type=jar;scope=compile|runtime;inline=true',
-          'Embed-Transitive' => true
-        } ) do
+plugin('org.apache.felix:maven-bundle-plugin', '2.4.0',
+       instructions: {
+         # org.junit is needed for the test phase to run unit tests
+         "Export-Package": 'org.jruby.*,org.junit.*',
+         # this is needed to find javax.* packages
+         "DynamicImport-Package": '*',
+         "Include-Resource": '{maven-resources}',
+         "Import-Package": '!org.jruby.*,*;resolution:=optional',
+         "Embed-Dependency": '*;type=jar;scope=compile|runtime;inline=true',
+         "Embed-Transitive": true
+       }) do
   # pack the bundle before the test phase
-  execute_goal :bundle, :phase => 'process-test-resources'
-  # TODO fix DSL
+  execute_goal :bundle, phase: 'process-test-resources'
+  # TODO: fix DSL
   @current.extensions = true
 end
 
@@ -52,21 +54,21 @@ scope :test do
   jar 'ch.qos.logback:logback-core', '${logback.version}'
   jar 'ch.qos.logback:logback-classic', '${logback.version}'
 
-  profile :id => 'equinox-3.6' do
+  profile id: 'equinox-3.6' do
     jar 'org.eclipse.osgi:org.eclipse.osgi:3.6.0.v20100517'
   end
-  profile :id => 'equinox-3.7' do
+  profile id: 'equinox-3.7' do
     jar 'org.eclipse.osgi:org.eclipse.osgi:3.7.1'
   end
-  profile :id => 'felix-4.4' do
+  profile id: 'felix-4.4' do
     jar 'org.apache.felix:org.apache.felix.framework:4.4.1'
   end
-  profile :id => 'felix-3.2' do
+  profile id: 'felix-3.2' do
     jar 'org.apache.felix:org.apache.felix.framework:3.2.2'
   end
-  profile :id => 'knoplerfish' do
-    repository( :id => :knoplerfish,
-                :url => 'http://www.knopflerfish.org/maven2' )
+  profile id: 'knoplerfish' do
+    repository(id: :knoplerfish,
+               url: 'http://www.knopflerfish.org/maven2')
     jar 'org.knopflerfish:framework:5.1.6'
   end
 end

--- a/maven/pom.rb
+++ b/maven/pom.rb
@@ -1,7 +1,8 @@
-project 'JRuby Artifacts' do
+# frozen_string_literal: true
 
+project 'JRuby Artifacts' do
   version = ENV['JRUBY_VERSION'] ||
-    File.read( File.join( basedir, '..', 'VERSION' ) ).strip
+            File.read(File.join(basedir, '..', 'VERSION')).strip
 
   model_version '4.0.0'
   id 'jruby-artifacts'
@@ -10,44 +11,44 @@ project 'JRuby Artifacts' do
 
   # it looks like some people have problems with this artifact as parent
   # TODO set the parent pom to pom.rb inside the children
-  properties( 'polyglot.dump.pom' => 'pom.xml',
-              'polyglot.dump.readonly' => true )
+  properties("polyglot.dump.pom": 'pom.xml',
+             "polyglot.dump.readonly": true)
 
   plugin_management do
     plugin 'org.codehaus.mojo:build-helper-maven-plugin' do
-      execute_goals( 'attach-artifact',
-                     :id => 'attach-artifacts',
-                     :phase => 'package',
-                     'artifacts' => [ { 'file' =>  '${basedir}/src/empty.jar',
-                                        'classifier' =>  'sources' },
-                                      { 'file' =>  '${basedir}/src/empty.jar',
-                                        'classifier' =>  'javadoc' } ] )
+      execute_goals('attach-artifact',
+                    id: 'attach-artifacts',
+                    phase: 'package',
+                    artifacts: [{ file: '${basedir}/src/empty.jar',
+                                  classifier: 'sources' },
+                                { file: '${basedir}/src/empty.jar',
+                                  classifier: 'javadoc' }])
     end
 
-    plugin( 'net.ju-n.maven.plugins:checksum-maven-plugin', '1.2' ) do
+    plugin('net.ju-n.maven.plugins:checksum-maven-plugin', '1.2') do
       execute_goals(
-          :artifacts,
-          phase: :package,
-          algorithms: ['SHA-256', 'SHA-512' ] )
+        :artifacts,
+        phase: :package,
+        algorithms: %w[SHA-256 SHA-512]
+      )
     end
   end
 
   # module to profile map
-  map = { 'jruby' => [ :apps, :release, :main, :osgi, :j2ee, :snapshots ],
-    'jruby-complete' => [ :release, :complete, :osgi, :'jruby_complete_jar_extended', :snapshots],
-    'jruby-dist' => [ :release, :dist, :snapshots ],
-    'jruby-jars' => [ :release, :'jruby-jars', :snapshots ]
-  }
+  map = { jruby: %i[apps release main osgi j2ee snapshots],
+          "jruby-complete": %i[release complete osgi jruby_complete_jar_extended snapshots],
+          "jruby-dist": %i[release dist snapshots],
+          "jruby-jars": %i[release jruby-jars snapshots] }
 
   profile :all do
     modules map.keys
   end
 
-  # TODO once ruby-maven profile! we can do this in one loop
+  # TODO: once ruby-maven profile! we can do this in one loop
   invert = {}
   map.each do |m, pp|
     pp.each do |p|
-      ( invert[ p ] ||= [] ) << m
+      (invert[p] ||= []) << m
     end
   end
   invert.each do |p, m|

--- a/maven/pom.rb
+++ b/maven/pom.rb
@@ -35,10 +35,11 @@ project 'JRuby Artifacts' do
   end
 
   # module to profile map
-  map = { jruby: %i[apps release main osgi j2ee snapshots],
-          "jruby-complete": %i[release complete osgi jruby_complete_jar_extended snapshots],
-          "jruby-dist": %i[release dist snapshots],
-          "jruby-jars": %i[release jruby-jars snapshots] }
+  # rubocop:disable Style/StringHashKeys
+  map = { 'jruby' => %i[apps release main osgi j2ee snapshots],
+          'jruby-complete' => %i[release complete osgi jruby_complete_jar_extended snapshots],
+          'jruby-dist' => %i[release dist snapshots],
+          'jruby-jars' => %i[release jruby-jars snapshots] }
 
   profile :all do
     modules map.keys

--- a/pom.rb
+++ b/pom.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 version = ENV['JRUBY_VERSION'] ||
-  File.read( File.join( basedir, 'VERSION' ) ).strip
+          File.read(File.join(basedir, 'VERSION')).strip
 
 project 'JRuby', 'https://github.com/jruby/jruby' do
-
   model_version '4.0.0'
   inception_year '2001'
   id 'org.jruby:jruby-parent', version
@@ -12,7 +13,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
 
   organization 'JRuby', 'https://www.jruby.org'
 
-  [ 'headius', 'enebo', 'wmeissner', 'BanzaiMan', 'mkristian' ].each do |name|
+  %w[headius enebo wmeissner BanzaiMan mkristian].each do |name|
     developer name do
       name name
       roles 'developer'
@@ -21,81 +22,81 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
 
   issue_management 'https://github.com/jruby/jruby/issues', 'GitHub'
 
-  mailing_list "jruby" do
-    archives "https://github.com/jruby/jruby/wiki/MailingLists"
+  mailing_list 'jruby' do
+    archives 'https://github.com/jruby/jruby/wiki/MailingLists'
   end
 
   license 'GPL-2.0', 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'
   license 'LGPL-2.1', 'http://www.gnu.org/licenses/lgpl-2.1-standalone.html'
   license 'EPL-2.0', 'http://www.eclipse.org/legal/epl-v20.html'
 
-  plugin_repository( :url => 'https://central.sonatype.com/repository/maven-snapshots/',
-                     :id => 'sonatype' ) do
+  plugin_repository(url: 'https://central.sonatype.com/repository/maven-snapshots/',
+                    id: 'sonatype') do
     releases 'false'
     snapshots 'true'
   end
-  repository( :url => 'https://central.sonatype.com/repository/maven-snapshots/',
-              :id => 'sonatype' ) do
+  repository(url: 'https://central.sonatype.com/repository/maven-snapshots/',
+             id: 'sonatype') do
     releases 'false'
     snapshots 'true'
   end
 
-  source_control( :url => 'https://github.com/jruby/jruby',
-                  :connection => 'scm:git:git@jruby.org:jruby.git',
-                  :developer_connection => 'scm:git:ssh://git@jruby.org/jruby.git' )
+  source_control(url: 'https://github.com/jruby/jruby',
+                 connection: 'scm:git:git@jruby.org:jruby.git',
+                 developer_connection: 'scm:git:ssh://git@jruby.org/jruby.git')
 
   distribution do
-    site( :url => 'https://github.com/jruby/jruby',
-          :id => 'gh-pages',
-          :name => 'JRuby Site' )
+    site(url: 'https://github.com/jruby/jruby',
+         id: 'gh-pages',
+         name: 'JRuby Site')
   end
 
-  properties( 'its.j2ee' => 'j2ee*/pom.xml',
-              'its.osgi' => 'osgi*/pom.xml',
-              'jruby.basedir' => '${project.basedir}',
-              'main.basedir' => '${project.basedir}',
-              'project.build.sourceEncoding' => 'utf-8',
-              'base.java.version' => '1.8',
-              'base.javac.version' => '1.8',
-              'invoker.skip' => 'true',
-              'version.jruby' => '${project.version}',
-              'github.global.server' => 'github',
-              'polyglot.dump.pom' => 'pom.xml',
-              'polyglot.dump.readonly' => 'true',
-              'jruby.plugins.version' => '3.0.6',
+  properties("its.j2ee": 'j2ee*/pom.xml',
+             "its.osgi": 'osgi*/pom.xml',
+             "jruby.basedir": '${project.basedir}',
+             "main.basedir": '${project.basedir}',
+             "project.build.sourceEncoding": 'utf-8',
+             "base.java.version": '1.8',
+             "base.javac.version": '1.8',
+             "invoker.skip": 'true',
+             "version.jruby": '${project.version}',
+             "github.global.server": 'github',
+             "polyglot.dump.pom": 'pom.xml',
+             "polyglot.dump.readonly": 'true',
+             "jruby.plugins.version": '3.0.6',
 
-              # versions for default gems with bin executables
-              # used in ./lib/pom.rb and ./maven/jruby-stdlib/pom.rb
-              'rake.version' => '13.0.6',
-              'jruby-launcher.version' => '1.1.6',
-              'ant.version' => '1.9.8',
-              'asm.version' => '9.7.1',
-              'jar-dependencies.version' => '0.4.1',
-              'jffi.version' => '1.3.13',
-              'joda.time.version' => '2.12.7' )
+             # versions for default gems with bin executables
+             # used in ./lib/pom.rb and ./maven/jruby-stdlib/pom.rb
+             "rake.version": '13.0.6',
+             "jruby-launcher.version": '1.1.6',
+             "ant.version": '1.9.8',
+             "asm.version": '9.7.1',
+             "jar-dependencies.version": '0.4.1',
+             "jffi.version": '1.3.13',
+             "joda.time.version": '2.12.7')
 
   plugin_management do
-    jar( 'junit:junit:4.13.1',
-         :scope => 'test' )
+    jar('junit:junit:4.13.1',
+        scope: 'test')
 
-    jar( 'org.awaitility:awaitility:4.1.0',
-         :scope => 'test' )
+    jar('org.awaitility:awaitility:4.1.0',
+        scope: 'test')
 
-    plugin( 'org.apache.felix:maven-bundle-plugin:4.2.1',
-            'instructions' => {
-              'Export-Package' =>  'org.jruby.*;version=${project.version}',
-              'Import-Package' =>  '!org.jruby.*, *;resolution:=optional',
-              'Private-Package' =>  'org.jruby.*,jnr.*,com.kenai.*,com.martiansoftware.*,jay.*,jline.*,jni.*,org.fusesource.*,org.jcodings.*,org.joda.convert.*,org.joda.time.*,org.joni.*,org.yaml.*,org.yecht.*,tables.*,org.objectweb.*,com.headius.*,org.bouncycastle.*,com.jcraft.jzlib,.',
-              'Bundle-Name' =>  '${bundle.name} ${project.version}',
-              'Bundle-Description' =>  '${bundle.name} ${project.version} OSGi bundle',
-              'Bundle-SymbolicName' =>  '${bundle.symbolic_name}'
-            } ) do
+    plugin('org.apache.felix:maven-bundle-plugin:4.2.1',
+           instructions: {
+             "Export-Package": 'org.jruby.*;version=${project.version}',
+             "Import-Package": '!org.jruby.*, *;resolution:=optional',
+             "Private-Package": 'org.jruby.*,jnr.*,com.kenai.*,com.martiansoftware.*,jay.*,jline.*,jni.*,org.fusesource.*,org.jcodings.*,org.joda.convert.*,org.joda.time.*,org.joni.*,org.yaml.*,org.yecht.*,tables.*,org.objectweb.*,com.headius.*,org.bouncycastle.*,com.jcraft.jzlib,.',
+             "Bundle-Name": '${bundle.name} ${project.version}',
+             "Bundle-Description": '${bundle.name} ${project.version} OSGi bundle',
+             "Bundle-SymbolicName": '${bundle.symbolic_name}'
+           }) do
       dependency(groupId: 'biz.aQute.bnd', artifactId: 'biz.aQute.bndlib', version: '6.3.1')
-      execute_goals( 'manifest',
-                     :phase => 'prepare-package' )
+      execute_goals('manifest',
+                    phase: 'prepare-package')
     end
 
-    plugin( :site, '3.9.1', 'skipDeploy' =>  'true' )
+    plugin(:site, '3.9.1', skipDeploy: 'true')
     plugin 'org.codehaus.mojo:build-helper-maven-plugin:3.2.0'
     plugin 'org.codehaus.mojo:exec-maven-plugin:3.0.0'
     plugin :antrun, '3.0.0'
@@ -110,81 +111,78 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
     plugin :release, '3.0.0-M1'
     plugin :jar, '3.2.0'
 
-    rules = { :requireMavenVersion => { :version => '[3.3.0,)' } }
-    unless model.version =~ /-SNAPSHOT/
-       rules[:requireReleaseDeps] = { :message => 'No Snapshots Allowed!' }
-    end
+    rules = { requireMavenVersion: { version: '[3.3.0,)' } }
+    rules[:requireReleaseDeps] = { message: 'No Snapshots Allowed!' } unless model.version =~ /-SNAPSHOT/
     plugin :enforcer, '1.4' do
-      execute_goal :enforce, :rules => rules
+      execute_goal :enforce, rules: rules
     end
 
     plugin :compiler, '3.8.1'
     plugin :shade, '3.2.4'
     plugin :surefire, '3.0.0'
     plugin :plugin, '3.6.0'
-    plugin( :invoker, '3.2.1',
-            'properties' => { 'jruby.version' => '${project.version}',
-                              'jruby.plugins.version' => '${jruby.plugins.version}' },
-            'pomIncludes' => [ '*/pom.xml' ],
-            'pomExcludes' => [ 'extended/pom.xml', '${its.j2ee}', '${its.osgi}' ],
-            'projectsDirectory' =>  'src/it',
-            'cloneProjectsTo' =>  '${project.build.directory}/it',
-            'preBuildHookScript' =>  'setup.bsh',
-            'postBuildHookScript' =>  'verify.bsh',
-            'goals' => [:install],
-            'streamLogs' =>  'true' ) do
-      execute_goals( 'install', 'run',
-                     :id => 'integration-test' )
+    plugin(:invoker, '3.2.1',
+           properties: { "jruby.version": '${project.version}',
+                         "jruby.plugins.version": '${jruby.plugins.version}' },
+           pomIncludes: ['*/pom.xml'],
+           pomExcludes: ['extended/pom.xml', '${its.j2ee}', '${its.osgi}'],
+           projectsDirectory: 'src/it',
+           cloneProjectsTo: '${project.build.directory}/it',
+           preBuildHookScript: 'setup.bsh',
+           postBuildHookScript: 'verify.bsh',
+           goals: [:install],
+           streamLogs: 'true') do
+      execute_goals('install', 'run',
+                    id: 'integration-test')
     end
 
     plugin 'org.eclipse.m2e:lifecycle-mapping:1.0.0'
     plugin :'scm-publish', '3.1.0'
   end
-  
-  plugin( 'org.sonatype.central:central-publishing-maven-plugin:0.7.0',
-          extensions: true,
-          publishingServerId: 'central')
 
-  plugin( :site,
-          'port' =>  '9000',
-          'tempWebappDirectory' =>  '${basedir}/target/site/tempdir' ) do
-    execute_goals( 'stage',
-                   :id => 'stage-for-scm-publish',
-                   :phase => 'post-site',
-                   'skipDeploy' =>  'false' )
+  plugin('org.sonatype.central:central-publishing-maven-plugin:0.7.0',
+         extensions: true,
+         publishingServerId: 'central')
+
+  plugin(:site,
+         port: '9000',
+         tempWebappDirectory: '${basedir}/target/site/tempdir') do
+    execute_goals('stage',
+                  id: 'stage-for-scm-publish',
+                  phase: 'post-site',
+                  skipDeploy: 'false')
   end
 
-  plugin( :'scm-publish', '1.0-beta-2',
-          'scmBranch' =>  'gh-pages',
-          'pubScmUrl' =>  'scm:git:git@github.com:jruby/jruby.git',
-          'tryUpdate' =>  'true' ) do
-    execute_goals( 'publish-scm',
-                   :id => 'scm-publish',
-                   :phase => 'site-deploy' )
+  plugin(:'scm-publish', '1.0-beta-2',
+         scmBranch: 'gh-pages',
+         pubScmUrl: 'scm:git:git@github.com:jruby/jruby.git',
+         tryUpdate: 'true') do
+    execute_goals('publish-scm',
+                  id: 'scm-publish',
+                  phase: 'site-deploy')
   end
 
   build do
     default_goal 'install'
   end
 
-  modules("core", "shaded")
+  modules('core', 'shaded')
 
   profile :stdlib do
     activation do
       property name: '!core'
     end
-    modules(["lib"])
+    modules(['lib'])
   end
 
   profile 'test' do
-    properties 'invoker.skip' => false
-    modules [ 'test' ]
+    properties "invoker.skip": false
+    modules ['test']
   end
 
-  [ 'rake', 'exec' ].each do |name|
+  %w[rake exec].each do |name|
     profile name do
-
-      modules [ 'test' ]
+      modules ['test']
 
       build do
         default_goal 'package'
@@ -192,40 +190,35 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
     end
   end
 
-  [ 'bootstrap', 'bootstrap-no-launcher' ].each do |name|
+  %w[bootstrap bootstrap-no-launcher].each do |name|
     profile name do
-
-      modules [ 'test' ]
-
+      modules ['test']
     end
   end
 
-  [ 'jruby-jars', 'main', 'complete', 'dist' ].each do |name|
-
+  %w[jruby-jars main complete dist].each do |name|
     profile name do
-
-      modules [ 'maven' ]
+      modules ['maven']
 
       build do
         default_goal 'install'
         plugin_management do
-          plugin :surefire, '2.15', :skipTests => true
+          plugin :surefire, '2.15', skipTests: true
         end
       end
     end
   end
 
-  [ 'osgi', 'j2ee' ].each do |name|
+  %w[osgi j2ee].each do |name|
     profile name do
+      modules ['maven']
 
-      modules [ 'maven' ]
-
-      properties( 'invoker.skip' => false,
-                  "its.#{name}" => 'no-excludes/pom.xml' )
+      properties(:"invoker.skip" => false,
+                 "its.#{name}" => 'no-excludes/pom.xml')
 
       build do
         default_goal 'install'
-        plugin :invoker, 'pomIncludes' => [ "#{name}*/pom.xml" ]
+        plugin :invoker, pomIncludes: ["#{name}*/pom.xml"]
       end
     end
   end
@@ -239,18 +232,16 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
   end
 
   profile 'jruby_complete_jar_extended' do
-
-    modules [ 'test', 'maven' ]
+    modules %w[test maven]
 
     build do
       default_goal 'install'
     end
   end
 
-  all_modules = [ 'test', 'maven' ]
+  all_modules = %w[test maven]
 
   profile 'all' do
-
     modules all_modules
 
     build do
@@ -259,7 +250,6 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
   end
 
   profile 'clean' do
-
     modules all_modules
 
     build do
@@ -268,50 +258,49 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
   end
 
   profile 'release' do
-    modules [ 'maven' ]
-    properties 'invoker.skip' => true
+    modules ['maven']
+    properties "invoker.skip": true
     plugin(:source) do
-      execute_goals('jar-no-fork', :id => 'attach-sources')
+      execute_goals('jar-no-fork', id: 'attach-sources')
     end
     plugin(:javadoc) do
-      execute_goals('jar', :id => 'attach-javadocs')
+      execute_goals('jar', id: 'attach-javadocs')
       configuration(doclint: 'none')
     end
-    plugin( :gpg, '1.6',
-            gpgArguments: [ '--pinentry-mode', 'loopback' ]) do
-      execute_goals( 'sign', id: 'sign-artifacts', phase: 'verify')
+    plugin(:gpg, '1.6',
+           gpgArguments: ['--pinentry-mode', 'loopback']) do
+      execute_goals('sign', id: 'sign-artifacts', phase: 'verify')
     end
   end
 
   profile 'snapshots' do
-
-    modules [ 'maven' ]
+    modules ['maven']
 
     build do
       default_goal :deploy
     end
 
     plugin(:source) do
-      execute_goals('jar-no-fork', :id => 'attach-sources')
+      execute_goals('jar-no-fork', id: 'attach-sources')
     end
     plugin(:javadoc) do
-      execute_goals('jar', :id => 'attach-javadocs')
+      execute_goals('jar', id: 'attach-javadocs')
       configuration(doclint: 'none', additionalOptions: '-Xdoclint:none', failOnError: 'false')
     end
   end
 
   profile 'single invoker test' do
     activation do
-      property :name => 'invoker.test'
+      property name: 'invoker.test'
     end
-    properties 'invoker.skip' => false
+    properties "invoker.skip": false
   end
 
   profile 'jdk8' do
     activation do
       jdk '1.8'
     end
-    plugin :javadoc, :additionalparam => '-Xdoclint:none'
+    plugin :javadoc, additionalparam: '-Xdoclint:none'
   end
 
   profile 'core' do
@@ -321,60 +310,60 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
   end
 
   reporting do
-    plugin( :'project-info-reports', '2.4',
-            'dependencyLocationsEnabled' =>  'false',
-            'dependencyDetailsEnabled' =>  'false' )
+    plugin(:'project-info-reports', '2.4',
+           dependencyLocationsEnabled: 'false',
+           dependencyDetailsEnabled: 'false')
     plugin :changelog, '2.2'
-    plugin( :checkstyle, '2.9.1',
-            'configLocation' =>  '${main.basedir}/docs/style_checks.xml',
-            'propertyExpansion' =>  'cacheFile=${project.build.directory}/checkstyle-cachefile' ) do
-      report_set( 'checkstyle',
-                  :inherited => 'false' )
+    plugin(:checkstyle, '2.9.1',
+           configLocation: '${main.basedir}/docs/style_checks.xml',
+           propertyExpansion: 'cacheFile=${project.build.directory}/checkstyle-cachefile') do
+      report_set('checkstyle',
+                 inherited: 'false')
     end
 
-    plugin( 'org.codehaus.mojo:cobertura-maven-plugin:2.5.1',
-            'aggregate' =>  'true' )
+    plugin('org.codehaus.mojo:cobertura-maven-plugin:2.5.1',
+           aggregate: 'true')
     plugin :dependency, '2.8' do
       report_set 'analyze-report'
     end
 
     plugin 'org.codehaus.mojo:findbugs-maven-plugin:2.5'
-    plugin( :javadoc, '2.9',
-            'quiet' =>  'true',
-            'aggregate' =>  'true',
-            'failOnError' =>  'false',
-            'detectOfflineLinks' =>  'false',
-            'show' =>  'package',
-            'level' =>  'package',
-            'maxmemory' =>  '1g' ) do
-      report_set( 'javadoc',
-                  'quiet' =>  'true',
-                  'failOnError' =>  'false',
-                  'detectOfflineLinks' =>  'false' )
+    plugin(:javadoc, '2.9',
+           quiet: 'true',
+           aggregate: 'true',
+           failOnError: 'false',
+           detectOfflineLinks: 'false',
+           show: 'package',
+           level: 'package',
+           maxmemory: '1g') do
+      report_set('javadoc',
+                 quiet: 'true',
+                 failOnError: 'false',
+                 detectOfflineLinks: 'false')
     end
 
-    plugin( :pmd, '2.7.1',
-            'linkXRef' =>  'true',
-            'sourceEncoding' =>  'utf-8',
-            'minimumTokens' =>  '100',
-            'targetJdk' =>  '${base.javac.version}' )
-    plugin( :jxr, '2.3',
-            'linkJavadoc' =>  'true',
-            'aggregate' =>  'true' )
+    plugin(:pmd, '2.7.1',
+           linkXRef: 'true',
+           sourceEncoding: 'utf-8',
+           minimumTokens: '100',
+           targetJdk: '${base.javac.version}')
+    plugin(:jxr, '2.3',
+           linkJavadoc: 'true',
+           aggregate: 'true')
     plugin :'surefire-report', '2.14.1'
-    plugin( 'org.codehaus.mojo:taglist-maven-plugin:2.4',
-            'tagListOptions' => {
-              'tagClasses' => {
-                'tagClass' => {
-                  'tags' => [ { 'matchString' =>  'todo',
-                                'matchType' =>  'ignoreCase' },
-                              { 'matchString' =>  'FIXME',
-                                'matchType' =>  'ignoreCase' },
-                              { 'matchString' =>  'deprecated',
-                                'matchType' =>  'ignoreCase' } ]
-                }
-              }
-            } )
+    plugin('org.codehaus.mojo:taglist-maven-plugin:2.4',
+           tagListOptions: {
+             tagClasses: {
+               tagClass: {
+                 tags: [{ matchString: 'todo',
+                          matchType: 'ignoreCase' },
+                        { matchString: 'FIXME',
+                          matchType: 'ignoreCase' },
+                        { matchString: 'deprecated',
+                          matchType: 'ignoreCase' }]
+               }
+             }
+           })
     plugin 'org.codehaus.mojo:versions-maven-plugin:2.1' do
       report_set 'dependency-updates-report', 'plugin-updates-report', 'property-updates-report'
     end

--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -1,36 +1,35 @@
+# frozen_string_literal: true
+
 version = ENV['JRUBY_VERSION'] ||
-  File.read( File.join( basedir, '..', 'VERSION' ) ).strip
+          File.read(File.join(basedir, '..', 'VERSION')).strip
 
-# note: the module name is logical and the artifact keeps it legacy name
+# NOTE: the module name is logical and the artifact keeps it legacy name
 project 'JRuby Core' do
-
   model_version '4.0.0'
   inherit 'org.jruby:jruby-parent', version
   id 'org.jruby:jruby-core'
 
-  properties( 'polyglot.dump.pom' => 'pom.xml',
-              'polyglot.dump.readonly' => true,
-              'jruby.basedir' => '${basedir}/..'
-            )
+  properties("polyglot.dump.pom": 'pom.xml',
+             "polyglot.dump.readonly": true,
+             "jruby.basedir": '${basedir}/..')
 
   jar 'org.jruby:jruby-base', '${project.version}'
   plugin :shade do
-    execute_goals( 'shade',
-                   id: 'create shaded jar',
-                   phase: 'package',
-                   artifactSet: {
-                       excludes: 'javax.annotation:javax.annotation-api'
-                   },
-                   relocations: [
-                       {pattern: 'org.objectweb', shadedPattern: 'org.jruby.org.objectweb' },
-                       {pattern: 'me.qmx.jitescript', shadedPattern: 'org.jruby.me.qmx.jitescript'},
-                   ],
-                   transformers: [ {'@implementation' => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
-                                         mainClass: 'org.jruby.Main',
-                                         manifestEntries: {'Automatic-Module-Name' => 'org.jruby.dist'}}],
-                   createSourcesJar: false,
-                   compress: false
-    )
+    execute_goals('shade',
+                  id: 'create shaded jar',
+                  phase: 'package',
+                  artifactSet: {
+                    excludes: 'javax.annotation:javax.annotation-api'
+                  },
+                  relocations: [
+                    { pattern: 'org.objectweb', shadedPattern: 'org.jruby.org.objectweb' },
+                    { pattern: 'me.qmx.jitescript', shadedPattern: 'org.jruby.me.qmx.jitescript' }
+                  ],
+                  transformers: [{ :@implementation => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
+                                   mainClass: 'org.jruby.Main',
+                                   manifestEntries: { "Automatic-Module-Name": 'org.jruby.dist' } }],
+                  createSourcesJar: false,
+                  compress: false)
   end
 
   plugin :'com.coderplus.maven.plugins:copy-rename-maven-plugin', '1.0' do
@@ -41,51 +40,48 @@ project 'JRuby Core' do
                   destinationFile: '${jruby.basedir}/lib/jruby.jar'
   end
 
-  plugin( :compiler,
-          'encoding' => 'utf-8',
-          'verbose' => 'true',
-          'fork' => 'false',
-          'compilerArgs' => { 'arg' => '-J-Xmx1G' },
-          'showWarnings' => 'true',
-          'showDeprecation' => 'true',
-          'source' => [ '${base.java.version}', '1.8' ],
-          'target' => [ '${base.javac.version}', '1.8' ],
-          'useIncrementalCompilation' =>  'false' )
+  plugin(:compiler,
+         encoding: 'utf-8',
+         verbose: 'true',
+         fork: 'false',
+         compilerArgs: { arg: '-J-Xmx1G' },
+         showWarnings: 'true',
+         showDeprecation: 'true',
+         source: ['${base.java.version}', '1.8'],
+         target: ['${base.javac.version}', '1.8'],
+         useIncrementalCompilation: 'false')
 
+  plugin(:source, skipSource: 'true')
 
-  plugin( :source, 'skipSource' =>  'true' )
-
-  [:all, :release, :main, :osgi, :j2ee, :complete, :dist, :'jruby_complete_jar_extended', :'jruby-jars' ].each do |name|
+  %i[all release main osgi j2ee complete dist jruby_complete_jar_extended jruby-jars].each do |name|
     profile name do
       # we shade in all dependencies which use the asm classes and relocate
       # the asm package-name. with all jruby artifacts behave the same
       # regarding asm: lib/jruby, jruby-core and jruby-complete via maven
       plugin :shade do
-        execute_goals( 'shade',
-                       id: 'shade dependencies into jar',
-                       phase: 'package',
-                       artifactSet: {
-                           # IMPORTANT these needs to match exclusions in
-                           # maven/jruby-complete/pom.rb
-                           includes: [ 'com.github.jnr:jnr-ffi',
-                                       'me.qmx.jitescript:jitescript',
-                                       'org.ow2.asm:*'
-                           ],
-                           excludes: 'javax.annotation:javax.annotation-api'
-                       },
-                       relocations: [
-                           {pattern: 'org.objectweb', shadedPattern: 'org.jruby.org.objectweb' },
-                           {pattern: 'me.qmx.jitescript', shadedPattern: 'org.jruby.me.qmx.jitescript'},
-                       ],
-                       transformers: [ {'@implementation' => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
-                                         'mainClass' => 'org.jruby.Main',
-                                         'manifestEntries' => {'Automatic-Module-Name' => 'org.jruby.dist'}}],
-                       filters: [
-                           {artifact: 'com.headius:invokebinder', excludes: '**/module-info.class'}
-                       ],
-                       createSourcesJar: true,
-                       compress: true
-        )
+        execute_goals('shade',
+                      id: 'shade dependencies into jar',
+                      phase: 'package',
+                      artifactSet: {
+                        # IMPORTANT these needs to match exclusions in
+                        # maven/jruby-complete/pom.rb
+                        includes: ['com.github.jnr:jnr-ffi',
+                                   'me.qmx.jitescript:jitescript',
+                                   'org.ow2.asm:*'],
+                        excludes: 'javax.annotation:javax.annotation-api'
+                      },
+                      relocations: [
+                        { pattern: 'org.objectweb', shadedPattern: 'org.jruby.org.objectweb' },
+                        { pattern: 'me.qmx.jitescript', shadedPattern: 'org.jruby.me.qmx.jitescript' }
+                      ],
+                      transformers: [{ :@implementation => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
+                                       :mainClass => 'org.jruby.Main',
+                                       :manifestEntries => { "Automatic-Module-Name": 'org.jruby.dist' } }],
+                      filters: [
+                        { artifact: 'com.headius:invokebinder', excludes: '**/module-info.class' }
+                      ],
+                      createSourcesJar: true,
+                      compress: true)
       end
     end
   end

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 version = ENV['JRUBY_VERSION'] ||
-  File.read( File.join( basedir, '..', 'VERSION' ) ).strip
+          File.read(File.join(basedir, '..', 'VERSION')).strip
 
 project 'JRuby Integration Tests' do
-
   model_version '4.0.0'
 
   inherit 'org.jruby:jruby-parent', version
@@ -10,18 +11,18 @@ project 'JRuby Integration Tests' do
 
   extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 
-  repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'
-  plugin_repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'
+  repository id: :mavengems, url: 'mavengem:http://rubygems.org'
+  plugin_repository id: :mavengems, url: 'mavengem:http://rubygems.org'
 
-  plugin_repository( :url => 'https://central.sonatype.com/repository/maven-snapshots/',
-                     :id => 'sonatype' ) do
+  plugin_repository(url: 'https://central.sonatype.com/repository/maven-snapshots/',
+                    id: 'sonatype') do
     releases 'false'
     snapshots 'true'
   end
 
-  properties( 'polyglot.dump.pom' => 'pom.xml',
-              'jruby.home' => '${basedir}/..',
-              'gem.home' => '${jruby.home}/lib/ruby/gems/shared' )
+  properties("polyglot.dump.pom": 'pom.xml',
+             "jruby.home": '${basedir}/..',
+             "gem.home": '${jruby.home}/lib/ruby/gems/shared')
 
   scope :test do
     jar 'junit:junit:4.11'
@@ -32,70 +33,69 @@ project 'JRuby Integration Tests' do
   scope :provided do
     jar 'org.apache.ant:ant:${ant.version}'
   end
-  jar( 'org.jruby:requireTest:1.0',
-       :scope => 'system',
-       :systemPath => '${project.basedir}/jruby/requireTest-1.0.jar' )
+  jar('org.jruby:requireTest:1.0',
+      scope: 'system',
+      systemPath: '${project.basedir}/jruby/requireTest-1.0.jar')
 
   overrides do
-    plugin( 'org.eclipse.m2e:lifecycle-mapping:1.0.0',
-            'lifecycleMappingMetadata' => {
-              'pluginExecutions' => [ { 'pluginExecutionFilter' => {
-                                          'groupId' =>  'org.jruby.maven',
-                                          'artifactId' =>  'gem-maven-plugin',
-                                          'versionRange' =>  '[1.0.0-rc3,)',
-                                          'goals' => [ 'initialize' ]
-                                        },
-                                        'action' => {
-                                          'ignore' =>  ''
-                                        } } ]
-            } )
+    plugin('org.eclipse.m2e:lifecycle-mapping:1.0.0',
+           lifecycleMappingMetadata: {
+             pluginExecutions: [{ pluginExecutionFilter: {
+                                    groupId: 'org.jruby.maven',
+                                    artifactId: 'gem-maven-plugin',
+                                    versionRange: '[1.0.0-rc3,)',
+                                    goals: ['initialize']
+                                  },
+                                  action: {
+                                    ignore: ''
+                                  } }]
+           })
   end
 
   jruby_plugin :gem, '${jruby.plugins.version}' do
-    options = { :phase => 'initialize',
-      'gemPath' => '${gem.home}',
-      'gemHome' => '${gem.home}',
-      'binDirectory' => '${jruby.home}/bin',
-      'includeRubygemsInTestResources' => 'false',
-    }
+    options = { phase: 'initialize',
+                gemPath: '${gem.home}',
+                gemHome: '${gem.home}',
+                binDirectory: '${jruby.home}/bin',
+                includeRubygemsInTestResources: 'false' }
 
-    execute_goals( 'initialize', options )
+    execute_goals('initialize', options)
   end
 
-  plugin( :compiler,
-          'encoding' =>  'utf-8',
-          'debug' =>  'true',
-          'verbose' =>  'true',
-          'fork' =>  'true',
-          'showWarnings' =>  'true',
-          'showDeprecation' =>  'true',
-          'source' =>  '${base.java.version}',
-          'target' =>  '${base.java.version}' )
+  plugin(:compiler,
+         encoding: 'utf-8',
+         debug: 'true',
+         verbose: 'true',
+         fork: 'true',
+         showWarnings: 'true',
+         showDeprecation: 'true',
+         source: '${base.java.version}',
+         target: '${base.java.version}')
   plugin :dependency do
-    execute_goals( 'copy',
-                   :id => 'copy jars for testing',
-                   :phase => 'process-classes',
-                   'artifactItems' => [ { 'groupId' =>  'junit',
-                                          'artifactId' =>  'junit',
-                                          'version' =>  '4.11',
-                                          'type' =>  'jar',
-                                          'overWrite' =>  'false',
-                                          'outputDirectory' =>  'target',
-                                          'destFileName' =>  'junit.jar' },
-                                        { 'groupId' =>  'com.googlecode.jarjar',
-                                          'artifactId' =>  'jarjar',
-                                          'version' =>  '1.1',
-                                          'type' =>  'jar',
-                                          'overWrite' =>  'false',
-                                          'outputDirectory' =>  'target',
-                                          'destFileName' =>  'jarjar.jar' } ] )
+    execute_goals('copy',
+                  id: 'copy jars for testing',
+                  phase: 'process-classes',
+                  artifactItems: [{ groupId: 'junit',
+                                    artifactId: 'junit',
+                                    version: '4.11',
+                                    type: 'jar',
+                                    overWrite: 'false',
+                                    outputDirectory: 'target',
+                                    destFileName: 'junit.jar' },
+                                  { groupId: 'com.googlecode.jarjar',
+                                    artifactId: 'jarjar',
+                                    version: '1.1',
+                                    type: 'jar',
+                                    overWrite: 'false',
+                                    outputDirectory: 'target',
+                                    destFileName: 'jarjar.jar' }])
   end
 
-  plugin( :deploy,
-          'skip' =>  'true' )
-  plugin( :site,
-          'skip' =>  'true',
-          'skipDeploy' =>  'true' )
+  plugin(:deploy,
+         skip: 'true')
+  plugin(:site,
+         skip: 'true',
+         skipDeploy: 'true')
 
   build do
     default_goal 'test'
@@ -103,67 +103,64 @@ project 'JRuby Integration Tests' do
   end
 
   profile 'rake' do
-
     plugin :antrun do
-      execute_goals( 'run',
-                     :id => 'rake',
-                     :phase => 'test',
-                     :configuration => [ xml( '<target><exec dir="${jruby.home}" executable="${jruby.home}/bin/jruby" failonerror="true"><env key="JRUBY_OPTS" value=""/><arg value="-S"/><arg value="rake"/><arg value="${task}"/></exec></target>' ) ] )
+      execute_goals('run',
+                    id: 'rake',
+                    phase: 'test',
+                    configuration: [xml('<target><exec dir="${jruby.home}" executable="${jruby.home}/bin/jruby" failonerror="true"><env key="JRUBY_OPTS" value=""/><arg value="-S"/><arg value="rake"/><arg value="${task}"/></exec></target>')])
     end
-
   end
 
   profile 'jruby_complete_jar_extended' do
-
-    jar 'org.jruby:jruby-complete', '${project.version}', :scope => :provided
+    jar 'org.jruby:jruby-complete', '${project.version}', scope: :provided
 
     plugin :antrun do
-      [ 'jruby', 'objectspace', 'slow' ].each do |index|
+      %w[jruby objectspace slow].each do |index|
         filenames = []
-        File.open(File.join(basedir, index + '.index')) do |file|
+        File.open(File.join(basedir, "#{index}.index")) do |file|
           file.each_line do |line|
             next if line =~ /^#/ || line.strip.empty?
+
             filename = "mri/#{line.chomp}"
             filename = "jruby/#{line.chomp}.rb" unless File.exist? File.join(basedir, filename)
             filename = "#{line.chomp}.rb" unless File.exist? File.join(basedir, filename)
-            next if filename =~ /mri\/psych\//
-            next if filename =~ /mri\/net\/http\//
+            next if filename =~ %r{mri/psych/}
+            next if filename =~ %r{mri/net/http/}
             next unless File.exist? File.join(basedir, filename)
+
             filenames << filename
           end
         end
 
         # some tests from jruby suite (test/jruby/test_kernel.rb, test/jruby/test_socket.rb) need sub-process control
-        if ENV_JAVA['java.specification.version'].to_i > 8
-          add_opens = ['java.base/java.io=ALL-UNNAMED', 'java.base/sun.nio.ch=ALL-UNNAMED']
-        else
-          add_opens = []
-        end
+        add_opens = if ENV_JAVA['java.specification.version'].to_i > 8
+                      ['java.base/java.io=ALL-UNNAMED', 'java.base/sun.nio.ch=ALL-UNNAMED']
+                    else
+                      []
+                    end
 
-        execute_goals( 'run',
-                       :id => "jruby_complete_jar_#{index}",
-                       :phase => 'test',
-                       :configuration => [
-                         xml( "<target unless='maven.test.skip'>" +
-                                "<exec dir='${jruby.home}' executable='java' failonerror='true'>" +
-                                  add_opens.map { |value| "<arg value='--add-opens'/><arg value='#{value}'/>" }.join +
-                                  "<arg value='-Djruby.home=${jruby.home}'/>" +
-                                  "<arg value='-cp'/>" +
-                                  "<arg value='core/target/test-classes:test/target/test-classes:maven/jruby-complete/target/jruby-complete-${project.version}.jar'/>" +
-                                  "<arg value='-Djruby.home=${jruby.home}'/>" +
-                                  "<arg value='-Djruby.aot.loadClasses=true'/>" +
-                                  "<arg value='org.jruby.Main'/>" +
-                                  "<arg value='-I.'/>" +
-                                  "<arg value='-Itest'/>" +
-                                  "<arg value='lib/ruby/gems/shared/gems/rake-${rake.version}/lib/rake/rake_test_loader.rb'/>" +
-                                  filenames.map { |filename| "<arg value='test/#{filename}'/>" }.join +
-                                  "<arg value='-v'/>
+        execute_goals('run',
+                      id: "jruby_complete_jar_#{index}",
+                      phase: 'test',
+                      configuration: [
+                        xml("<target unless='maven.test.skip'>" \
+                               "<exec dir='${jruby.home}' executable='java' failonerror='true'>" +
+                                 add_opens.map { |value| "<arg value='--add-opens'/><arg value='#{value}'/>" }.join +
+                                 "<arg value='-Djruby.home=${jruby.home}'/>" \
+                                 "<arg value='-cp'/>" \
+                                 "<arg value='core/target/test-classes:test/target/test-classes:maven/jruby-complete/target/jruby-complete-${project.version}.jar'/>" \
+                                 "<arg value='-Djruby.home=${jruby.home}'/>" \
+                                 "<arg value='-Djruby.aot.loadClasses=true'/>" \
+                                 "<arg value='org.jruby.Main'/>" \
+                                 "<arg value='-I.'/>" \
+                                 "<arg value='-Itest'/>" \
+                                 "<arg value='lib/ruby/gems/shared/gems/rake-${rake.version}/lib/rake/rake_test_loader.rb'/>" +
+                                 filenames.map { |filename| "<arg value='test/#{filename}'/>" }.join +
+                                 "<arg value='-v'/>
                                 </exec>
-                              </target>" )
-                       ] )
+                              </target>")
+                      ])
       end
     end
-
   end
-
 end


### PR DESCRIPTION
Clean up all polyglot pom files using automated tools. These changes are highly unlikely to merge across branches, so we'll run this process against 9.4 and 10 separately.