### PR TITLE
Fix "+00:00" and 0 being treated as UTC by Time#localtime and Time.at

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -628,15 +628,14 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = "localtime")
     public RubyTime localtime(ThreadContext context, IRubyObject arg) {
-        final DateTimeZone zone = getTimeZoneFromUtcOffset(context, arg);
+        setIsTzRelative(false);
+        final DateTimeZone zone = handleUTCDateTimeZone(context, arg);
 
         if (zone == null) {
             throw invalidUTCOffset(context);
-        } else if (zone == DateTimeZone.UTC) {
-            return gmtime(context);
         }
 
-        return adjustTimeZone(context, zone, true);
+        return adjustTimeZone(context, zone, isTzRelative);
     }
 
     private RubyTime adjustTimeZone(ThreadContext context, final DateTimeZone zone, boolean isTzRelative) {
@@ -2300,15 +2299,15 @@ public class RubyTime extends RubyObject {
 
         if (zoneLocalTime(context, zone, time)) return time;
 
-        if ((dtz = getTimeZoneFromUtcOffset(context, off)) == null) {
+        time.setIsTzRelative(false);
+
+        if ((dtz = time.handleUTCDateTimeZone(context, off)) == null) {
             zone = time.findTimezone(context, zone);
             if (!zoneLocalTime(context, zone, time)) throw invalidUTCOffset(context, zone);
             return time;
-        } else if (dtz == DateTimeZone.UTC) {
-            return time.gmtime(context);
         }
 
-        time.adjustTimeZone(context, dtz, false);
+        time.adjustTimeZone(context, dtz, time.isTzRelative);
 
         return time;
     }

--- a/spec/ruby/core/time/utc_spec.rb
+++ b/spec/ruby/core/time/utc_spec.rb
@@ -43,10 +43,14 @@ describe "Time#utc?" do
 
   it "does not treat time with +00:00 offset as UTC" do
     Time.new(2022, 1, 1, 0, 0, 0, "+00:00").utc?.should == false
+    Time.now.localtime("+00:00").utc?.should == false
+    Time.at(Time.now, in: "+00:00").utc?.should == false
   end
 
   it "does not treat time with 0 offset as UTC" do
     Time.new(2022, 1, 1, 0, 0, 0, 0).utc?.should == false
+    Time.now.localtime(0).utc?.should == false
+    Time.at(Time.now, in: 0).utc?.should == false
   end
 end
 


### PR DESCRIPTION
This PR changes `Time#localtime` and `Time.at`, so that it no longer treats a zone of `"+00:00"` or `0` as UTC (i.e. `Time#utc?` will return `false`). It resolves #8998.

I've included some additional test cases from ruby/spec#1285.

The fixes to both methods reset `isTzRelative` to `false` and then use `handleUTCDateTimeZone` to determine the time zone instead of `getTimeZoneFromUtcOffset`. `handleUTCDateTimeZone` calls `getTimeZoneFromUtcOffset` and contains the necessary checks to determine if the specified zone should be treated as UTC. It sets `isTzRelative` to `true` if not. The call to `adjustTimeZone` is then made with the newly set `isTzRelative` value.

