### PR TITLE
regression fix in glob

### DIFF
--- a/core/src/main/java/org/jruby/util/Dir.java
+++ b/core/src/main/java/org/jruby/util/Dir.java
@@ -884,7 +884,7 @@ public class Dir {
 
             final int SLASH_INDEX = indexOf(path, ptr, end, (byte) '/');
             final GlobMagic magical = has_magic(path, ptr, SLASH_INDEX == -1 ? end : SLASH_INDEX, flags);
-            if (magical.compareTo(nonMagic) > 0) {
+            if (magical == GlobMagic.MAGICAL) {
                 finalize: do {
                     byte[] base = extract_path(path, begin, ptr);
                     byte[] dir = begin == ptr ? new byte[] { '.' } : base;


### PR DESCRIPTION
I think nonMagic is not doing the right thing as it completely bypasses any found magic (e.g. *, **, ? ....) in processing.