### PR TITLE
private_constant should just update existing autoload

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -5639,12 +5639,17 @@ public class RubyModule extends RubyObject {
 
                 storeConstant(context, name, value, hidden, file, line);
             } else {
-                boolean autoloading = setAutoloadConstant(context, name, value, hidden, file, line);
-                if (autoloading) {
-                    // invoke const_added for Autoload in progress
-                    callMethod(context, "const_added", asSymbol(context, name));
-                } else {
+                if (value == UNDEF) {
+                    // original autoload was not loaded, just update visibility
                     storeConstant(context, name, value, hidden, file, line);
+                } else {
+                    boolean autoloading = setAutoloadConstant(context, name, value, hidden, file, line);
+                    if (autoloading) {
+                        // invoke const_added for Autoload in progress
+                        callMethod(context, "const_added", asSymbol(context, name));
+                    } else {
+                        storeConstant(context, name, value, hidden, file, line);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
The logic here was proceeding to set the existing autoload to UNDEF, which then triggered it to be removed as a failed autoload. This left us with a constant table containing a private entry of UNDEF but no autoload in the table to load for it.

The modified logic checks if the incoming value was also UNDEF, indicating that the value was a previously-unloaded or in-progress autoload, and leaves the autoload table alone while just updating the constant table with the new visibility.

Fixes jruby/jruby#8923