### PR TITLE
Update rexml gem to solve CVE-2025-58767

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -141,7 +141,7 @@ bundled_gems = [
   # Depends on prism gem with native ext
   # ['repl_type_completer', '0.1.1'],
   ['resolv-replace', '0.1.1'],
-  ['rexml', '3.4.0'],
+  ['rexml', '3.4.4'],
   ['rinda', '0.2.0'],
   ['rss', '0.3.1'],
   # https://github.com/ruby/syslog/issues/1

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -1048,7 +1048,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rexml</artifactId>
-      <version>3.4.0</version>
+      <version>3.4.4</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1196,7 +1196,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/racc-1.8.1*</include>
           <include>specifications/rake-${rake.version}*</include>
           <include>specifications/resolv-replace-0.1.1*</include>
-          <include>specifications/rexml-3.4.0*</include>
+          <include>specifications/rexml-3.4.4*</include>
           <include>specifications/rinda-0.2.0*</include>
           <include>specifications/rss-0.3.1*</include>
           <include>specifications/test-unit-3.6.7*</include>
@@ -1278,7 +1278,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/racc-1.8.1*/**/*</include>
           <include>gems/rake-${rake.version}*/**/*</include>
           <include>gems/resolv-replace-0.1.1*/**/*</include>
-          <include>gems/rexml-3.4.0*/**/*</include>
+          <include>gems/rexml-3.4.4*/**/*</include>
           <include>gems/rinda-0.2.0*/**/*</include>
           <include>gems/rss-0.3.1*/**/*</include>
           <include>gems/test-unit-3.6.7*/**/*</include>
@@ -1360,7 +1360,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/racc-1.8.1*</include>
           <include>cache/rake-${rake.version}*</include>
           <include>cache/resolv-replace-0.1.1*</include>
-          <include>cache/rexml-3.4.0*</include>
+          <include>cache/rexml-3.4.4*</include>
           <include>cache/rinda-0.2.0*</include>
           <include>cache/rss-0.3.1*</include>
           <include>cache/test-unit-3.6.7*</include>


### PR DESCRIPTION
The REXML gems from 3.3.3 to 3.4.1 has a DoS vulnerability when parsing XML containing multiple XML declarations.

https://github.com/ruby/rexml/security/advisories/GHSA-c2f4-jgmc-q2r5