### PR TITLE
We need to remove \r from heredoc strings

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
@@ -143,7 +143,7 @@ public class HeredocTerm extends StrTerm {
                         case '\n':
                             pend--;
                             if (pend == p || lexer.p(pend-1) == '\r') {
-                                pend++;
+                                pend--;
                                 break;
                             }
                             break;

--- a/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
@@ -142,11 +142,10 @@ public class HeredocTerm extends StrTerm {
                     switch(lexer.p(pend-1)) {
                         case '\n':
                             pend--;
-                            if (pend == p || lexer.p(pend-1) == '\r') {
-                                pend--;
+                            if (pend == p || lexer.p(pend - 1) != '\r') {
+                                pend++;
                                 break;
                             }
-                            break;
                         case '\r':
                             pend--;
                             break;

--- a/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
@@ -125,11 +125,10 @@ public class HeredocTerm extends StrTerm {
                     switch (lexer.p(pend - 1)) {
                         case '\n':
                             pend--;
-                            if (pend == p || lexer.p(pend - 1) == '\r') {
-                                pend--;
+                            if (pend == p || lexer.p(pend - 1) != '\r') {
+                                pend++;
                                 break;
                             }
-                            break;
                         case '\r':
                             pend--;
                             break;

--- a/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
@@ -126,7 +126,7 @@ public class HeredocTerm extends StrTerm {
                         case '\n':
                             pend--;
                             if (pend == p || lexer.p(pend - 1) == '\r') {
-                                pend++;
+                                pend--;
                                 break;
                             }
                             break;


### PR DESCRIPTION
We need to remove \r from heredoc strings.  This should fix #9018.  There may be a followup in StringTerm if it also does the wrong thing in multiline strings.