### PR TITLE
Avoid binding unreadable modules' classes

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -5362,6 +5362,8 @@ public final class Ruby implements Constantizable {
     private JavaSupport javaSupport;
     private final JRubyClassLoader jrubyClassLoader;
 
+    public static final Module JRUBY_MODULE = Ruby.class.getModule();
+
     // Object Specializer
     private final RubyObjectSpecializer objectSpecializer;
 

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -170,13 +170,13 @@ public class MethodGatherer {
     }
 
     public static void eachAccessibleMethod(final Class<?> javaClass, Predicate<Method[]> classProcessor, Predicate<Method[]> interfaceProcessor) {
-        boolean isPublic = Modifier.isPublic(javaClass.getModifiers());
+        boolean isPublic = Ruby.JRUBY_MODULE.canRead(javaClass.getModule()) && Modifier.isPublic(javaClass.getModifiers());
 
         // we scan all superclasses, but avoid adding superclass methods with
         // same name+signature as subclass methods (see JRUBY-3130)
         for ( Class<?> klass = javaClass; klass != null; klass = klass.getSuperclass() ) {
             // only add if target class is public or source class is public, and package is exported
-            if ((isPublic || Modifier.isPublic(klass.getModifiers())) && Modules.isExported(klass, Java.class)) {
+            if ((isPublic || (Ruby.JRUBY_MODULE.canRead(klass.getModule()) && Modifier.isPublic(klass.getModifiers()))) && Modules.isExported(klass, Java.class)) {
                 // for each class, scan declared methods for new signatures
                 try {
                     // add methods, including static if this is the actual class,

--- a/core/src/main/java/org/jruby/runtime/invokedynamic/InvokeDynamicSupport.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/InvokeDynamicSupport.java
@@ -75,7 +75,6 @@ public class InvokeDynamicSupport {
     
     public static MethodHandle findStatic(Class target, String name, MethodType type) {
         try {
-            JRUBY_MODULE.addReads(target.getModule());
             return LOOKUP.findStatic(target, name, type);
         } catch (NoSuchMethodException|IllegalAccessException ex) {
             throw new RuntimeException(ex);
@@ -84,7 +83,6 @@ public class InvokeDynamicSupport {
 
     public static MethodHandle findVirtual(Class target, String name, MethodType type) {
         try {
-            JRUBY_MODULE.addReads(target.getModule());
             return LOOKUP.findVirtual(target, name, type);
         } catch (NoSuchMethodException|IllegalAccessException ex) {
             throw new RuntimeException(ex);


### PR DESCRIPTION
This PR is an alternative (and probably more correct) fix for #8987, and does the following:

* Removes the old fix to add new modules reads before acquiring method handles (#8989).
* Avoids binding classes that are not **both** in a readable module and public, rather than just basing that determination on Java class visibility.

This fixes the issues in #8987 without adding new module reads for every method handle acquisition.

See the following OpenJDK core-libs-dev discussion for details: https://mail.openjdk.org/pipermail/core-libs-dev/2025-September/151017.html