### PR TITLE
Backport ArgumentError message update from 2010

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -964,7 +964,8 @@ public class LibrarySearcher {
                 script.setFileName(scriptName);
                 runtime.loadScope(script, wrap);
             } catch(IOException e) {
-                throw runtime.newLoadError("no such file to load -- " + searchName, searchName);
+                String name = searchName;
+                throw LoadService.loadFailed(runtime, name);
             }
         }
     }

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -363,7 +363,7 @@ public class LoadService {
         int currentLine = runtime.getCurrentLine();
         try {
             if(!runtime.getProfile().allowLoad(file)) {
-                throw runtime.newLoadError("no such file to load -- " + file, file);
+                throw loadFailed(runtime, file);
             }
 
             LibrarySearcher.FoundLibrary library = librarySearcher.findLibraryForLoad(file);
@@ -372,7 +372,7 @@ public class LoadService {
             if (library == null) {
                 FileResource fileResource = JRubyFile.createResourceAsFile(runtime, file);
 
-                if (!fileResource.exists()) throw runtime.newLoadError("no such file to load -- " + file, file);
+                if (!fileResource.exists()) throw loadFailed(runtime, file);
 
                 library = new LibrarySearcher.FoundLibrary(file, file, LibrarySearcher.ResourceLibrary.create(file, file, fileResource));
             }
@@ -399,7 +399,7 @@ public class LoadService {
 
             LoadServiceResource resource = getClassPathResource(classLoader, file);
 
-            if (resource == null) throw runtime.newLoadError("no such file to load -- " + file);
+            if (resource == null) throw loadFailed(runtime, file);
 
             String loadName = resolveLoadName(resource, file);
             LibrarySearcher.FoundLibrary library =
@@ -541,14 +541,14 @@ public class LoadService {
         checkEmptyLoad(file);
 
         if (!runtime.getProfile().allowRequire(file)) {
-            throw runtime.newLoadError("no such file to load -- " + file, file);
+            throw loadFailed(runtime, file);
         }
 
         LibrarySearcher.FoundLibrary[] libraryHolder = {null};
         char found = searchForRequire(file, libraryHolder);
 
         if (found == 0) {
-            throw runtime.newLoadError("no such file to load -- " + file, file);
+            throw loadFailed(runtime, file);
         }
 
         LibrarySearcher.FoundLibrary library = libraryHolder[0];
@@ -707,7 +707,7 @@ public class LoadService {
 
     protected void checkEmptyLoad(String file) throws RaiseException {
         if (file.isEmpty()) {
-            throw runtime.newLoadError("no such file to load -- " + file, file);
+            throw loadFailed(runtime, file);
         }
     }
 
@@ -785,6 +785,11 @@ public class LoadService {
         } else {
             return new ExternalScript(resource, location);
         }
+    }
+
+    // MRI: load_failed
+    static RaiseException loadFailed(Ruby runtime, String name) {
+        return runtime.newLoadError("cannot load such file -- " + name, name);
     }
 
     protected String getLoadPathEntry(IRubyObject entry) {


### PR DESCRIPTION
Backport of #8929, since this message change appears to have happened long ago in CRuby.

Does not fix anything significant but 9.4.x will now also be green on mustermann specs (cc @dentarg).

Mentioned along with the kwargs regression fix (#8922, backported as #9001) in #9000.