### PR TITLE
Rexml security updateUpdate rexml gem to solve CVE-2025-58767 (9.4)

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -140,7 +140,7 @@ bundled_gems = [
   ['rake', '${rake.version}'],
   # Depends on many CRuby internals
   # ['rbs', '2.0.0'],
-  ['rexml', '3.3.9'],
+  ['rexml', '3.4.4'],
   ['rss', '0.3.1'],
   ['test-unit', '3.5.3']
   # Depends on many CRuby internals

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -1034,7 +1034,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rexml</artifactId>
-      <version>3.3.9</version>
+      <version>3.4.4</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1168,7 +1168,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/prime-0.1.2*</include>
           <include>specifications/power_assert-2.0.1*</include>
           <include>specifications/rake-${rake.version}*</include>
-          <include>specifications/rexml-3.3.9*</include>
+          <include>specifications/rexml-3.4.4*</include>
           <include>specifications/rss-0.3.1*</include>
           <include>specifications/test-unit-3.5.3*</include>
           <include>gems/rubygems-update-3.6.3*/**/*</include>
@@ -1248,7 +1248,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/prime-0.1.2*/**/*</include>
           <include>gems/power_assert-2.0.1*/**/*</include>
           <include>gems/rake-${rake.version}*/**/*</include>
-          <include>gems/rexml-3.3.9*/**/*</include>
+          <include>gems/rexml-3.4.4*/**/*</include>
           <include>gems/rss-0.3.1*/**/*</include>
           <include>gems/test-unit-3.5.3*/**/*</include>
           <include>cache/rubygems-update-3.6.3*</include>
@@ -1328,7 +1328,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/prime-0.1.2*</include>
           <include>cache/power_assert-2.0.1*</include>
           <include>cache/rake-${rake.version}*</include>
-          <include>cache/rexml-3.3.9*</include>
+          <include>cache/rexml-3.4.4*</include>
           <include>cache/rss-0.3.1*</include>
           <include>cache/test-unit-3.5.3*</include>
         </includes>


### PR DESCRIPTION
Backport of #9011 to 9.4.