### PR TITLE
Handle `warn(foo, uplevel: nil`)

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1484,7 +1484,7 @@ public class RubyKernel {
                 argMessagesLen--;
 
                 IRubyObject[] ret = ArgsUtil.extractKeywordArgs(context, (RubyHash) opts, "uplevel", "category");
-                if (ret[0] != null) {
+                if (ret[0] != null && !ret[0].isNil()) {
                     explicitUplevel = true;
                     uplevel = toInt(context, ret[0]);
                     if (uplevel < 0) throw argumentError(context, "negative level (" + uplevel + ")");

--- a/spec/ruby/core/kernel/warn_spec.rb
+++ b/spec/ruby/core/kernel/warn_spec.rb
@@ -112,6 +112,12 @@ describe "Kernel#warn" do
       ruby_exe(file, options: "-rrubygems", args: "2>&1").should == "#{file}:2: warning: warn-require-warning\n"
     end
 
+    it "doesn't show the caller when the uplevel is `nil`" do
+      w = KernelSpecs::WarnInNestedCall.new
+
+      -> { w.f4("foo", nil) }.should output(nil, "foo\n")
+    end
+
     guard -> { Kernel.instance_method(:tap).source_location } do
       it "skips <internal: core library methods defined in Ruby" do
         file, line = Kernel.instance_method(:tap).source_location


### PR DESCRIPTION
Ruby simply ignores the nil uplevel (it is the default value), JRuby tries to convert it to an integer.

I wanted to write such code for a polyfill in https://github.com/ruby/prism/pull/3647 but had to change it around to make work on jruby.