### PR TITLE
Consider .class a source extension during search

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -250,7 +250,12 @@ public class LibrarySearcher {
     }
 
     public static boolean isSourceExt(String file) {
-        return file.endsWith(".rb");
+        for (Suffix suffix : Suffix.SOURCES) {
+            if (file.endsWith(suffix.extension)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean isLibraryExt(String file) {


### PR DESCRIPTION
The logic here was ported from CRuby, which only considers .rb to be a source extension. This causes our logic to think a filename like "foo.class" is not a source file and try to load it as either "foo.class.rb" or "foo.class.class". This is the cause of #8758 and prevents explicitly loading precompiled Ruby sources using the filename with .class extension.

The fix here modifies the source extension check to also consider other configured source extensions, so that when .class searching is enabled, we will properly treat `require "foo.class"` as a source file.

Fixes #8758

This affects all releases since 9.3.0.0 and could be backported all the way if we choose.