### PR TITLE
Fix language spec where error string changed

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -602,7 +602,7 @@ public abstract class RubyParserBase {
             yyerror("keyword arg given in index");
         }
         if (block != null) {
-            yyerror("block arg given in index");
+            yyerror("block arg given in index assignment");
         }
     }
 

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1253,6 +1253,8 @@ public abstract class RubyParserBase {
     public Node new_ary_op_assign(Node receiverNode, Node argsNode, ByteList operatorName, Node valueNode) {
         int line = lexer.tokline;
 
+        aryset_check(argsNode);
+
         // We extract BlockPass from tree and insert it as a block node value (MRI wraps it around the args)
         Node blockNode = null;
         if (argsNode instanceof BlockPassNode) {

--- a/spec/tags/ruby/language/assignments_tags.txt
+++ b/spec/tags/ruby/language/assignments_tags.txt
@@ -1,3 +1,1 @@
-fails:Multiple assignments evaluation order evaluates expressions right to left when assignment with compounded constant
-fails:Assignments using = given block argument raises SyntaxError
 fails:Assignments using += using a #[] given block argument raises SyntaxError

--- a/spec/tags/ruby/language/assignments_tags.txt
+++ b/spec/tags/ruby/language/assignments_tags.txt
@@ -1,1 +1,0 @@
-fails:Assignments using += using a #[] given block argument raises SyntaxError


### PR DESCRIPTION
error string changed for ```            eval "obj[:a, &block] = 2"```