### PR TITLE
Retire safe double processing utilities

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -56,7 +56,6 @@ import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
-import org.jruby.util.SafeDoubleParser;
 import org.jruby.util.StringSupport;
 
 import static org.jruby.api.Access.kernelModule;
@@ -1685,7 +1684,7 @@ public class RubyBigDecimal extends RubyNumeric {
     @Override
     @JRubyAPI
     public double asDouble(ThreadContext context) {
-        return SafeDoubleParser.doubleValue(value);
+        return value.doubleValue();
     }
 
     @Override
@@ -2141,7 +2140,7 @@ public class RubyBigDecimal extends RubyNumeric {
             return asFloat(context, 0);
         }
 
-        return asFloat(context, SafeDoubleParser.doubleValue(value));
+        return asFloat(context, value.doubleValue());
     }
 
     @Override
@@ -2450,7 +2449,7 @@ public class RubyBigDecimal extends RubyNumeric {
       int shift = Math.max(0, biLen - BITS + (biLen%2 == 0 ? 0 : 1));   // even shift..
       bi = bi.shiftRight(shift);                  // ..floors to 62 or 63 bit BigInteger
 
-      double root = Math.sqrt(SafeDoubleParser.doubleValue(bi));
+      double root = Math.sqrt(bi.doubleValue());
       BigDecimal halfBack = new BigDecimal(BigInteger.ONE.shiftLeft(shift/2));
 
       int scale = squarD.scale();

--- a/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
@@ -43,14 +43,12 @@ import org.jruby.parser.RubyParserBase;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.RegexpOptions;
-import org.jruby.util.SafeDoubleParser;
 import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
 
 import static org.jruby.ext.ripper.RipperParser.*;
 import static org.jruby.parser.RubyParser.tGVAR;
 import static org.jruby.util.StringSupport.CR_7BIT;
-import static org.jruby.util.StringSupport.codeRangeScan;
 
 public class RubyLexer extends LexingCommon {
     private static final HashMap<String, Keyword> map;
@@ -127,13 +125,10 @@ public class RubyLexer extends LexingCommon {
             return considerComplex(tRATIONAL, suffix);
         }
 
-        double d;
         try {
-            d = SafeDoubleParser.parseDouble(number);
+            Double.valueOf(number);
         } catch (NumberFormatException e) {
             warn("Float " + number + " out of range.");
-
-            d = number.startsWith("-") ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
         }
 
         return considerComplex(tFLOAT, suffix);

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -66,7 +66,6 @@ import org.jruby.parser.RubyParserBase;
 import org.jruby.parser.ProductionState;
 import org.jruby.util.ByteList;
 import org.jruby.util.RegexpOptions;
-import org.jruby.util.SafeDoubleParser;
 import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
 
@@ -634,7 +633,7 @@ public class RubyLexer extends LexingCommon {
 
         double d;
         try {
-            d = SafeDoubleParser.parseDouble(number);
+            d = Double.valueOf(number);
         } catch (NumberFormatException e) {
             warning(ID.FLOAT_OUT_OF_RANGE, "Float " + number + " out of range.");
 

--- a/core/src/main/java/org/jruby/util/ConvertDouble.java
+++ b/core/src/main/java/org/jruby/util/ConvertDouble.java
@@ -154,7 +154,7 @@ public class ConvertDouble {
                 addExponentToResult(adjustExponent);
             }
 
-            return SafeDoubleParser.parseDouble(new String(chars, 0, charsIndex));
+            return Double.valueOf(new String(chars, 0, charsIndex));
         }
 
         static class LightweightNumberFormatException extends NumberFormatException {

--- a/core/src/main/java/org/jruby/util/SafeDecimalParser.java
+++ b/core/src/main/java/org/jruby/util/SafeDecimalParser.java
@@ -2,57 +2,18 @@ package org.jruby.util;
 
 import java.math.BigDecimal;
 
+@Deprecated(since = "10.0.4.0")
 class SafeDecimalParser {
-
-    /** Constant 2 */
-    protected static final BigDecimal TWO = new BigDecimal(2);
-
-    /** Lower allowed value */
-    protected static final BigDecimal LOWER = new BigDecimal("2.22507385850720113605e-308");
-
-    /** Upper allowed value */
-    protected static final BigDecimal UPPER = new BigDecimal("2.22507385850720125958e-308");
-
-    /** The middle of the bad interval - used for rounding bad values */
-    protected static final BigDecimal MIDDLE = LOWER.add(UPPER).divide(TWO);
-
-    /** Upper allowed value as Double */
-    private static final Double UPPER_DOUBLE = Double.valueOf(UPPER.doubleValue());
-
-    /** Lower allowed value as Double */
-    private static final Double LOWER_DOUBLE = Double.valueOf(LOWER.doubleValue());
-
-    /** Digit sequence to trigger the slow path */
-    private static final String SUSPICIOUS_DIGITS = "22250738585072";
-
-    /**
-     * Heuristic test if we should look closer at the value
-     * 
-     * @param s The non-null input String
-     * @return <code>true</code> if the value is suspicious, <code>false</code> otherwise
-     */
-    final protected static boolean isSuspicious(String s) {
-        return digits(s).indexOf(SUSPICIOUS_DIGITS) >= 0;
-    }
-
     /**
      * Safe parsing of a String into a Double
      * 
-     * @param s
-     *            The input String, can be null
+     * @param s The input String, can be null
      * @return The Double value
+     *
      */
+    @Deprecated(since = "10.0.4.0")
     final protected static Double decimalValueOf(String s) {
-        Double result = null;
-        if (s != null) {
-            if (isSuspicious(s)) {
-                // take the slow path
-                result = parseSafely(s);
-            } else {
-                result = Double.valueOf(s);
-            }
-        }
-        return result;
+        return s != null ? Double.valueOf(s) : null;
     }
 
     /**
@@ -62,16 +23,9 @@ class SafeDecimalParser {
      * @param number
      * @return the double value
      */
+    @Deprecated(since = "10.0.4.0")
     final protected static double decimalValue(Number number) {
-        double result = 0;
-        if (number != null) {
-            if (number instanceof BigDecimal) {
-                result = decimalValue((BigDecimal)number);
-            } else {
-                result = number.doubleValue();
-            }
-        }
-        return result;
+        return number != null ? number.doubleValue() : 0.0;
     }
 
     /**
@@ -81,70 +35,8 @@ class SafeDecimalParser {
      * @param bigDecimal
      * @return the double value
      */
+    @Deprecated(since = "10.0.4.0")
     final protected static double decimalValue(BigDecimal bigDecimal) {
-        double result = 0.0;
-        if (bigDecimal != null) {
-            if (isDangerous(bigDecimal)) {
-                result = decimalValueOf(bigDecimal.toString()).doubleValue();
-            } else {
-                result = bigDecimal.doubleValue();
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Slow parsing of a suspicious value
-     * <p>
-     * Rounding takes place if the value is inside the bad interval
-     * 
-     * @param s
-     *            The non-null input String
-     * @return the double value
-     */
-    final private static Double parseSafely(String s) {
-        Double result;
-        BigDecimal bd = new BigDecimal(s);
-        if (isDangerous(bd)) {
-            if (bd.compareTo(MIDDLE) >= 0) {
-                result = UPPER_DOUBLE;
-            } else {
-                result = LOWER_DOUBLE;
-            }
-        } else {
-            result = Double.valueOf(s);
-        }
-        return result;
-    }
-
-    /**
-     * Extract the digits from a numeric string
-     * 
-     * @param s
-     *            The non-null String value
-     * @return A String containing only the digits
-     */
-    final private static String digits(String s) {
-        char[] ca = s.toCharArray();
-        int len = ca.length;
-        StringBuilder b = new StringBuilder(len);
-        for (int i = 0; i < len; i++) {
-            char c = ca[i];
-            if (c >= '0' && c <= '9') {
-                b.append(c);
-            }
-        }
-        return b.toString();
-    }
-
-    /**
-     * Tests if the value is in the dangerous interval
-     * 
-     * @param bd
-     *            The big decimal value
-     * @return <code>true</code> if the value is dangerous, <code>false</code> otherwise
-     */
-    final private static boolean isDangerous(BigDecimal bd) {
-        return bd.compareTo(UPPER) < 0 && bd.compareTo(LOWER) > 0;
+        return bigDecimal != null ? bigDecimal.doubleValue() : 0.0;
     }
 }

--- a/core/src/main/java/org/jruby/util/SafeDecimalParser.java
+++ b/core/src/main/java/org/jruby/util/SafeDecimalParser.java
@@ -2,7 +2,7 @@ package org.jruby.util;
 
 import java.math.BigDecimal;
 
-@Deprecated(since = "10.0.4.0")
+@Deprecated(since = "10.0.3.0")
 class SafeDecimalParser {
     /**
      * Safe parsing of a String into a Double
@@ -11,7 +11,7 @@ class SafeDecimalParser {
      * @return The Double value
      *
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     final protected static Double decimalValueOf(String s) {
         return s != null ? Double.valueOf(s) : null;
     }
@@ -23,7 +23,7 @@ class SafeDecimalParser {
      * @param number
      * @return the double value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     final protected static double decimalValue(Number number) {
         return number != null ? number.doubleValue() : 0.0;
     }
@@ -35,7 +35,7 @@ class SafeDecimalParser {
      * @param bigDecimal
      * @return the double value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     final protected static double decimalValue(BigDecimal bigDecimal) {
         return bigDecimal != null ? bigDecimal.doubleValue() : 0.0;
     }

--- a/core/src/main/java/org/jruby/util/SafeDoubleParser.java
+++ b/core/src/main/java/org/jruby/util/SafeDoubleParser.java
@@ -7,7 +7,7 @@ import java.math.BigDecimal;
  * <p>
  * Prevents brute force attacks using the famous Java bug.
  */
-@Deprecated(since = "10.0.4.0")
+@Deprecated(since = "10.0.3.0")
 final public class SafeDoubleParser extends SafeDecimalParser {
 
     /**
@@ -17,7 +17,7 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      *            The input String
      * @return the Double value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static Double valueOf(String s) {
         return s != null ? Double.valueOf(s) : null;
     }
@@ -29,7 +29,7 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      *            The input String
      * @return the Double value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static Double parseDouble(String s) {
         return s != null ? Double.valueOf(s) : null;
     }
@@ -41,7 +41,7 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      * @param number
      * @return the double value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static double doubleValue(Number number) {
         return number != null ? number.doubleValue() : 0.0;
     }
@@ -53,7 +53,7 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      * @param bigDecimal
      * @return the double value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static double doubleValue(BigDecimal bigDecimal) {
         return bigDecimal != null ? bigDecimal.doubleValue() : 0.0;
     }

--- a/core/src/main/java/org/jruby/util/SafeDoubleParser.java
+++ b/core/src/main/java/org/jruby/util/SafeDoubleParser.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
  * <p>
  * Prevents brute force attacks using the famous Java bug.
  */
+@Deprecated(since = "10.0.4.0")
 final public class SafeDoubleParser extends SafeDecimalParser {
 
     /**
@@ -16,8 +17,9 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      *            The input String
      * @return the Double value
      */
+    @Deprecated(since = "10.0.4.0")
     public static Double valueOf(String s) {
-        return decimalValueOf(s);
+        return s != null ? Double.valueOf(s) : null;
     }
 
     /**
@@ -27,8 +29,9 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      *            The input String
      * @return the Double value
      */
+    @Deprecated(since = "10.0.4.0")
     public static Double parseDouble(String s) {
-        return valueOf(s);
+        return s != null ? Double.valueOf(s) : null;
     }
 
     /**
@@ -38,8 +41,9 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      * @param number
      * @return the double value
      */
+    @Deprecated(since = "10.0.4.0")
     public static double doubleValue(Number number) {
-        return decimalValue(number);
+        return number != null ? number.doubleValue() : 0.0;
     }
 
     /**
@@ -49,7 +53,8 @@ final public class SafeDoubleParser extends SafeDecimalParser {
      * @param bigDecimal
      * @return the double value
      */
+    @Deprecated(since = "10.0.4.0")
     public static double doubleValue(BigDecimal bigDecimal) {
-        return decimalValue(bigDecimal);
+        return bigDecimal != null ? bigDecimal.doubleValue() : 0.0;
     }
 }

--- a/core/src/main/java/org/jruby/util/SafeFloatParser.java
+++ b/core/src/main/java/org/jruby/util/SafeFloatParser.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
  * <p>
  * Prevents brute force attacks using the famous Java bug.
  */
+@Deprecated(since = "10.0.4.0")
 public final class SafeFloatParser extends SafeDecimalParser {
 
     /**
@@ -16,13 +17,9 @@ public final class SafeFloatParser extends SafeDecimalParser {
      *            The input String
      * @return the Float value
      */
+    @Deprecated(since = "10.0.4.0")
     public static Float valueOf(String s) {
-        Float result = null;
-        Double decimalValue = decimalValueOf(s);
-        if (decimalValue != null) {
-            result = Float.valueOf(decimalValue.floatValue());
-        }
-        return result;
+        return s != null ? Float.valueOf(Double.valueOf(s).floatValue()) : null;
     }
 
     /**
@@ -32,8 +29,9 @@ public final class SafeFloatParser extends SafeDecimalParser {
      *            The input String
      * @return the Float value
      */
+    @Deprecated(since = "10.0.4.0")
     public static Float parseFloat(String s) {
-        return valueOf(s);
+        return s != null ? Float.valueOf(Double.valueOf(s).floatValue()) : null;
     }
 
     /**
@@ -43,8 +41,9 @@ public final class SafeFloatParser extends SafeDecimalParser {
      * @param number
      * @return the float value
      */
+    @Deprecated(since = "10.0.4.0")
     public static float floatValue(Number number) {
-        return Float.valueOf((float)decimalValue(number));
+        return number != null ? (float) number.doubleValue() : 0.0f;
     }
 
     /**
@@ -54,7 +53,8 @@ public final class SafeFloatParser extends SafeDecimalParser {
      * @param bigDecimal
      * @return the float value
      */
+    @Deprecated(since = "10.0.4.0")
     public static float floatValue(BigDecimal bigDecimal) {
-        return Float.valueOf((float)decimalValue(bigDecimal));
+        return bigDecimal != null ? (float) bigDecimal.doubleValue() : 0.0f;
     }
 }

--- a/core/src/main/java/org/jruby/util/SafeFloatParser.java
+++ b/core/src/main/java/org/jruby/util/SafeFloatParser.java
@@ -7,7 +7,7 @@ import java.math.BigDecimal;
  * <p>
  * Prevents brute force attacks using the famous Java bug.
  */
-@Deprecated(since = "10.0.4.0")
+@Deprecated(since = "10.0.3.0")
 public final class SafeFloatParser extends SafeDecimalParser {
 
     /**
@@ -17,7 +17,7 @@ public final class SafeFloatParser extends SafeDecimalParser {
      *            The input String
      * @return the Float value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static Float valueOf(String s) {
         return s != null ? Float.valueOf(Double.valueOf(s).floatValue()) : null;
     }
@@ -29,7 +29,7 @@ public final class SafeFloatParser extends SafeDecimalParser {
      *            The input String
      * @return the Float value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static Float parseFloat(String s) {
         return s != null ? Float.valueOf(Double.valueOf(s).floatValue()) : null;
     }
@@ -41,7 +41,7 @@ public final class SafeFloatParser extends SafeDecimalParser {
      * @param number
      * @return the float value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static float floatValue(Number number) {
         return number != null ? (float) number.doubleValue() : 0.0f;
     }
@@ -53,7 +53,7 @@ public final class SafeFloatParser extends SafeDecimalParser {
      * @param bigDecimal
      * @return the float value
      */
-    @Deprecated(since = "10.0.4.0")
+    @Deprecated(since = "10.0.3.0")
     public static float floatValue(BigDecimal bigDecimal) {
         return bigDecimal != null ? (float) bigDecimal.doubleValue() : 0.0f;
     }


### PR DESCRIPTION
This came about when an old version of Java had a CVE and would end up in an endless loop processing a number (numbers?).  This was fixed in Java 1.6.

Here is a reference to it being fixed:
https://www.exploringbinary.com/fpupdater-fixes-the-java-2-2250738585072012e-308-bug/

This should get rid of multiple scans and simplify the overall codepath of converting a string to a double/bigdecimal.