### PR TITLE
Explicitly request access before Lookup.find*

### DIFF
--- a/core/src/main/java/org/jruby/runtime/invokedynamic/InvokeDynamicSupport.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/InvokeDynamicSupport.java
@@ -28,6 +28,7 @@
 package org.jruby.runtime.invokedynamic;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 
 import org.jruby.*;
@@ -43,7 +44,9 @@ import org.jruby.runtime.callsite.CacheEntry;
 import static java.lang.invoke.MethodHandles.*;
 
 public class InvokeDynamicSupport {
-    
+    private static final Lookup LOOKUP = MethodHandles.lookup();
+    private static final Module JRUBY_MODULE = InvokeDynamicSupport.class.getModule();
+
     ////////////////////////////////////////////////////////////////////////////
     // method_missing support code
     ////////////////////////////////////////////////////////////////////////////
@@ -72,7 +75,8 @@ public class InvokeDynamicSupport {
     
     public static MethodHandle findStatic(Class target, String name, MethodType type) {
         try {
-            return lookup().findStatic(target, name, type);
+            JRUBY_MODULE.addReads(target.getModule());
+            return LOOKUP.findStatic(target, name, type);
         } catch (NoSuchMethodException|IllegalAccessException ex) {
             throw new RuntimeException(ex);
         }
@@ -80,7 +84,8 @@ public class InvokeDynamicSupport {
 
     public static MethodHandle findVirtual(Class target, String name, MethodType type) {
         try {
-            return lookup().findVirtual(target, name, type);
+            JRUBY_MODULE.addReads(target.getModule());
+            return LOOKUP.findVirtual(target, name, type);
         } catch (NoSuchMethodException|IllegalAccessException ex) {
             throw new RuntimeException(ex);
         }

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1586,5 +1586,12 @@ modes.each do |mode|
         expect(it).to eq("a#{$$}" * 24)
       end
     end
+
+    it "can invoke java.lang.reflect.Proxy dynamic proxy objects" do
+      run(<<~RUBY) { expect(it).to eq [1].to_java }
+        proxy = java.lang.reflect.Proxy.newProxyInstance(JRuby.runtime.jruby_class_loader, [java.util.function.Function].to_java(java.lang.Class)) {|o, m, x| x}
+        proxy.apply(1)
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Edit: a previous version of this patch attempted to switch these lookups to `publicLookup()`, but that broke several tests and internal logic that needed "more than public" access. The new patch was proposed by our friends on the core-libs-dev OpenJDK list.

The Lookup acquired from MethodHandles.lookup appears to produce
IllegalAccessException for cases that publicLookup does not. This
appears to be due to a JDK bug, but we can work around it by'
explicitly requesting read access to the target class's module.

There have been similar bugs relating to the use of
MethodHandles.lookup versus MethodHandles.publicLookup. The most
recent bug was filed in https://github.com/jruby/jruby/issues/8987. Related JRuby bugs and
an OpenJDK bug filed by me are also referenced from there. There's
also a link to an OpenJDK core-libs-dev thread about this issue.

The change here requests read access from the JRuby module to the
module of the target class, avoiding the accessibility issue for
classes that should otherwise be readable. There may be additional
overhead in acquiring the MethodHandle this way.