### PR TITLE
Add "since" to bare Deprecated annotations

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -88,7 +88,7 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
         return asFixnum(context, method.getSignature().arityValue());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum arity() {
         return arity(getCurrentContext());
     }
@@ -139,17 +139,17 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
                 context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean public_p(ThreadContext context) {
         return context.runtime.newBoolean(method.getVisibility().isPublic());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean protected_p(ThreadContext context) {
         return context.runtime.newBoolean(method.getVisibility().isProtected());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean private_p(ThreadContext context) {
         return context.runtime.newBoolean(method.getVisibility().isPrivate());
     }

--- a/core/src/main/java/org/jruby/FiberScheduler.java
+++ b/core/src/main/java/org/jruby/FiberScheduler.java
@@ -203,7 +203,7 @@ public class FiberScheduler {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject result(Ruby runtime, int result, Errno error) {
         return result(runtime.getCurrentContext(), result, error);
     }

--- a/core/src/main/java/org/jruby/IncludedModule.java
+++ b/core/src/main/java/org/jruby/IncludedModule.java
@@ -45,7 +45,7 @@ public class IncludedModule extends RubyClass implements DelegatedModule {
         return origin;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     @Override
     public RubyModule getNonIncludedClass() {
         return origin;

--- a/core/src/main/java/org/jruby/IncludedModuleWrapper.java
+++ b/core/src/main/java/org/jruby/IncludedModuleWrapper.java
@@ -80,7 +80,7 @@ public class IncludedModuleWrapper extends IncludedModule {
      * @see org.jruby.RubyModule#newIncludeClass(RubyClass)
      */
     @Override
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public IncludedModuleWrapper newIncludeClass(RubyClass superClass) {
         var context = getCurrentContext();
         IncludedModuleWrapper includedModule = new IncludedModuleWrapper(context.runtime, superClass, getOrigin());

--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -238,7 +238,7 @@ public class Main {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public Status run() {
         return internalRun();
     }

--- a/core/src/main/java/org/jruby/MetaClass.java
+++ b/core/src/main/java/org/jruby/MetaClass.java
@@ -41,7 +41,7 @@ import static org.jruby.api.Error.typeError;
 
 public final class MetaClass extends RubyClass {
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public MetaClass(Ruby runtime, RubyClass superClass, IRubyObject attached) {
         this(runtime, superClass, (RubyBasicObject) attached);
     }

--- a/core/src/main/java/org/jruby/NativeException.java
+++ b/core/src/main/java/org/jruby/NativeException.java
@@ -39,7 +39,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Define.defineClass;
 
-@Deprecated
+@Deprecated(since = "9.2.0.0")
 @JRubyClass(name = "NativeException", parent = "RuntimeError")
 public class NativeException extends RubyException {
 
@@ -82,7 +82,7 @@ public class NativeException extends RubyException {
         return Java.getInstance(getRuntime(), getCause());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public final IRubyObject cause(Block unusedBlock) {
         return cause();
     }

--- a/core/src/main/java/org/jruby/PrependedModule.java
+++ b/core/src/main/java/org/jruby/PrependedModule.java
@@ -137,7 +137,7 @@ public class PrependedModule extends RubyClass implements DelegatedModule {
         return origin;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     @Override
     public RubyModule getNonIncludedClass() {
         return origin;

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1020,7 +1020,7 @@ public final class Ruby implements Constantizable {
      * @param filename The filename to use for parsing
      * @return The root node of the parsed script
      */
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parseFromMain(InputStream inputStream, String filename) {
         return (Node) parseFromMain(filename, inputStream).getAST();
     }
@@ -1105,12 +1105,12 @@ public final class Ruby implements Constantizable {
  *     @param wrap whether to wrap the execution in an anonymous module
      * @return The result of executing the script
      */
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject runNormally(Node scriptNode, boolean wrap) {
         return runNormally(scriptNode, getTopSelf(), wrap);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject runNormally(Node scriptNode, IRubyObject self, boolean wrap) {
         return runNormally((ParseResult) scriptNode, self, wrap);
     }
@@ -1147,7 +1147,7 @@ public final class Ruby implements Constantizable {
      * bytecode before execution
      * @return The result of executing the script
      */
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject runNormally(Node scriptNode) {
         return runNormally(scriptNode, false);
     }
@@ -1177,7 +1177,7 @@ public final class Ruby implements Constantizable {
         return scriptAndCode;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Script tryCompile(Node node) {
         return tryCompile((ParseResult) node);
     }
@@ -1275,7 +1275,7 @@ public final class Ruby implements Constantizable {
         return runInterpreter(scriptNode);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Parser getParser() {
         return getParserManager().getParser();
     }
@@ -1336,7 +1336,7 @@ public final class Ruby implements Constantizable {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule getModule(String name) {
         return Access.getModule(getCurrentContext(), name);
     }
@@ -1347,7 +1347,7 @@ public final class Ruby implements Constantizable {
      * @param name The name of the class
      * @return The class
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass getClass(String name) {
         return Access.getClass(getCurrentContext(), name);
     }
@@ -1360,7 +1360,7 @@ public final class Ruby implements Constantizable {
      * @param internedName the name of the class; <em>must</em> be an interned String!
      * @return
      */
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public RubyClass fastGetClass(String internedName) {
         return Access.getClass(getCurrentContext(), internedName);
     }
@@ -1375,12 +1375,12 @@ public final class Ruby implements Constantizable {
      * instances of the new class.
      * @return The new class
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineClass(String name, RubyClass superClass, ObjectAllocator allocator, CallSite[] callSites) {
         return defineClassUnder(getCurrentContext(), name, superClass, allocator, objectClass, callSites);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineClass(String name, RubyClass superClass, ObjectAllocator allocator) {
         return defineClassUnder(getCurrentContext(), name, superClass, allocator, objectClass, null);
     }
@@ -1401,12 +1401,12 @@ public final class Ruby implements Constantizable {
      * @return The new class
      */
     @Extension
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineClassUnder(String name, RubyClass superClass, ObjectAllocator allocator, RubyModule parent) {
         return defineClassUnder(runtimeError.getCurrentContext(), name, superClass, allocator, parent, null);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineClassUnder(String id, RubyClass superClass, ObjectAllocator allocator, RubyModule parent, CallSite[] callSites) {
         return defineClassUnder(getCurrentContext(), id, superClass, allocator, parent, callSites);
     }
@@ -1464,7 +1464,7 @@ public final class Ruby implements Constantizable {
      * @param name The name of the new module
      * @return The new module
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule defineModule(String name) {
         return defineModuleUnder(getCurrentContext(), name, objectClass);
     }
@@ -1479,7 +1479,7 @@ public final class Ruby implements Constantizable {
         return RubyModule.newModuleBootstrap(this, name, objectClass);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule defineModuleUnder(String name, RubyModule parent) {
         return defineModuleUnder(getCurrentContext(), name, parent);
     }
@@ -1524,7 +1524,7 @@ public final class Ruby implements Constantizable {
      * @deprecated Use {@link org.jruby.api.Define#defineModule(ThreadContext, String)} OR
      * {@link org.jruby.RubyModule#defineModuleUnder(ThreadContext, String)}.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule getOrCreateModule(String id) {
         var context = getCurrentContext();
         IRubyObject module = objectClass.getConstantAt(context, id);
@@ -1554,7 +1554,7 @@ public final class Ruby implements Constantizable {
      * @deprecated Use {@link RubyModule#defineConstant(ThreadContext, String, IRubyObject)} with a reference
      * to Object.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void defineGlobalConstant(String name, IRubyObject value) {
         objectClass.defineConstant(name, value);
     }
@@ -1566,12 +1566,12 @@ public final class Ruby implements Constantizable {
      * @param name the name
      * @return the value
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject fetchGlobalConstant(String name) {
         return objectClass.fetchConstant(getCurrentContext(), name, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isClassDefined(String name) {
         return Access.getModule(getCurrentContext(), name) != null;
     }
@@ -1822,7 +1822,7 @@ public final class Ruby implements Constantizable {
     }
 
     // Nothing uses this anymore
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule getEtc() {
         return etcModule;
     }
@@ -2115,7 +2115,7 @@ public final class Ruby implements Constantizable {
      * @return
      * @deprecated Use {@link org.jruby.api.Access#integerClass(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass getBignum() {
         return integerClass;
     }
@@ -2637,47 +2637,47 @@ public final class Ruby implements Constantizable {
     }
 
     // Obsolete parseFile function
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parseFile(InputStream in, String file, DynamicScope scope) {
         // Note: We don't know what the caller so we have to assume it may be a toplevel binding use so it uses main parse.
         return (Node) getParserManager().parseMainFile(file, 0, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN).getAST();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public ParseResult parseFile(String file, InputStream in, DynamicScope scope) {
         // Note: We don't know what the caller so we have to assume it may be a toplevel binding use so it uses main parse.
        return getParserManager().parseMainFile(file, 0, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parseFile(InputStream in, String file, DynamicScope scope, int lineNumber) {
         // Note: We don't know what the caller so we have to assume it may be a toplevel binding use so it uses main parse.
         return (Node) getParserManager().parseMainFile(file, lineNumber, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN).getAST();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public ParseResult parseFile(String file, InputStream in, DynamicScope scope, int lineNumber) {
         // Note: We don't know what the caller so we have to assume it may be a toplevel binding use so it uses main parse.
         return getParserManager().parseMainFile(file, lineNumber, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parseFileFromMain(InputStream in, String file, DynamicScope scope) {
         return (Node) getParserManager().parseMainFile(file, 0, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN).getAST();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public ParseResult parseFileFromMain(String file, InputStream in, DynamicScope scope) {
         return getParserManager().parseMainFile(file, 0, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     private Node parseFileFromMainAndGetAST(InputStream in, String file, DynamicScope scope) {
         // Note: We don't know what the caller so we have to assume it may be a toplevel binding use so it uses main parse.
         return (Node) getParserManager().parseMainFile(file, 0, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN).getAST();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     private Node parseFileAndGetAST(InputStream in, String file, DynamicScope scope, int lineNumber, boolean isFromMain) {
          if (isFromMain) {
              return (Node) getParserManager().parseMainFile(file, lineNumber, in, setupSourceEncoding(UTF8Encoding.INSTANCE), scope, MAIN).getAST();
@@ -2686,7 +2686,7 @@ public final class Ruby implements Constantizable {
          }
      }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parseInline(InputStream in, String file, DynamicScope scope) {
         return (Node) getParserManager().parseMainFile(file, 0, in, setupSourceEncoding(getEncodingService().getLocaleEncoding()), scope, INLINE).getAST();
     }
@@ -2700,7 +2700,7 @@ public final class Ruby implements Constantizable {
         return getEncodingService().getEncodingFromString(config.getSourceEncoding());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parseEval(String source, String file, DynamicScope scope, int lineNumber) {
         return (Node) getParserManager().parseEval(file, lineNumber, source, scope).getAST();
     }
@@ -2711,12 +2711,12 @@ public final class Ruby implements Constantizable {
         return charset == null ? string.getBytes() : string.getBytes(charset);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public ParseResult parseEval(ByteList source, String file, DynamicScope scope, int lineNumber) {
         return getParserManager().parseEval(file, lineNumber, source, scope);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parse(ByteList content, String file, DynamicScope scope, int lineNumber, boolean extraPositionInformation) {
         InputStream in = new ByteArrayInputStream(content.getUnsafeBytes(), content.begin(), content.length());
         if (extraPositionInformation) {
@@ -3439,52 +3439,52 @@ public final class Ruby implements Constantizable {
 
     // new factory methods ------------------------------------------------------------------------
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newEmptyArray() {
         return RubyArray.newEmptyArray(this);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArray() {
         return RubyArray.newArray(this.getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArrayLight() {
         return RubyArray.newArrayLight(this);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArray(IRubyObject object) {
         return RubyArray.newArray(this, object);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArray(IRubyObject car, IRubyObject cdr) {
         return RubyArray.newArray(this, car, cdr);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArray(IRubyObject... objects) {
         return RubyArray.newArray(this, objects);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArrayNoCopy(IRubyObject... objects) {
         return RubyArray.newArrayNoCopy(this, objects);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArrayNoCopyLight(IRubyObject... objects) {
         return RubyArray.newArrayNoCopyLight(this, objects);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArray(List<IRubyObject> list) {
         return RubyArray.newArray(this, list);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray newArray(int size) {
         return RubyArray.newArray(this.getCurrentContext(), size);
     }
@@ -3630,7 +3630,7 @@ public final class Ruby implements Constantizable {
      * @return
      * @deprecated Use {@link org.jruby.api.Error#argumentError(ThreadContext, int, int)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newArgumentError(int got, int expected) {
         return newArgumentError(got, expected, expected);
     }
@@ -3645,12 +3645,12 @@ public final class Ruby implements Constantizable {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newArgumentError(String name, int got, int expected) {
         return newArgumentError(name, got, expected, expected);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newArgumentError(String name, int got, int min, int max) {
         if (min == max) {
             return newRaiseException(getArgumentError(), "wrong number of arguments (given " + got + ", expected " + min + ")");
@@ -4016,7 +4016,7 @@ public final class Ruby implements Constantizable {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newTypeError(String message) {
         return newRaiseException(getTypeError(), message);
     }
@@ -4170,7 +4170,7 @@ public final class Ruby implements Constantizable {
      * @return a new NameError
      * @deprecated Use {@link org.jruby.api.Error#nameError(ThreadContext, String, String)}
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newNameError(String message, String name) {
         return newNameError(message, name, null, false);
     }
@@ -4178,7 +4178,7 @@ public final class Ruby implements Constantizable {
     /**
      * @deprecated Use {@link org.jruby.api.Error#nameError(ThreadContext, String, String)}
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newNameError(String message, IRubyObject name) {
         return newNameError(message, name, (Throwable) null, false);
     }
@@ -4196,7 +4196,7 @@ public final class Ruby implements Constantizable {
      * @return a new NameError
      * @deprecated Use {@link org.jruby.api.Error#nameError(ThreadContext, String, String, Throwable)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newNameError(String message, String name, Throwable origException) {
         return newNameError(message, name, origException, false);
     }
@@ -4269,7 +4269,7 @@ public final class Ruby implements Constantizable {
         return newFrozenError(receiver, message);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newFrozenError(IRubyObject receiver, String message) {
         ThreadContext context = getCurrentContext();
 
@@ -4333,19 +4333,19 @@ public final class Ruby implements Constantizable {
         return Helpers.newIOErrorFromException(this, ex);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newTypeError(IRubyObject receivedObject, RubyClass expectedType) {
         ThreadContext context = getCurrentContext();
         return createTypeError(context, createTypeErrorMessage(context, receivedObject, expectedType));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newTypeError(IRubyObject receivedObject, RubyModule expectedType) {
         ThreadContext context = getCurrentContext();
         return createTypeError(context, createTypeErrorMessage(context, receivedObject, expectedType));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RaiseException newTypeError(IRubyObject receivedObject, String expectedType) {
         return newRaiseException(getTypeError(),
                 str(this, "wrong argument type ",
@@ -4523,17 +4523,17 @@ public final class Ruby implements Constantizable {
         this.abortOnException = abortOnException;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.1.0")
     public boolean isGlobalAbortOnExceptionEnabled() {
         return abortOnException;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.1.0")
     public void setGlobalAbortOnExceptionEnabled(boolean enable) {
         abortOnException = enable;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.1.0")
     public IRubyObject getReportOnException() {
         return reportOnException ? getTrue() : getFalse();
     }
@@ -4685,7 +4685,7 @@ public final class Ruby implements Constantizable {
      * @param <C> the enum type, which must implement {@link Constant}.
      * @deprecated Use {@link org.jruby.RubyModule#defineConstantsFrom(ThreadContext, Class)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public <C extends Enum<C> & Constant> void loadConstantSet(RubyModule module, Class<C> enumClass) {
         module.defineConstantsFrom(getCurrentContext(), enumClass);
     }
@@ -4696,7 +4696,7 @@ public final class Ruby implements Constantizable {
      * @param module the module in which we want to define the constants
      * @param constantSetName the name of the constant set from which to get the constants
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void loadConstantSet(RubyModule module, String constantSetName) {
         var context = getCurrentContext();
         for (Constant c : ConstantSet.getConstantSet(constantSetName)) {
@@ -5686,62 +5686,62 @@ public final class Ruby implements Constantizable {
 
     ParserManager parserManager;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RaiseException newErrnoEADDRFromBindException(BindException be) {
         return newErrnoEADDRFromBindException(be, null);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public RaiseException newFrozenError(String objectType) {
         return newFrozenError(objectType, null);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public RaiseException newFrozenError(RubyModule type) {
         return newRaiseException(getFrozenError(), str(this, "can't modify frozen ", types(this, type)));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public RaiseException newFrozenError(String objectType, boolean runtimeError) {
         return newRaiseException(getFrozenError(), str(this, "can't modify frozen ", ids(this, objectType)));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public synchronized void addEventHook(EventHook hook) {
         traceEvents.addEventHook(getCurrentContext(), hook);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public synchronized void removeEventHook(EventHook hook) {
         traceEvents.removeEventHook(hook);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public void setTraceFunction(RubyProc traceFunction) {
         traceEvents.setTraceFunction(traceFunction);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public void setTraceFunction(TraceEventManager.CallTraceFuncHook hook, RubyProc traceFunction) {
         traceEvents.setTraceFunction(hook, traceFunction);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public void removeAllCallEventHooksFor(ThreadContext context) {
         traceEvents.removeAllCallEventHooksFor(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public void callEventHooks(ThreadContext context, RubyEvent event, String file, int line, String name, IRubyObject type) {
         traceEvents.callEventHooks(context, event, file, line, name, type);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public boolean hasEventHooks() {
         return traceEvents.hasEventHooks();
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public void setENV(RubyHash env) {
     }
 

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -160,7 +160,7 @@ public class RubyArgsFile extends RubyObject {
             this.currentFile = runtime.getNil();
         }
 
-        @Deprecated
+        @Deprecated(since = "9.1.8.0")
         public void setCurrentLineNumber(Ruby runtime, int linenumber) {
             runtime.setCurrentLine(linenumber);
         }
@@ -239,7 +239,7 @@ public class RubyArgsFile extends RubyObject {
             return (ArgsFileData) runtime.getArgsFile().dataGetStruct();
         }
 
-        @Deprecated
+        @Deprecated(since = "9.1.8.0")
         public static ArgsFileData getDataFrom(IRubyObject recv) {
             return getArgsFileData(((RubyBasicObject) recv).getCurrentContext().runtime);
         }
@@ -302,7 +302,7 @@ public class RubyArgsFile extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.8.0")
     public static void setCurrentLineNumber(IRubyObject recv, int newLineNumber) {
         ((RubyBasicObject) recv).getCurrentContext().runtime.setCurrentLine(newLineNumber);
     }
@@ -623,7 +623,7 @@ public class RubyArgsFile extends RubyObject {
         return recv;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject lines(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, recv, "each_line");
         return each_line(context, recv, args, block);
@@ -643,7 +643,7 @@ public class RubyArgsFile extends RubyObject {
         return data.currentFile;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject skip(IRubyObject recv) {
         return skip(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -952,7 +952,7 @@ public class RubyArgsFile extends RubyObject {
         return globalVariables(context).get("$FILENAME");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject to_s(IRubyObject recv) {
         return to_s(((RubyBasicObject) recv).getCurrentContext(), recv);
     }

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -164,7 +164,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return ex;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject create(IRubyObject klass, IRubyObject[] args, Block block) {
         return create(klass.getRuntime().getCurrentContext(), klass, args, block);
     }
@@ -190,13 +190,13 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      * Create array with specific allocated size
      * @deprecated Use {@link Create#allocArray(ThreadContext, int)} instead
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static final RubyArray newArray(final Ruby runtime, final long len) {
         ThreadContext context = runtime.getCurrentContext();
         return Create.allocArray(context, checkLength(context, len));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static final RubyArray<?> newArrayLight(final Ruby runtime, final long len) {
         return newArrayLight(runtime, checkLength(runtime.getCurrentContext(), len));
     }
@@ -217,7 +217,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return new RubyArray<>(runtime, runtime.getArray(), values, 0, 0, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static final RubyArray<?> newArray(final Ruby runtime) {
         return newArray(runtime.getCurrentContext());
     }
@@ -521,7 +521,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         values = reallocated;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected static final void checkLength(Ruby runtime, long length) {
         checkLength(runtime.getCurrentContext(), length);
     }
@@ -549,7 +549,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      * @return ""
      * @deprecated Use {@link RubyArray#toJavaArray(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject[] toJavaArray() {
         return toJavaArray(getCurrentContext());
     }
@@ -637,7 +637,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return makeShared(context, last ? begin + realLength - n : begin, n, arrayClass(context));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final void modifyCheck() {
         modifyCheck(getCurrentContext());
     }
@@ -652,7 +652,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void modify() {
         modify(getCurrentContext());
     }
@@ -818,7 +818,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return dupImpl(runtime, runtime.getArray());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject replace(IRubyObject orig) {
         return replace(getCurrentContext(), orig);
     }
@@ -1092,7 +1092,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return tmp != context.nil ? (RubyArray) tmp : newArray(context.runtime, obj);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.5.0")
     public static RubyArray aryToAry(IRubyObject obj) {
         return aryToAry(obj.getRuntime().getCurrentContext(), obj);
     }
@@ -1214,7 +1214,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         throw argumentError(getRuntime().getCurrentContext(), 0, 1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject insert(IRubyObject arg) {
         return insert(getCurrentContext(), arg);
     }
@@ -1229,7 +1229,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject insert(IRubyObject arg1, IRubyObject arg2) {
         return insert(getCurrentContext(), arg1, arg2);
     }
@@ -1252,7 +1252,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         spliceOne(context, pos, val); // rb_ary_new4
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject insert(IRubyObject[] args) {
         return insert(getCurrentContext(), args);
     }
@@ -1291,7 +1291,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray transpose() {
         return transpose(getCurrentContext());
     }
@@ -1324,7 +1324,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return new RubyArray<>(context.runtime, result);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject values_at(IRubyObject[] args) {
         return values_at(getCurrentContext(), args);
     }
@@ -1500,7 +1500,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return asFixnum(context, realLength);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum length() {
         return length(getCurrentContext());
     }
@@ -1514,7 +1514,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return self.length(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray<?> append(IRubyObject item) {
         return append(getCurrentContext(), item);
     }
@@ -1553,7 +1553,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return push(items);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray push(IRubyObject item) {
         append(item);
 
@@ -1567,7 +1567,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray<?> push(IRubyObject[] items) {
         return push(getCurrentContext(), items);
     }
@@ -1642,7 +1642,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      * @return ""
      * @deprecated Use {@link RubyArray#unshift(ThreadContext)} instead
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject unshift() {
         return unshift(getCurrentContext());
     }
@@ -1653,7 +1653,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject unshift(IRubyObject item) {
         return unshift(getCurrentContext(), item);
     }
@@ -1685,7 +1685,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject unshift(IRubyObject[] items) {
         return unshift(getCurrentContext(), items);
     }
@@ -1733,7 +1733,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      * Variable arity version for compatibility. Not bound to a Ruby method.
      * @deprecated Use the versions with zero, one, or two args.
      */
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aref(IRubyObject[] args) {
         ThreadContext context = getCurrentContext();
         return switch (args.length) {
@@ -1746,7 +1746,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject aref(IRubyObject arg0) {
         return aref(getCurrentContext(), arg0);
     }
@@ -1779,7 +1779,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return entry(toLong(context, arg0));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aref(IRubyObject arg0, IRubyObject arg1) {
         return aref(getCurrentContext(), arg0, arg1);
     }
@@ -1804,7 +1804,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         };
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aset(IRubyObject arg0, IRubyObject arg1) {
         return aset(getCurrentContext(), arg0, arg1);
     }
@@ -1852,7 +1852,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      * @return ""
      * @deprecated Use {@link RubyArray#aset(ThreadContext, IRubyObject, IRubyObject, IRubyObject)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aset(IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return aset(getCurrentContext(), arg0, arg1, arg2);
     }
@@ -1872,7 +1872,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      * @return ""
      * @deprecated Use {@link RubyArray#at(ThreadContext, IRubyObject)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject at(IRubyObject pos) {
         return at(getCurrentContext(), pos);
     }
@@ -1900,7 +1900,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         splice(context, realLength, 0, obj, obj.realLength);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray aryAppend(RubyArray y) {
         return aryAppend(getCurrentContext(), y);
     }
@@ -1989,7 +1989,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         };
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject first() {
         return first(getCurrentContext());
     }
@@ -2001,7 +2001,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return realLength == 0 ? context.nil : eltOk(0);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject first(IRubyObject arg0) {
         return first(getCurrentContext(), arg0);
     }
@@ -2041,7 +2041,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         };
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject last() {
         return last(getCurrentContext());
     }
@@ -2054,7 +2054,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return realLength == 0 ? context.nil : eltOk(realLength - 1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject last(IRubyObject arg0) {
         return last(getCurrentContext(), arg0);
     }
@@ -2242,7 +2242,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         context.safeRecurse(JOIN_RECURSIVE, new JoinRecursive.State(ary, outValue, sep, result, first), outValue, "join", true);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject join19(final ThreadContext context, IRubyObject sep) {
         return join(context, sep);
     }
@@ -2284,7 +2284,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return result;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject join19(ThreadContext context) {
         return join(context);
     }
@@ -2313,7 +2313,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             dupImpl(context.runtime, arrayClass) : this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_ary() {
         return this;
     }
@@ -2323,7 +2323,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     	return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public IRubyObject to_h(ThreadContext context) {
         return to_h(context, Block.NULL_BLOCK);
     }
@@ -2421,7 +2421,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      * @return ""
      * @deprecated Use {@link RubyArray#compact_bang(ThreadContext)}
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject compact_bang() {
         return compact_bang(getCurrentContext());
     }
@@ -2458,7 +2458,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject compact() {
         return compact(getCurrentContext());
     }
@@ -2471,7 +2471,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return ary;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject empty_p() {
         return empty_p(getCurrentContext());
     }
@@ -2484,7 +2484,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return realLength == 0 ? context.tru : context.fals;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rb_clear() {
         return rb_clear(getCurrentContext());
     }
@@ -2755,12 +2755,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject indexes(IRubyObject[] args) {
         return indexes(getCurrentContext(), args);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject indexes(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -2778,7 +2778,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return ary;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject reverse_bang() {
         return reverse_bang(getCurrentContext());
     }
@@ -2805,7 +2805,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject reverse() {
         return reverse(getCurrentContext());
     }
@@ -3050,7 +3050,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject delete_at(int pos) {
         return delete_at(getCurrentContext(), pos);
     }
@@ -3089,7 +3089,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject delete_at(IRubyObject obj) {
         return delete_at(getCurrentContext(), obj);
     }
@@ -3352,7 +3352,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject slice_bang(IRubyObject arg0) {
         return slice_bang(getCurrentContext(), arg0);
     }
@@ -3374,7 +3374,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return delete_at(toInt(context, arg0));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject slice_bang(IRubyObject arg0, IRubyObject arg1) {
         return slice_bang(getCurrentContext(), arg0, arg1);
     }
@@ -3581,12 +3581,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return asFixnum(context, n);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject nitems() {
         return nitems(getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_plus(IRubyObject obj) {
         return op_plus(getCurrentContext(), obj);
     }
@@ -3764,7 +3764,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_diff(IRubyObject other) {
         return op_diff(getCurrentContext(), other);
     }
@@ -3874,7 +3874,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return context.fals;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_and(IRubyObject other) {
         return op_and(getCurrentContext(), other);
     }
@@ -3918,7 +3918,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return res;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_or(IRubyObject other) {
         return op_or(getCurrentContext(), other);
     }
@@ -4031,12 +4031,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    // @Deprecated
+    // @Deprecated(since = "9.2.0.0")
     protected static int compareFixnums(RubyFixnum o1, RubyFixnum o2) {
         return DefaultComparator.compareInteger(o1, o2);
     }
 
-    // @Deprecated
+    // @Deprecated(since = "9.2.0.0")
     protected static int compareOthers(ThreadContext context, IRubyObject o1, IRubyObject o2) {
         return DefaultComparator.compareGeneric(context, o1, o2);
     }
@@ -5309,13 +5309,13 @@ float_loop:
         return ifnone != null && !ifnone.isNil() ? sites(context).call.call(context, ifnone, ifnone) : context.nil;
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(RubyArray array, org.jruby.runtime.marshal.MarshalStream output) throws IOException {
         marshalTo(((RubyBasicObject) array).getCurrentContext(), array, output);
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(ThreadContext context, RubyArray array, org.jruby.runtime.marshal.MarshalStream output) throws IOException {
         output.registerLinkTarget(context, array);
@@ -5347,7 +5347,7 @@ float_loop:
         }
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyArray unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
         int size = input.unmarshalInt();
@@ -5378,7 +5378,7 @@ float_loop:
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyArray newBlankArray(Ruby runtime, int size) {
         return newBlankArray(runtime.getCurrentContext(), size);
     }
@@ -5631,7 +5631,7 @@ float_loop:
         return List.class;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void copyInto(IRubyObject[] target, int start) {
         copyInto(getCurrentContext(), target, start);
     }
@@ -5645,7 +5645,7 @@ float_loop:
         safeArrayCopy(context, values, begin, target, start, realLength);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void copyInto(IRubyObject[] target, int start, int len) {
         copyInto(getCurrentContext(), target, start, len);
     }
@@ -6018,7 +6018,7 @@ float_loop:
      * Increases the capacity of this <code>Array</code>, if necessary.
      * @param minCapacity the desired minimum capacity of the internal array
      */
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public void ensureCapacity(int minCapacity) {
         unpack(getCurrentContext());
         if ( isShared || (values.length - begin) < minCapacity ) {
@@ -6031,7 +6031,7 @@ float_loop:
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     @Override
     public RubyArray to_a() {
         var context = metaClass.runtime.getCurrentContext();
@@ -6039,7 +6039,7 @@ float_loop:
         return metaClass != arrayClass ? dupImpl(context.runtime, arrayClass) : this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.15.0")
     public IRubyObject shuffle(ThreadContext context, IRubyObject[] args) {
         switch (args.length) {
             case 0:
@@ -6051,7 +6051,7 @@ float_loop:
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.15.0")
     public IRubyObject shuffle_bang(ThreadContext context, IRubyObject[] args) {
         switch (args.length) {
             case 0:
@@ -6063,7 +6063,7 @@ float_loop:
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.15.0")
     public IRubyObject sample(ThreadContext context, IRubyObject[] args) {
         switch (args.length) {
             case 0:

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -521,7 +521,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return klass;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass makeMetaClass(RubyClass superClass) {
         return makeMetaClass(getCurrentContext(), superClass);
     }
@@ -647,7 +647,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     // IMPORTANT: This method should only be used in deprecated methods.  If you do
     // not have access then you should continue using getRuntime().getCurrentContext()
     // until we can plumb ThreadContext into whatever method needs it.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public final ThreadContext getCurrentContext() {
         return getRuntime().getCurrentContext();
     }
@@ -1002,12 +1002,12 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return cloneSetup(context, clone, freeze);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected RubyClass getSingletonClassClone() {
         return getSingletonClassCloneAndAttach(null);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected RubyClass getSingletonClassCloneAndAttach(RubyBasicObject attach) {
         return getSingletonClassCloneAndAttach(getCurrentContext(), attach);
     }
@@ -1111,7 +1111,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return metaClass.getRealClass().getVariableTableManager().getObjectId(this);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject inspect() {
         return inspect(getCurrentContext());
     }
@@ -1308,7 +1308,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return invokedynamic(metaClass.runtime.getCurrentContext(), this, EQL, other).isTrue();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.10.0")
     @Override
     public void addFinalizer(IRubyObject f) {
         addFinalizer(getRuntime().getCurrentContext(), f);
@@ -1697,7 +1697,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     @Override
     public final int getNativeTypeIndex() {
         return getNativeClassIndex().ordinal();
@@ -1744,7 +1744,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return RubyKernel.methodMissingDirect(context, recv, sym, lastVis, lastCallType, args);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject send(ThreadContext context, Block block) {
         throw context.runtime.newArgumentError(0, 1);
     }
@@ -1993,7 +1993,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return evalUnder(context, mod, evalStr, file, line, evalType);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected RubyModule getInstanceEvalClass() {
         return getInstanceEvalClass(getCurrentContext());
     }
@@ -2042,7 +2042,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             this.finalized = new AtomicBoolean(false);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.10.0")
         public void addFinalizer(IRubyObject finalizer) {
             addFinalizer(finalizer.getRuntime().getCurrentContext(), finalizer);
         }
@@ -2124,7 +2124,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return asBoolean(context, this == other);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject eql_p(IRubyObject obj) {
         return eql_p(getCurrentContext(), obj);
     }
@@ -2149,7 +2149,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @return a copy
      * @deprecated Use {@link org.jruby.RubyBasicObject#initialize_copy(ThreadContext, IRubyObject)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize_copy(IRubyObject original) {
         return initialize_copy(getCurrentContext(), original);
     }
@@ -2232,7 +2232,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @deprecated Use {@link RubyBasicObject#hash(ThreadContext)} instead.
      * @return hash value
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum hash() {
         return hash(getCurrentContext());
     }
@@ -2429,7 +2429,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return methods;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public final IRubyObject methods(ThreadContext context, IRubyObject[] args, boolean useSymbols) {
         return methodsImpl(context, args.length == 1 ? args[0].isTrue() : true);
     }
@@ -2542,7 +2542,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return RubyArray.newArray(context.runtime, names);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject singleton_method(IRubyObject name) {
         return singleton_method(getCurrentContext(), name);
     }
@@ -2590,14 +2590,14 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *     m = l.method("hello")
      *     m.call   #=&gt; "Hello, {@literal @}iv = Fred"
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject method(IRubyObject name) {
         var context = getCurrentContext();
         final RubySymbol symbol = checkID(context, name);
         return getMetaClass().newMethod(context, this, symbol.idString(), null, true, null, true, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject method(IRubyObject name, StaticScope refinedScope) {
         return method(getCurrentContext(), name, refinedScope);
     }
@@ -2618,7 +2618,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @return ""
      * @deprecated Use {@link RubyBasicObject#to_s(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_s() {
         return to_s(getCurrentContext());
     }
@@ -3022,7 +3022,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return nonFixnumHashCode(context, hashValue);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected static int nonFixnumHashCode(IRubyObject hashValue) {
         return nonFixnumHashCode(hashValue.getRuntime().getCurrentContext(), hashValue);
     }
@@ -3038,14 +3038,14 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @param name of instance variable
      * @return name it is valid
      */
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     protected String validateInstanceVariable(String name) {
         if (IdUtil.isValidInstanceVariableName(name)) return name;
 
         throw getRuntime().newNameError("'%1$s' is not allowable as an instance variable name", this, name);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     protected String validateInstanceVariable(IRubyObject name, String _unused_) {
         return validateInstanceVariable(name);
     }
@@ -3124,230 +3124,230 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     // Deprecated methods below this line
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     protected RubyBasicObject(Ruby runtime, RubyClass metaClass, boolean useObjectSpace, boolean canBeTainted) {
         this(runtime, metaClass, useObjectSpace);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public IRubyObject callSuper(ThreadContext context, IRubyObject[] args, Block block) {
         return Helpers.invokeSuper(context, this, args, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public final IRubyObject callMethod(ThreadContext context, int methodIndex, String name) {
         return Helpers.invoke(context, this, name);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public final IRubyObject callMethod(ThreadContext context, int methodIndex, String name, IRubyObject arg) {
         return Helpers.invoke(context, this, name, arg, Block.NULL_BLOCK);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public RubyInteger convertToInteger(int methodIndex, String convertMethod) {
         return convertToInteger(convertMethod);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public int getVariableCount() {
         return getMetaClass().getVariableTableSize();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     protected boolean variableTableFastContains(String internedName) {
         return variableTableContains(internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     protected Object variableTableFastFetch(String internedName) {
         return variableTableFetch(internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     protected Object variableTableFastStore(String internedName, Object value) {
         return variableTableStore(internedName, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public boolean fastHasInternalVariable(String internedName) {
         return hasInternalVariable(internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public Object fastGetInternalVariable(String internedName) {
         return getInternalVariable(internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public void fastSetInternalVariable(String internedName, Object value) {
         setInternalVariable(internedName, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public void syncVariables(List<Variable<Object>> variables) {
         variableTableSync(variables);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public boolean fastHasInstanceVariable(String internedName) {
         return hasInstanceVariable(internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public IRubyObject fastGetInstanceVariable(String internedName) {
         return getInstanceVariable(internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     @Override
     public IRubyObject fastSetInstanceVariable(String internedName, IRubyObject value) {
         return setInstanceVariable(internedName, value);
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public boolean isUntrusted() {
         return false;
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public void setUntrusted(boolean untrusted) {
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public RubyBoolean untrusted_p(ThreadContext context) {
         return context.fals;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject untrust(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject trust(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public final Object getNativeHandle() {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public final void setNativeHandle(Object value) {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public synchronized Object dataGetStructChecked() {
         TypeConverter.checkData(this);
         return getInternalVariable("__wrap_struct__");
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public RubyArray to_a() {
         return to_a(getRuntime().getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public RubyBoolean tainted_p(ThreadContext context) {
         return context.fals;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject taint(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     IRubyObject tainted() {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     protected final void taint(Ruby runtime) {
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject untaint(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     public boolean isTaint() {
         return false;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     public void setTaint(boolean taint) {
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     public IRubyObject infectBy(IRubyObject obj) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     final RubyBasicObject infectBy(RubyBasicObject obj) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     final RubyBasicObject infectBy(int tuFlags) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int FL_USHIFT = 4;
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER0_F = (1<<(FL_USHIFT+0));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER1_F = (1<<(FL_USHIFT+1));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER2_F = (1<<(FL_USHIFT+2));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER3_F = (1<<(FL_USHIFT+3));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER4_F = (1<<(FL_USHIFT+4));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER5_F = (1<<(FL_USHIFT+5));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER6_F = (1<<(FL_USHIFT+6));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER7_F = (1<<(FL_USHIFT+7));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER8_F = (1<<(FL_USHIFT+8));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USER9_F = (1<<(FL_USHIFT+9));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int USERA_F = (1<<(FL_USHIFT+10));
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int REFINED_MODULE_F = USER9_F;
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int IS_OVERLAID_F = USERA_F;
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static final int COMPARE_BY_IDENTITY_F = USER8_F;
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public static final int TAINTED_F = 0;
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static final long VAR_TABLE_OFFSET = -1;
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static final long STAMP_OFFSET = -1;
 }

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -362,7 +362,7 @@ public class RubyBignum extends RubyInteger {
     /** rb_big_to_s
      *
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_s(IRubyObject[] args) {
         var context = getRuntime().getCurrentContext();
         return switch (args.length) {
@@ -655,7 +655,7 @@ public class RubyBignum extends RubyInteger {
      *
      * Deprecated since 10.0 since CRuby no longer has Bignum-specific quo logic.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject quo(ThreadContext context, IRubyObject otherArg) {
         return super.quo(context, otherArg);
     }
@@ -1106,7 +1106,7 @@ public class RubyBignum extends RubyInteger {
         return asFloat(context, asDouble(context));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject abs() {
         return abs(getCurrentContext());
     }
@@ -1142,7 +1142,7 @@ public class RubyBignum extends RubyInteger {
         return isZero(context) ? context.nil : this;
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(RubyBignum bignum, org.jruby.runtime.marshal.MarshalStream output) throws IOException {
         var context = bignum.getRuntime().getCurrentContext();
@@ -1198,7 +1198,7 @@ public class RubyBignum extends RubyInteger {
         }
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyNumeric unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
         boolean positive = input.readUnsignedByte() == '+';

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -87,12 +87,12 @@ public class RubyBinding extends RubyObject implements DataType {
         return new RubyBinding(runtime, runtime.getBinding(), binding);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static RubyBinding newBinding(Ruby runtime) {
         return newBinding(runtime, runtime.getCurrentContext().currentBinding());
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static RubyBinding newBinding(Ruby runtime, IRubyObject self) {
        return newBinding(runtime, runtime.getCurrentContext().currentBinding(self));
     }

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -114,12 +114,12 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
                 tap(c -> c.getMetaClass().undefMethods(context, "new"));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubyBoolean newBoolean(Ruby runtime, boolean value) {
         return value ? runtime.getTrue() : runtime.getFalse();
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubyBoolean newBoolean(ThreadContext context, boolean value) {
         return value ? context.tru : context.fals;
     }
@@ -153,12 +153,12 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
             return oth.isTrue() ? context.tru : fals;
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static RubyString false_to_s(ThreadContext context, IRubyObject fals) {
             return context.runtime.getFalseString();
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public RubyString inspect() {
             return getRuntime().getFalseString();
         }
@@ -201,12 +201,12 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
             return oth.isTrue() ? context.fals : tru;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static RubyString true_to_s(ThreadContext context, IRubyObject tru) {
             return context.runtime.getTrueString();
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public RubyString inspect() {
             return getRuntime().getTrueString();
         }
@@ -244,13 +244,13 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
         }
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public void marshalTo(org.jruby.runtime.marshal.MarshalStream output) throws java.io.IOException {
         output.write(isTrue() ? 'T' : 'F');
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     public IRubyObject taint(ThreadContext context) {
         return this;

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -142,7 +142,7 @@ public class RubyClass extends RubyModule {
      * @param allocator
      * @deprecated Use {@link org.jruby.RubyClass#allocator(ObjectAllocator)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void setAllocator(ObjectAllocator allocator) {
         allocator(allocator);
     }
@@ -279,7 +279,7 @@ public class RubyClass extends RubyModule {
         return withException(createTypeError(runtime.getCurrentContext(), msg.toString()), e);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject allocate() {
         return allocate(getCurrentContext());
     }
@@ -492,14 +492,14 @@ public class RubyClass extends RubyModule {
      * and with Object as its immediate superclass.
      * Corresponds to rb_class_new in MRI.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass newClass(Ruby runtime, RubyClass superClass) {
         if (superClass == runtime.getClassClass()) throw typeError(runtime.getCurrentContext(), "can't make subclass of Class");
         if (superClass.isSingleton()) throw typeError(runtime.getCurrentContext(), "can't make subclass of virtual class");
         return new RubyClass(runtime, superClass);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass newClass(Ruby runtime, RubyClass superClass, CallSite[] extraCallSites) {
         return newClass(runtime.getCurrentContext(), superClass, extraCallSites);
     }
@@ -522,7 +522,7 @@ public class RubyClass extends RubyModule {
      * Corresponds to rb_class_new/rb_define_class_id/rb_name_class/rb_set_class_path
      * in MRI.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass newClass(Ruby runtime, RubyClass superClass, String name, ObjectAllocator allocator, RubyModule parent, boolean setParent) {
         var context = runtime.getCurrentContext();
         RubyClass clazz = newClass(context, superClass, null).
@@ -536,7 +536,7 @@ public class RubyClass extends RubyModule {
         return clazz;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass newClass(Ruby runtime, RubyClass superClass, String name, ObjectAllocator allocator,
                                      RubyModule parent, boolean setParent, String file, int line) {
         return newClass(runtime.getCurrentContext(), superClass, name, allocator, parent, setParent, file, line);
@@ -556,7 +556,7 @@ public class RubyClass extends RubyModule {
         return clazz;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass newClass(Ruby runtime, RubyClass superClass, String name, ObjectAllocator allocator, RubyModule parent, boolean setParent, CallSite[] extraCallSites) {
         return newClass(runtime.getCurrentContext(), superClass, name, allocator, parent, setParent, extraCallSites);
     }
@@ -596,7 +596,7 @@ public class RubyClass extends RubyModule {
         return clazz;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     RubyClass toSingletonClass(RubyBasicObject target) {
         return toSingletonClass(getCurrentContext(), target);
     }
@@ -1448,7 +1448,7 @@ public class RubyClass extends RubyModule {
     /** rb_class_inherited (reversed semantics!)
      *
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void inherit(RubyClass superClazz) {
         if (superClazz == null) superClazz = runtime.getObject();
 
@@ -1487,7 +1487,7 @@ public class RubyClass extends RubyModule {
     /** rb_check_inheritable
      *
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void checkInheritable(IRubyObject superClass) {
         checkInheritable(((RubyBasicObject) superClass).getCurrentContext(), superClass);
     }
@@ -1508,12 +1508,12 @@ public class RubyClass extends RubyModule {
      * @param marshal
      * @deprecated Use {@link org.jruby.RubyClass#marshalWith(ObjectMarshal)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final void setMarshal(ObjectMarshal marshal) {
         marshalWith(marshal);
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public final void marshal(Object obj, org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
         getMarshal().marshalTo(runtime, obj, this, marshalStream);
@@ -1523,7 +1523,7 @@ public class RubyClass extends RubyModule {
         getMarshal().marshalTo(context, out, obj, this, marshalStream);
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public final Object unmarshal(org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
         return getMarshal().unmarshalFrom(runtime, this, unmarshalStream);
@@ -1533,7 +1533,7 @@ public class RubyClass extends RubyModule {
         return getMarshal().unmarshalFrom(context, in, this, loader);
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(RubyClass clazz, org.jruby.runtime.marshal.MarshalStream output) throws java.io.IOException {
         var context = clazz.getRuntime().getCurrentContext();
@@ -1546,7 +1546,7 @@ public class RubyClass extends RubyModule {
         output.writeString(out, MarshalDumper.getPathFromClass(context, clazz).idString());
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyClass unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         String name = RubyString.byteListToString(input.unmarshalString());
@@ -1560,7 +1560,7 @@ public class RubyClass extends RubyModule {
 
     protected static final ObjectMarshal DEFAULT_OBJECT_MARSHAL = new ObjectMarshal() {
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
             IRubyObject object = (IRubyObject) obj;
@@ -1579,7 +1579,7 @@ public class RubyClass extends RubyModule {
         }
 
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             IRubyObject result = input.entry(type.allocate(runtime.getCurrentContext()));
@@ -2593,7 +2593,7 @@ public class RubyClass extends RubyModule {
      * @param reifiedClass
      * @deprecated Use {@link org.jruby.RubyClass#reifiedClass(Class)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void setReifiedClass(Class<? extends IRubyObject> reifiedClass) {
         this.reifiedClass = (Class<? extends Reified>) reifiedClass; // Not always true
     }
@@ -2602,7 +2602,7 @@ public class RubyClass extends RubyModule {
      * @return
      * @deprecated Use {@link RubyClass#reifiedClass()} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public Class<? extends Reified> getReifiedClass() {
         return reifiedClass();
     }
@@ -2837,7 +2837,7 @@ public class RubyClass extends RubyModule {
          * @param object The object to dump
          * @throws IOException If there is an IO error during dumping
          */
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void dump(org.jruby.runtime.marshal.MarshalStream stream, IRubyObject object) throws IOException {
             var context = object.getRuntime().getCurrentContext();
@@ -2914,7 +2914,7 @@ public class RubyClass extends RubyModule {
      * @throws IOException If there is an IO exception while writing to the
      * stream.
      */
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public void smartDump(org.jruby.runtime.marshal.MarshalStream stream, IRubyObject target) throws IOException {
         MarshalTuple tuple;
@@ -3079,7 +3079,7 @@ public class RubyClass extends RubyModule {
 
     // DEPRECATED METHODS
 
-    @Deprecated
+    @Deprecated(since = "9.1.5.0")
     public IRubyObject invoke(ThreadContext context, IRubyObject self, int methodIndex, String name, IRubyObject[] args, CallType callType, Block block) {
         return invoke(context, self, name, args, callType, block);
     }
@@ -3311,7 +3311,7 @@ public class RubyClass extends RubyModule {
         return variableTableManager.getObjectGroupAccessorField();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   Block block) {
         CacheEntry entry = searchWithCache(name);
@@ -3323,7 +3323,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject[] args, Block block) {
         assert args != null;
@@ -3336,7 +3336,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, args, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject arg, Block block) {
         CacheEntry entry = searchWithCache(name);
@@ -3348,7 +3348,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, arg, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject arg0, IRubyObject arg1, Block block) { // NOT USED?
         CacheEntry entry = searchWithCache(name);
@@ -3360,7 +3360,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, arg0, arg1, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         CacheEntry entry = searchWithCache(name);
@@ -3372,7 +3372,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, arg0, arg1, arg2, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name) {
         CacheEntry entry = searchWithCache(name);
         DynamicMethod method = entry.method;
@@ -3383,7 +3383,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject[] args) {
         assert args != null;
@@ -3396,7 +3396,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, args);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject arg) {
         CacheEntry entry = searchWithCache(name);
@@ -3408,7 +3408,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, arg);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject arg0, IRubyObject arg1) {
         CacheEntry entry = searchWithCache(name);
@@ -3420,7 +3420,7 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, arg0, arg1);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public IRubyObject invokeFrom(ThreadContext context, CallType callType, IRubyObject caller, IRubyObject self, String name,
                                   IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         CacheEntry entry = searchWithCache(name);

--- a/core/src/main/java/org/jruby/RubyClassPathVariable.java
+++ b/core/src/main/java/org/jruby/RubyClassPathVariable.java
@@ -54,7 +54,7 @@ public class RubyClassPathVariable extends RubyObject {
         super(context.runtime, Object);
     }
     
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject append(IRubyObject obj) {
         return append(obj.getRuntime().getCurrentContext(), obj);
     }

--- a/core/src/main/java/org/jruby/RubyComparable.java
+++ b/core/src/main/java/org/jruby/RubyComparable.java
@@ -90,7 +90,7 @@ public class RubyComparable {
         return cmpint(context, op_gt, op_lt, cmpResult, a, b);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject cmperr(IRubyObject recv, IRubyObject other) {
         return cmperr(((RubyBasicObject) recv).getCurrentContext(), recv, other);
     }

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -193,7 +193,7 @@ public class RubyComplex extends RubyNumeric {
         return newComplexBang(context, clazz, x, RubyFixnum.zero(context.runtime));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static RubyComplex newComplexBang(ThreadContext context, RubyClass clazz, IRubyObject x) {
         return newComplexBang(context, clazz, (RubyNumeric) x);
     }
@@ -257,7 +257,7 @@ public class RubyComplex extends RubyNumeric {
     /** nucomp_s_new_bang
      *
      */
-    @Deprecated
+    @Deprecated(since = "1.1.4")
     public static IRubyObject newInstanceBang(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 1: return newInstanceBang(context, recv, args[0]);
@@ -342,7 +342,7 @@ public class RubyComplex extends RubyNumeric {
     /** nucomp_s_new
      * 
      */
-    @Deprecated
+    @Deprecated(since = "1.1.4")
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 1: return newInstance(context, recv, args[0]);
@@ -427,7 +427,7 @@ public class RubyComplex extends RubyNumeric {
     }
 
 
-    @Deprecated
+    @Deprecated(since = "1.1.4")
     public static IRubyObject convert(ThreadContext context, IRubyObject clazz, IRubyObject[]args) {
         switch (args.length) {
             case 1: return convert(context, clazz, args[0]);
@@ -576,7 +576,7 @@ public class RubyComplex extends RubyNumeric {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject real() {
         return real(getCurrentContext());
     }
@@ -587,7 +587,7 @@ public class RubyComplex extends RubyNumeric {
         return real;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject image() {
         return image(getCurrentContext());
     }
@@ -1181,7 +1181,7 @@ public class RubyComplex extends RubyNumeric {
 
     private static final ObjectMarshal COMPLEX_MARSHAL = new ObjectMarshal() {
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) {
             //do nothing
@@ -1193,7 +1193,7 @@ public class RubyComplex extends RubyNumeric {
         }
 
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type,
                                     org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {

--- a/core/src/main/java/org/jruby/RubyContinuation.java
+++ b/core/src/main/java/org/jruby/RubyContinuation.java
@@ -42,9 +42,9 @@ import static org.jruby.api.Define.defineClass;
  * Minimal RubyContinuation class to support third-party users.
  */
 @JRubyClass(name="Continuation")
-@Deprecated
+@Deprecated(since = "9.2.6.0")
 public class RubyContinuation extends RubyObject {
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public static class Continuation extends CatchThrow {
         public Continuation() {
             super();
@@ -65,7 +65,7 @@ public class RubyContinuation extends RubyObject {
                 tap(c -> c.singletonClass(context).undefMethods(context, "new"));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public RubyContinuation(Ruby runtime) {
         super(runtime, runtime.getContinuation());
         this.continuation = new Continuation();
@@ -77,18 +77,18 @@ public class RubyContinuation extends RubyObject {
      * @param runtime Current JRuby runtime
      * @param tag The tag to use
      */
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public RubyContinuation(Ruby runtime, IRubyObject tag) {
         super(runtime, runtime.getContinuation());
         this.continuation = new Continuation(tag);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public Continuation getContinuation() {
         return continuation;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public IRubyObject call(ThreadContext context, IRubyObject[] args) {
         if (disabled) {
             RubyKernel.raise(context, context.runtime.getThreadError(),
@@ -99,7 +99,7 @@ public class RubyContinuation extends RubyObject {
         throw continuation;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public IRubyObject enter(ThreadContext context, IRubyObject yielded, Block block) {
         try {
             return block.yield(context, yielded);

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -355,7 +355,7 @@ public class RubyDir extends RubyObject implements Closeable {
         return asRubyStringList(runtime, dirs);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray entries() {
         return entries(getCurrentContext());
     }
@@ -500,7 +500,7 @@ public class RubyDir extends RubyObject implements Closeable {
         return chdirCommon(context, block, checkEmbeddedNulls(context, RubyFile.get_path(context, path)), false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject chroot(IRubyObject recv, IRubyObject path) {
         return chroot(((RubyBasicObject) recv).getCurrentContext(), recv, path);
     }
@@ -533,12 +533,12 @@ public class RubyDir extends RubyObject implements Closeable {
         return dir.children(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject rmdir(IRubyObject recv, IRubyObject path) {
         return rmdir(recv.getRuntime().getCurrentContext(), recv, path);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject rmdir19(IRubyObject recv, IRubyObject path) {
         return rmdir(((RubyBasicObject) recv).getCurrentContext(), recv, path);
     }
@@ -648,7 +648,7 @@ public class RubyDir extends RubyObject implements Closeable {
                 enumeratorize(context.runtime, recv, "foreach", path, encOpts);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString getwd(IRubyObject recv) {
         return getwd(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -691,7 +691,7 @@ public class RubyDir extends RubyObject implements Closeable {
         return mkdirCommon(context, RubyFile.get_path(context, args[0]).asJavaString(), args);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static IRubyObject mkdir(IRubyObject recv, IRubyObject[] args) {
         return mkdir(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -771,7 +771,7 @@ public class RubyDir extends RubyObject implements Closeable {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final void close() {
         close(getCurrentContext());
     }
@@ -857,12 +857,12 @@ public class RubyDir extends RubyObject implements Closeable {
         return asFixnum(context, pos);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger tell() {
         return tell(getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject seek(IRubyObject newPos) {
         return seek(getCurrentContext(), newPos);
     }
@@ -879,7 +879,7 @@ public class RubyDir extends RubyObject implements Closeable {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_pos(IRubyObject newPos) {
         return set_pos(getCurrentContext(), newPos);
     }
@@ -905,7 +905,7 @@ public class RubyDir extends RubyObject implements Closeable {
         return path == null ? null : path.asJavaString();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject read() {
         return read(getCurrentContext());
     }
@@ -923,7 +923,7 @@ public class RubyDir extends RubyObject implements Closeable {
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rewind() {
         return rewind(getCurrentContext());
     }
@@ -958,7 +958,7 @@ public class RubyDir extends RubyObject implements Closeable {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject exists_p(ThreadContext context, IRubyObject recv, IRubyObject arg) {
         if (context.runtime.warningsEnabled()) {
             context.runtime.getWarnings().warnDeprecatedAlternate("Dir.exists?", "Dir.exist?");
@@ -1185,24 +1185,24 @@ public class RubyDir extends RubyObject implements Closeable {
         return super.toJava(target);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject home(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         if (args.length > 0 && args[0] != context.nil) return getHomeDirectoryPath(context, args[0].toString());
 
         return getHomeDirectoryPath(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.15.0")
     public static RubyArray entries(IRubyObject recv, IRubyObject path) {
         return entries(((RubyBasicObject) recv).getCurrentContext(), recv, path);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.15.0")
     public static RubyArray entries(IRubyObject recv, IRubyObject path, IRubyObject arg, IRubyObject opts) {
         return entries(((RubyBasicObject) recv).getCurrentContext(), recv, path, opts);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject chdir(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         return switch (args.length) {
             case 0 -> chdir(context, recv, block);

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -575,7 +575,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         return str instanceof RubyEncoding ? str : encodingService(context).rubyEncodingFromObject(str);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject replicate(ThreadContext context, IRubyObject arg) {
         return new RubyEncoding(context.runtime, arg.convertToString().getBytes(), getEncoding(), isDummy);
     }
@@ -679,7 +679,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         return encodingService(context).getDefaultInternal();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject getDefaultInternal(IRubyObject recv) {
         return getDefaultInternal(recv.getRuntime().getCurrentContext(), recv);
     }
@@ -694,7 +694,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     /**
      * @deprecated use {@link #decodeRaw(byte[], int, int)}
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static String decodeISO(byte[] bytes, int start, int length) {
         return decodeRaw(bytes, start, length);
     }
@@ -702,7 +702,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     /**
      * @deprecated use {@link #decodeRaw(ByteList)}
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static String decodeISO(ByteList byteList) {
         return decodeRaw(byteList);
     }

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -2191,7 +2191,7 @@ public class RubyEnumerable {
 
         private final RubyArray result;
 
-        @Deprecated
+        @Deprecated(since = "9.1.3.0")
         public AppendBlockCallback(Ruby runtime, RubyArray result) {
             this.result = result;
         }
@@ -2220,13 +2220,13 @@ public class RubyEnumerable {
         private final RubyHash result;
         private final Block block;
 
-        @Deprecated
+        @Deprecated(since = "9.1.3.0")
         public PutKeyValueCallback(Ruby runtime, RubyHash result) {
             this.result = result;
             this.block = Block.NULL_BLOCK;
         }
 
-        @Deprecated
+        @Deprecated(since = "9.3.0.0")
         public PutKeyValueCallback(Ruby runtime, RubyHash result, Block block) {
             this.result = result;
             this.block = block;
@@ -2309,18 +2309,18 @@ public class RubyEnumerable {
 
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject callEach(ThreadContext context, IRubyObject self, IRubyObject[] args, Signature signature,
                                        BlockCallback callback) {
         return callEach(context, eachSite(context), self, args, signature, callback);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject callEach(ThreadContext context, IRubyObject self, BlockCallback callback) {
         return callEach(context, eachSite(context), self, callback);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject each(ThreadContext context, IRubyObject self, BlockBody body) {
         return each(context, eachSite(context), self, body);
     }

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -109,7 +109,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
             value = context.nil;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         FeedValue(Ruby runtime) {
             this(runtime.getCurrentContext());
         }
@@ -567,14 +567,14 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         return enumeratorizeWithSize(context, producer, "each", RubyProducer::size);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         IRubyObject size = Arity.checkArgumentCount(context, args, 0, 1) == 1 ? args[0] : null;
 
         return initializeWithSize(context, size, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         return initialize(context, args, Block.NULL_BLOCK);
     }

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -173,7 +173,7 @@ public class RubyException extends RubyObject {
 
     private static final ObjectMarshal<RubyException> EXCEPTION_MARSHAL = new ObjectMarshal<RubyException>() {
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, RubyException exc, RubyClass type,
                               org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
@@ -196,7 +196,7 @@ public class RubyException extends RubyObject {
         }
 
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public RubyException unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             var context = runtime.getCurrentContext();
@@ -318,7 +318,7 @@ public class RubyException extends RubyObject {
         return getBacktrace();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_backtrace(IRubyObject obj) {
         return set_backtrace(getCurrentContext(), obj);
     }
@@ -636,7 +636,7 @@ public class RubyException extends RubyObject {
         return names;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public void prepareIntegratedBacktrace(ThreadContext context, StackTraceElement[] javaTrace) {
         // if it's null, build a backtrace
         if (backtrace.backtraceData == null) {
@@ -644,7 +644,7 @@ public class RubyException extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject newException(ThreadContext context, RubyClass exceptionClass, IRubyObject message) {
         return newException(context, exceptionClass, message.convertToString());
     }

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -455,7 +455,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return basenameImpl(context, (RubyClass) recv, path, ext == context.nil ? null : ext);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static IRubyObject basename(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         IRubyObject ext = (args.length > 1 && args[1] != context.nil) ? args[1] : null;
         return basenameImpl(context, (RubyClass) recv, args[0], ext);
@@ -1105,7 +1105,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject truncate19(ThreadContext context, IRubyObject recv, IRubyObject path, IRubyObject length) {
         return truncate(context, recv, path, length);
     }
@@ -2299,10 +2299,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     private static final String[] SLASHES = { "", "/", "//" };
     private static final Pattern URI_PREFIX = Pattern.compile("^(jar:)?[a-z]{2,}:(.*)");
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     protected String path;
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject dirname(ThreadContext context, IRubyObject recv, IRubyObject [] args) {
         return switch (args.length) {
             case 1 -> dirname(context, recv, args[0]);
@@ -2311,7 +2311,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject expand_path(ThreadContext context, IRubyObject recv, IRubyObject... args) {
         return switch (args.length) {
             case 1 -> expand_path(context, recv, args[0]);
@@ -2320,7 +2320,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     private static RubyString expandPathInternal(ThreadContext context, IRubyObject[] args, boolean expandUser, boolean canonicalize) {
         return switch (args.length) {
             case 1 -> expandPathInternal(context, args[0], null, expandUser, canonicalize);
@@ -2329,7 +2329,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject absolute_path(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 1:
@@ -2341,7 +2341,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject realdirpath(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 1:
@@ -2353,14 +2353,14 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject realpath(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         RubyString file = expandPathInternal(context, args, false, true);
         if (!RubyFileTest.exist(context, file)) throw context.runtime.newErrnoENOENTError(file.toString());
         return file;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject fnmatch(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return switch (args.length) {
             case 2 -> fnmatch(context, recv, args[0], args[1]);

--- a/core/src/main/java/org/jruby/RubyFileStat.java
+++ b/core/src/main/java/org/jruby/RubyFileStat.java
@@ -143,12 +143,12 @@ public class RubyFileStat extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize19(IRubyObject fname, Block unusedBlock) {
         return initialize(fname, unusedBlock);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize(IRubyObject fname, Block unusedBlock) {
         return initialize(getCurrentContext(), fname, unusedBlock);
     }
@@ -167,7 +167,7 @@ public class RubyFileStat extends RubyObject {
                 context.runtime.newTime(stat.atime() * 1000);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject atime() {
         return atime(getCurrentContext());
     }
@@ -179,7 +179,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.blockSize());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.4.0")
     public RubyFixnum blksize() {
         ThreadContext context = getCurrentContext();
         checkInitialized(context);
@@ -192,7 +192,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isBlockDev());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject blockdev_p() {
         return blockdev_p(getCurrentContext());
     }
@@ -204,7 +204,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.blocks());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject blocks() {
         return blocks(getCurrentContext());
     }
@@ -215,7 +215,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isCharDev());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject chardev_p() {
         return chardev_p(getCurrentContext());
     }
@@ -237,7 +237,7 @@ public class RubyFileStat extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject cmp(IRubyObject other) {
         return cmp(getCurrentContext(), other);
     }
@@ -251,7 +251,7 @@ public class RubyFileStat extends RubyObject {
         return context.runtime.newTime(stat.ctime() * 1000);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject ctime() {
         return ctime(getCurrentContext());
     }
@@ -271,7 +271,7 @@ public class RubyFileStat extends RubyObject {
         return context.runtime.newTime(btime.toMillis());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject birthtime() {
         return birthtime(getCurrentContext());
     }
@@ -282,7 +282,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.dev());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject dev() {
         return dev(getCurrentContext());
     }
@@ -294,7 +294,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.major(stat.dev()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject devMajor() {
         return devMajor(getCurrentContext());
     }
@@ -306,7 +306,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.minor(stat.dev()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject devMinor() {
         return devMinor(getCurrentContext());
     }
@@ -317,7 +317,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isDirectory());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean directory_p() {
         return directory_p(getCurrentContext());
     }
@@ -328,7 +328,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isExecutable());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject executable_p() {
         return executable_p(getCurrentContext());
     }
@@ -339,7 +339,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isExecutableReal());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject executableReal_p() {
         return executableReal_p(getCurrentContext());
     }
@@ -350,7 +350,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isFile());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean file_p() {
         return file_p(getCurrentContext());
     }
@@ -361,7 +361,7 @@ public class RubyFileStat extends RubyObject {
         return newString(context, stat.ftype());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyString ftype() {
         return ftype(getCurrentContext());
     }
@@ -373,7 +373,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.gid());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject gid() {
         return gid(getCurrentContext());
     }
@@ -385,7 +385,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isGroupOwned());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject group_owned_p() {
         return group_owned_p(getCurrentContext());
     }
@@ -410,7 +410,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.ino());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject ino() {
         return ino(getCurrentContext());
     }
@@ -457,7 +457,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.uid());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject uid() {
         return uid(getCurrentContext());
     }
@@ -468,7 +468,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.mode());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject mode() {
         return mode(getCurrentContext());
     }
@@ -481,7 +481,7 @@ public class RubyFileStat extends RubyObject {
                 context.runtime.newTime(stat.mtime() * 1000);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject mtime() {
         return mtime(getCurrentContext());
     }
@@ -497,7 +497,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, equal);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject mtimeEquals(IRubyObject other) {
         return mtimeEquals(getCurrentContext(), other);
     }
@@ -516,7 +516,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, gt);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject mtimeGreaterThan(IRubyObject other) {
         return mtimeGreaterThan(getCurrentContext(), other);
     }
@@ -535,7 +535,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, lt);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject mtimeLessThan(IRubyObject other) {
         return mtimeLessThan(getCurrentContext(), other);
     }
@@ -546,7 +546,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.nlink());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject nlink() {
         return nlink(getCurrentContext());
     }
@@ -557,7 +557,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isOwned());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject owned_p() {
         return owned_p(getCurrentContext());
     }
@@ -568,7 +568,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isNamedPipe());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject pipe_p() {
         return pipe_p(getCurrentContext());
     }
@@ -579,7 +579,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.rdev());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rdev() {
         return rdev(getCurrentContext());
     }
@@ -591,7 +591,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.major(stat.rdev()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rdevMajor() {
         return rdevMajor(getCurrentContext());
     }
@@ -603,7 +603,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, stat.minor(stat.rdev()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rdevMinor() {
         return rdevMinor(getCurrentContext());
     }
@@ -614,7 +614,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isReadable());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject readable_p() {
         return readable_p(getCurrentContext());
     }
@@ -625,7 +625,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isReadableReal());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject readableReal_p() {
         return readableReal_p(getCurrentContext());
     }
@@ -636,7 +636,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isSetgid());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setgid_p() {
         return setgid_p(getCurrentContext());
     }
@@ -647,7 +647,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isSetuid());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setuid_p() {
         return setuid_p(getCurrentContext());
     }
@@ -671,7 +671,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, sizeInternal(context));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject size() {
         return size(getCurrentContext());
     }
@@ -685,7 +685,7 @@ public class RubyFileStat extends RubyObject {
         return asFixnum(context, size);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject size_p() {
         return size_p(getCurrentContext());
     }
@@ -696,7 +696,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isSocket());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject socket_p() {
         return socket_p(getCurrentContext());
     }
@@ -710,7 +710,7 @@ public class RubyFileStat extends RubyObject {
                 context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject sticky_p() {
         return sticky_p(getCurrentContext());
     }
@@ -721,7 +721,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isSymlink());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject symlink_p() {
         return symlink_p(getCurrentContext());
     }
@@ -732,7 +732,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isWritable());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject writable_p() {
         return writable_p(getCurrentContext());
     }
@@ -743,7 +743,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isWritableReal());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject writableReal_p() {
         return writableReal_p(getCurrentContext());
     }
@@ -754,7 +754,7 @@ public class RubyFileStat extends RubyObject {
         return asBoolean(context, stat.isEmpty());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject zero_p() {
         return zero_p(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/RubyFileTest.java
+++ b/core/src/main/java/org/jruby/RubyFileTest.java
@@ -68,7 +68,7 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isBlockDev());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject blockdev_p(IRubyObject recv, IRubyObject filename) {
         return blockdev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -80,17 +80,17 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isCharDev());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject chardev_p(IRubyObject recv, IRubyObject filename) {
         return chardev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject directory_p(IRubyObject recv, IRubyObject filename) {
         return directory_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject directory_p(Ruby ruby, IRubyObject filename) {
         return directory_p(ruby.getCurrentContext(), filename);
     }
@@ -113,7 +113,7 @@ public class RubyFileTest {
         return asBoolean(context, fileResource(context, filename).canExecute());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject executable_p(IRubyObject recv, IRubyObject filename) {
         return executable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -128,12 +128,12 @@ public class RubyFileTest {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject executable_real_p(IRubyObject recv, IRubyObject filename) {
         return executable_real_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject exist_p(IRubyObject recv, IRubyObject filename) {
         return exist_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -152,7 +152,7 @@ public class RubyFileTest {
         return existsOnClasspath(context, pathStr);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyBoolean file_p(IRubyObject recv, IRubyObject filename) {
         return file_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -172,7 +172,7 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isGroupOwned());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject grpowned_p(IRubyObject recv, IRubyObject filename) {
         return grpowned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -211,7 +211,7 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isOwned());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject owned_p(IRubyObject recv, IRubyObject filename) {
         return owned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -223,12 +223,12 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isNamedPipe());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject pipe_p(IRubyObject recv, IRubyObject filename) {
         return pipe_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject readable_p(IRubyObject recv, IRubyObject filename) {
         return readable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -251,7 +251,7 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isROwned());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject rowned_p(IRubyObject recv, IRubyObject filename) {
         return rowned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -263,7 +263,7 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isSetgid());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setgid_p(IRubyObject recv, IRubyObject filename) {
         return setgid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -275,12 +275,12 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isSetuid());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setuid_p(IRubyObject recv, IRubyObject filename) {
         return setuid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject size(IRubyObject recv, IRubyObject filename) {
         return size(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -298,7 +298,7 @@ public class RubyFileTest {
         return asFixnum(context, stat.st_size());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static IRubyObject size_p(IRubyObject recv, IRubyObject filename) {
         return size_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -324,7 +324,7 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isSocket());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject socket_p(IRubyObject recv, IRubyObject filename) {
         return socket_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -336,7 +336,7 @@ public class RubyFileTest {
         return asBoolean(context, stat != null && stat.isSticky());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject sticky_p(IRubyObject recv, IRubyObject filename) {
         return sticky_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -346,7 +346,7 @@ public class RubyFileTest {
         return asBoolean(context, fileResource(context, filename).isSymLink());        
     }
     
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubyBoolean symlink_p(IRubyObject recv, IRubyObject filename) {
         return symlink_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -358,12 +358,12 @@ public class RubyFileTest {
         return asBoolean(context, fileResource(context, filename).canWrite());        
     }
     
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubyBoolean writable_p(IRubyObject recv, IRubyObject filename) {
         return writable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static RubyBoolean zero_p(IRubyObject recv, IRubyObject filename) {
         return zero_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
@@ -414,7 +414,7 @@ public class RubyFileTest {
             return RubyFileTest.blockdev_p(context, recv, filename);
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject blockdev_p(IRubyObject recv, IRubyObject filename) {
             return blockdev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -424,7 +424,7 @@ public class RubyFileTest {
             return RubyFileTest.chardev_p(context, recv, filename);            
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject chardev_p(IRubyObject recv, IRubyObject filename) {
             return chardev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -439,7 +439,7 @@ public class RubyFileTest {
             return RubyFileTest.executable_p(context, recv, filename);            
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject executable_p(IRubyObject recv, IRubyObject filename) {
             return executable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -449,7 +449,7 @@ public class RubyFileTest {
             return RubyFileTest.executable_real_p(context, recv, filename);            
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject executable_real_p(IRubyObject recv, IRubyObject filename) {
             return executable_real_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -469,7 +469,7 @@ public class RubyFileTest {
             return RubyFileTest.grpowned_p(context, recv, filename);            
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject grpowned_p(IRubyObject recv, IRubyObject filename) {
             return grpowned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -484,7 +484,7 @@ public class RubyFileTest {
             return RubyFileTest.owned_p(context, recv, filename);
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject owned_p(IRubyObject recv, IRubyObject filename) {
             return owned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -494,7 +494,7 @@ public class RubyFileTest {
             return RubyFileTest.pipe_p(context, recv, filename);
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject pipe_p(IRubyObject recv, IRubyObject filename) {
             return pipe_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -509,7 +509,7 @@ public class RubyFileTest {
             return RubyFileTest.setgid_p(context, recv, filename);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject setgid_p(IRubyObject recv, IRubyObject filename) {
             return setgid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -519,7 +519,7 @@ public class RubyFileTest {
             return RubyFileTest.setuid_p(context, recv, filename);            
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject setuid_p(IRubyObject recv, IRubyObject filename) {
             return setuid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -539,7 +539,7 @@ public class RubyFileTest {
             return RubyFileTest.socket_p(context, recv, filename);            
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject socket_p(IRubyObject recv, IRubyObject filename) {
             return socket_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -549,7 +549,7 @@ public class RubyFileTest {
             return RubyFileTest.sticky_p(context, recv, filename);
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject sticky_p(IRubyObject recv, IRubyObject filename) {
             return sticky_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -559,7 +559,7 @@ public class RubyFileTest {
             return RubyFileTest.symlink_p(context, recv, filename);            
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static RubyBoolean symlink_p(IRubyObject recv, IRubyObject filename) {
             return symlink_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -569,7 +569,7 @@ public class RubyFileTest {
             return RubyFileTest.writable_p(context, recv, filename);
         }
         
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static RubyBoolean writable_p(IRubyObject recv, IRubyObject filename) {
             return writable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
@@ -589,7 +589,7 @@ public class RubyFileTest {
             return RubyFileTest.worldWritable(context, recv, filename);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         public static IRubyObject identical_p(IRubyObject recv, IRubyObject filename1, IRubyObject filename2) {
             return RubyFileTest.identical_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename1, filename2);
         }
@@ -640,7 +640,7 @@ public class RubyFileTest {
         throw context.runtime.newErrnoENOENTError("No such file or directory - " + filename.convertToString());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject identical_p(IRubyObject recv, IRubyObject filename1, IRubyObject filename2) {
         return identical_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename1, filename2);
     }

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -221,13 +221,13 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
     }
 
     @Override
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public double getDoubleValue() {
         return value;
     }
 
     @Override
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public long getLongValue() {
         return value;
     }
@@ -437,7 +437,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
     /** fix_to_s
      *
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString to_s(IRubyObject[] args) {
         var context = getCurrentContext();
         return switch (args.length) {
@@ -469,7 +469,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
     /** fix_to_sym
      *
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject to_sym() {
         var context = getCurrentContext();
         RubySymbol symbol = RubySymbol.getSymbolLong(context.runtime, value);
@@ -708,7 +708,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         return op_minus_one(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject idiv(ThreadContext context, IRubyObject other, String method) {
         if (other instanceof RubyFixnum) {
             return idivLong(context, value, ((RubyFixnum) other).value);
@@ -723,7 +723,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         return coerceBin(context, site, other);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject idiv(ThreadContext context, long y, String method) {
         long x = value;
 
@@ -935,7 +935,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         return asFixnum(context, tmp);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     protected IRubyObject intPowTmp2(ThreadContext context, IRubyObject y, final long mm, boolean negaFlg) {
         return intPowTmp2(context, (RubyInteger) y, mm, negaFlg);
     }
@@ -1339,7 +1339,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
                 asFixnum(context, value >> width);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_rshift(long width) {
         return op_rshift(getCurrentContext(), width);
     }
@@ -1353,7 +1353,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
     }
 
     @Override
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_f() {
         return RubyFloat.newFloat(metaClass.runtime, (double) value);
     }
@@ -1366,7 +1366,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         return asFixnum(context, (long) ((BIT_SIZE + 7) / 8));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject zero_p() {
         return zero_p(getCurrentContext());
     }
@@ -1424,7 +1424,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         throw typeError(getRuntime().getCurrentContext(), "", this, " is not a symbol");
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyFixnum unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         return input.getRuntime().newFixnum(input.unmarshalInt());
@@ -1526,12 +1526,12 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         return context.sites.Fixnum;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static IRubyObject induced_from(IRubyObject recv, IRubyObject other) {
         return RubyNumeric.num2fix(recv.getRuntime().getCurrentContext(), other);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     public IRubyObject taint(ThreadContext context) {
         return this;

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -210,7 +210,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return asInteger(context, value > 0.0 ? Math.floor(value) : Math.ceil(value));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public int signum() {
         return signum(getCurrentContext());
     }
@@ -254,7 +254,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
     /** rb_flo_induced_from
      *
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject induced_from(ThreadContext context, IRubyObject recv, IRubyObject number) {
         if (number instanceof RubyFixnum || number instanceof RubyBignum || number instanceof RubyRational) {
             return number.callMethod(context, "to_f");
@@ -320,7 +320,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return asFloat(context, -value);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_uminus() {
         return op_uminus(getCurrentContext());
     }
@@ -657,7 +657,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return Helpers.multAndMix(runtime.getHashSeedK0(), hashLong);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_f() {
         return to_f(getCurrentContext());
     }
@@ -1089,7 +1089,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return asBoolean(context, isNaN());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject nan_p() {
         return nan_p(getCurrentContext());
     }
@@ -1098,7 +1098,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return Double.isNaN(value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject infinite_p() {
         return infinite_p(getCurrentContext());
     }
@@ -1115,7 +1115,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return Double.isInfinite(value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject finite_p() {
         return finite_p(getCurrentContext());
     }
@@ -1136,7 +1136,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return byteList;
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(RubyFloat aFloat, org.jruby.runtime.marshal.MarshalStream output) throws java.io.IOException {
         var context = aFloat.getRuntime().getCurrentContext();
@@ -1149,7 +1149,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         output.writeString(out, aFloat.marshalDump(context));
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyFloat unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         ByteList value = input.unmarshalString();
@@ -1183,7 +1183,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
     private static final ByteList NEGATIVE_INFINITY_BYTELIST = new ByteList("-inf".getBytes());
     private static final ByteList INFINITY_BYTELIST = new ByteList("inf".getBytes());
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject next_float() {
         return next_float(getCurrentContext());
     }
@@ -1193,7 +1193,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return asFloat(context, Math.nextAfter(value, Double.POSITIVE_INFINITY));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject prev_float() {
         return prev_float(getCurrentContext());
     }
@@ -1289,12 +1289,12 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         target.catWithCodeRange((RubyString) to_s(getRuntime().getCurrentContext()));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject zero_p() {
         return zero_p(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject floor(ThreadContext context, IRubyObject[] args) {
         return switch (args.length) {
             case 0 -> floor(context);
@@ -1303,7 +1303,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject round(ThreadContext context, IRubyObject[] args) {
         return switch (args.length) {
             case 0 -> round(context);

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -137,7 +137,7 @@ public class RubyGlobal {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void createGlobals(Ruby runtime) {
         var context = runtime.getCurrentContext();
         createGlobalsAndENV(context, globalVariables(context), instanceConfig(context));
@@ -574,7 +574,7 @@ public class RubyGlobal {
             return super.has_value_p(context, expected.convertToString());
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject index(ThreadContext context, IRubyObject expected) {
             warn(context, "ENV#index is deprecated; use ENV#key");
 
@@ -669,7 +669,7 @@ public class RubyGlobal {
             return newSharedString(context, ENV);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.3.0.0")
         public RubyHash to_h() {
             return to_h(getCurrentContext(), Block.NULL_BLOCK);
         }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1180,7 +1180,7 @@ public class RubyHash extends RubyObject implements Map {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyHash to_h(ThreadContext context) {
         return to_h(context, Block.NULL_BLOCK);
     }
@@ -1540,7 +1540,7 @@ public class RubyHash extends RubyObject implements Map {
         return hasKey(key) ? context.tru : context.fals;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.5.0")
     public RubyBoolean has_key_p(IRubyObject key) {
         return has_key_p(metaClass.runtime.getCurrentContext(), key);
     }
@@ -1880,7 +1880,7 @@ public class RubyHash extends RubyObject implements Map {
         return modified[0];
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject sort(ThreadContext context, Block block) {
         return to_a(context).sort_bang(context, block);
     }
@@ -2161,7 +2161,7 @@ public class RubyHash extends RubyObject implements Map {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyHash merge_bang(ThreadContext context, IRubyObject other, Block block) {
         return merge_bang(context, new IRubyObject[]{other}, block);
     }
@@ -2198,7 +2198,7 @@ public class RubyHash extends RubyObject implements Map {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyHash merge(ThreadContext context, IRubyObject other, Block block) {
         return merge(context, new IRubyObject[]{other}, block);
     }
@@ -2555,7 +2555,7 @@ public class RubyHash extends RubyObject implements Map {
 
     // FIXME:  Total hack to get flash in Rails marshalling/unmarshalling in session ok...We need
     // to totally change marshalling to work with overridden core classes.
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(final RubyHash hash, final org.jruby.runtime.marshal.MarshalStream output) throws IOException {
         var context = hash.getRuntime().getCurrentContext();
@@ -2590,7 +2590,7 @@ public class RubyHash extends RubyObject implements Map {
         if (hash.ifNone != UNDEF) output.dumpObject(context, out, hash.ifNone);
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     private static final VisitorWithState<org.jruby.runtime.marshal.MarshalStream> MarshalDumpVisitor = new VisitorWithState<>() {
         @Override
@@ -2604,7 +2604,7 @@ public class RubyHash extends RubyObject implements Map {
         }
     };
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyHash unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input, boolean defaultValue) throws IOException {
         RubyHash result = (RubyHash) input.entry(newHash(input.getRuntime()));
@@ -3056,24 +3056,24 @@ public class RubyHash extends RubyObject implements Map {
         return context.sites.Hash;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public IRubyObject op_aset(IRubyObject key, IRubyObject value) {
         return op_aset(metaClass.runtime.getCurrentContext(), key, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject each_pair(final ThreadContext context, final Block block) {
         return block.isGiven() ? each_pairCommon(context, block) : enumeratorizeWithSize(context, this, "each_pair", RubyHash::size);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public RubyHash each_pairCommon(final ThreadContext context, final Block block, final boolean oneNine) {
         iteratorVisitAll(context, YieldKeyValueArrayVisitor, block);
 
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public final void visitAll(Visitor visitor) {
         // use -1 to disable concurrency checks
         visitLimited(getRuntime().getCurrentContext(), visitor, -1, null);
@@ -3082,7 +3082,7 @@ public class RubyHash extends RubyObject implements Map {
     /** rb_hash_default
      *
      */
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public IRubyObject default_value_get(ThreadContext context, IRubyObject[] args) {
         return switch (args.length) {
             case 0 -> default_value_get(context);
@@ -3091,63 +3091,63 @@ public class RubyHash extends RubyObject implements Map {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     protected void internalPutSmall(final IRubyObject key, final IRubyObject value, final boolean checkForExisting) {
         internalPutNoResize(key, value, checkForExisting);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     @Override
     public RubyArray to_a() {
         return to_a(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public IRubyObject default_value_set(final IRubyObject defaultValue) {
         return default_value_set(getCurrentContext(), defaultValue);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public IRubyObject default_proc() {
         return (flags & PROCDEFAULT_HASH_F) != 0 ? ifNone : metaClass.runtime.getNil();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public IRubyObject set_default_proc(IRubyObject proc) {
         return set_default_proc(getCurrentContext(), proc);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public RubyFixnum rb_size() {
         return rb_size(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public RubyBoolean empty_p() {
         return asBoolean(getCurrentContext(), isEmpty());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public RubyHash rehash() {
         return rehash(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public RubyHash to_hash() {
         return to_hash(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public final RubyArray rb_values() {
         return values(metaClass.runtime.getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public RubyHash rb_clear() {
         return rb_clear(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
         return switch (args.length) {
             case 0 -> any_p(context, block);
@@ -3156,7 +3156,7 @@ public class RubyHash extends RubyObject implements Map {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject initialize(IRubyObject[] args, final Block block) {
         var context = getCurrentContext();
         return switch (args.length) {

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1294,7 +1294,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return port;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static IRubyObject sysopen(IRubyObject recv, IRubyObject[] args, Block block) {
         return sysopen(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }
@@ -1427,7 +1427,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @return
      * @deprecated Use {@link RubyIO#binmode(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject binmode() {
         return binmode(getCurrentContext());
     }
@@ -2176,7 +2176,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @return
      * @deprecated Use {@link RubyIO#sync_set(ThreadContext, IRubyObject)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject sync_set(IRubyObject sync) {
         return sync_set(getCurrentContext(), sync);
     }
@@ -3158,7 +3158,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return line;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public IRubyObject getc() {
         return getbyte(getCurrentContext());
     }
@@ -3538,7 +3538,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return str;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject read(IRubyObject[] args) {
         return read(getCurrentContext(), args);
     }
@@ -3687,7 +3687,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return fptr.fread(context, buffer, start, len);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public IRubyObject readchar() {
         return readchar(getCurrentContext());
     }
@@ -3746,7 +3746,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return block.isGiven() ? each_byteInternal(context, block) : enumeratorize(context.runtime, this, "each_byte");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject bytes(ThreadContext context, Block block) {
         context.runtime.getWarnings().warn("IO#bytes is deprecated; use #each_byte instead");
         return each_byte(context, block);
@@ -3783,13 +3783,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return each_charInternal(context, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject chars(ThreadContext context, Block block) {
         context.runtime.getWarnings().warn("IO#chars is deprecated; use #each_char instead");
         return each_charInternal(context, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject codepoints(ThreadContext context, Block block) {
         context.runtime.getWarnings().warn("IO#codepoints is deprecated; use #each_codepoint instead");
         return eachCodePointCommon(context, block, "each_codepoint");
@@ -3992,7 +3992,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject lines(final ThreadContext context, Block block) {
         context.runtime.getWarnings().warn("IO#lines is deprecated; use #each_line instead");
         return each_line(context, block);
@@ -5432,7 +5432,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         ALL_SPAWN_OPTIONS = new HashSet<>(Arrays.asList(SPAWN_OPTIONS));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static void checkExecOptions(IRubyObject options) {
         if (options instanceof RubyHash) {
             RubyHash opts = (RubyHash) options;
@@ -5443,7 +5443,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static void checkSpawnOptions(IRubyObject options) {
         if (options instanceof RubyHash) {
             RubyHash opts = (RubyHash) options;
@@ -5454,7 +5454,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static void checkPopenOptions(IRubyObject options) {
         if (options instanceof RubyHash) {
             RubyHash opts = (RubyHash) options;
@@ -5582,7 +5582,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public IRubyObject readline(ThreadContext context, IRubyObject[] args) {
         return args.length == 0 ? readline(context) : readline(context, args[0]);
     }
@@ -5686,27 +5686,27 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return context.sites.IO;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public IRubyObject getline(Ruby runtime, ByteList separator) {
         return getline(runtime.getCurrentContext(), runtime.newString(separator), -1);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public IRubyObject getline(Ruby runtime, ByteList separator, long limit) {
         return getline(runtime.getCurrentContext(), runtime.newString(separator), limit);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject getline(ThreadContext context, ByteList separator) {
         return getline(context, newString(context, separator), -1);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject getline(ThreadContext context, ByteList separator, long limit) {
         return getline(context, newString(context, separator), limit);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public RubyIO(Ruby runtime, STDIO stdio) {
         super(runtime, runtime.getIO());
 
@@ -5727,7 +5727,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         tmp.openFile = null;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public RubyIO(Ruby runtime, RubyClass cls, ShellLauncher.POpenProcess process, RubyHash options, IOOptions ioOptions) {
         super(runtime, cls);
         var context = runtime.getCurrentContext();
@@ -5739,12 +5739,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         setupPopen(context, ioOptions.getModeFlags(), process);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static ModeFlags getIOModes(Ruby runtime, String modesString) {
         return newModeFlags(runtime, modesString);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static int getIOModesIntFromString(Ruby runtime, String modesString) {
         try {
             return ModeFlags.getOFlagsFromString(modesString);
@@ -5753,12 +5753,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject writeStatic(ThreadContext context, IRubyObject recv, IRubyObject[] argv, Block unusedBlock) {
         return write(context, recv, argv);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     @JRubyMethod(name = "popen3", rest = true, meta = true)
     public static IRubyObject popen3(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         final Ruby runtime = context.runtime;
@@ -5837,7 +5837,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return yieldArgs;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject popen4(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         Ruby runtime = context.runtime;
 
@@ -5865,7 +5865,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     private static void cleanupPOpen(POpenTuple tuple) {
         if (tuple.input.openFile.isOpen()) {
             try {
@@ -5884,7 +5884,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     private static class POpenTuple {
         public POpenTuple(RubyIO i, RubyIO o, RubyIO e, Process p) {
             input = i; output = o; error = e; process = p;
@@ -5895,7 +5895,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         public final Process process;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static POpenTuple popenSpecial(ThreadContext context, IRubyObject[] args) {
         Ruby runtime = context.runtime;
 
@@ -5937,27 +5937,27 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public IRubyObject doWriteNonblock(ThreadContext context, IRubyObject[] argv, boolean useException) {
         return write_nonblock(context, argv);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject select_static(ThreadContext context, Ruby runtime, IRubyObject[] args) {
         return select(context, ioClass(context), args);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static RubyArray checkExecEnv(ThreadContext context, RubyHash hash) {
         return PopenExecutor.checkExecEnv(context, hash, null);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static IRubyObject ioOpen(ThreadContext context, IRubyObject filename, IRubyObject vmode, IRubyObject vperm, IRubyObject opt) {
         return ioOpen(context, ioClass(context), filename, vmode, vperm, opt);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject write_nonblock(ThreadContext context, IRubyObject[] argv) {
         switch (argv.length) {
             case 1:
@@ -5969,7 +5969,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject read_nonblock(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 3);
 
@@ -5977,7 +5977,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return doReadNonblock(context, args, exception);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject readpartial(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -5995,7 +5995,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return value;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject sysread(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -6007,7 +6007,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return sysreadCommon(context, runtime, _length, _str);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject pipe(ThreadContext context, IRubyObject klass, IRubyObject[] argv, Block block) {
         switch (argv.length) {
             case 0:

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1735,7 +1735,7 @@ public class RubyInstanceConfig {
      */
     public static final boolean NATIVE_ENABLED = Options.NATIVE_ENABLED.load();
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public final static boolean CEXT_ENABLED = false;
 
     /**
@@ -1842,76 +1842,76 @@ public class RubyInstanceConfig {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public void setSafeLevel(int safeLevel) {
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public String getInPlaceBackupExtention() {
         return inPlaceBackupExtension;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public String getBasicUsageHelp() {
         return OutputStrings.getBasicUsageHelp();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public String getExtendedHelp() {
         return OutputStrings.getExtendedHelp();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public String getPropertyHelp() {
         return OutputStrings.getPropertyHelp();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public String getVersionString() {
         return OutputStrings.getVersionString();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public String getCopyrightString() {
         return OutputStrings.getCopyrightString();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public Collection<String> requiredLibraries() {
         return requiredLibraries;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public List<String> loadPaths() {
         return loadPaths;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public boolean shouldPrintUsage() {
         return shouldPrintUsage;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public boolean shouldPrintProperties() {
         return shouldPrintProperties;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public Boolean getVerbose() {
         return isVerbose();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public boolean shouldRunInterpreter() {
         return isShouldRunInterpreter();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public boolean isShouldRunInterpreter() {
         return shouldRunInterpreter;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public boolean isxFlag() {
         return xFlag;
     }
@@ -1919,129 +1919,129 @@ public class RubyInstanceConfig {
     /**
      * The max count of active methods eligible for JIT-compilation.
      */
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public static final int JIT_MAX_METHODS_LIMIT = Constants.JIT_MAX_METHODS_LIMIT;
 
     /**
      * The max size of JIT-compiled methods (full class size) allowed.
      */
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public static final int JIT_MAX_SIZE_LIMIT = Constants.JIT_MAX_SIZE_LIMIT;
 
     /**
      * The JIT threshold to the specified method invocation count.
      */
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public static final int JIT_THRESHOLD = Constants.JIT_THRESHOLD;
 
     /**
      * Default size for chained compilation.
      */
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public static final int CHAINED_COMPILE_LINE_COUNT_DEFAULT = Constants.CHAINED_COMPILE_LINE_COUNT_DEFAULT;
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public static final boolean nativeEnabled = NATIVE_ENABLED;
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public boolean isSamplingEnabled() {
         return false;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public void setBenchmarking(boolean benchmarking) {
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public boolean isBenchmarking() {
         return false;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public void setCextEnabled(boolean b) {
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public boolean isCextEnabled() {
         return false;
     }
 
     @Deprecated public static final String JIT_CODE_CACHE = "";
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public boolean isJitDumping() {
         return jitDumping;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public String getThreadDumpSignal() {
         return threadDumpSignal;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public boolean isGlobalRequireLock() {
         return globalRequireLock;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public void setGlobalRequireLock(boolean globalRequireLock) {
         this.globalRequireLock = globalRequireLock;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public static final boolean NATIVE_NET_PROTOCOL = Options.NATIVE_NET_PROTOCOL.load();
 
-    @Deprecated
+    @Deprecated(since = "9.2.9.0")
     public static final boolean CAN_SET_ACCESSIBLE = Options.JI_SETACCESSIBLE.load();
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static boolean THREADLESS_COMPILE_ENABLED = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final int CHAINED_COMPILE_LINE_COUNT = 500;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final boolean PEEPHOLE_OPTZ = true;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static boolean NOGUARDS_COMPILE_ENABLED = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final boolean FASTEST_COMPILE_ENABLED = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static boolean FASTSEND_COMPILE_ENABLED = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static boolean FAST_MULTIPLE_ASSIGNMENT = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     private final boolean jitDumping = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final boolean JIT_LOADING_DEBUG = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final boolean JIT_CACHE_ENABLED = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     private boolean runRubyInProcess = true;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final boolean REFLECTED_HANDLES = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     private String threadDumpSignal = null;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final boolean COROUTINE_FIBERS = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     private boolean globalRequireLock = false;
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final boolean USE_GENERATED_HANDLES = false;
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public static final boolean FASTOPS_COMPILE_ENABLED = Options.COMPILE_FASTOPS.load();
 }

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -113,7 +113,7 @@ public abstract class RubyInteger extends RubyNumeric {
         super(runtime, rubyClass, useObjectSpace);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public RubyInteger(Ruby runtime, RubyClass rubyClass, boolean useObjectSpace, boolean canBeTainted) {
         super(runtime, rubyClass, useObjectSpace, canBeTainted);
     }
@@ -129,7 +129,7 @@ public abstract class RubyInteger extends RubyNumeric {
         return asFloat(context, asDouble(context));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public int signum() {
         return signum(getCurrentContext());
     }
@@ -139,7 +139,7 @@ public abstract class RubyInteger extends RubyNumeric {
         return asBigInteger(context).signum();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger negate() {
         return negate(getCurrentContext());
     }
@@ -505,7 +505,7 @@ public abstract class RubyInteger extends RubyNumeric {
      * @return ""
      * @deprecated Use {@link org.jruby.RubyInteger#numToUint(ThreadContext, IRubyObject)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static long numToUint(IRubyObject val) {
         return numToUint(((RubyBasicObject) val).getCurrentContext(), val);
     }
@@ -560,7 +560,7 @@ public abstract class RubyInteger extends RubyNumeric {
     }
 
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_i() {
         return to_i(getCurrentContext());
     }
@@ -862,7 +862,7 @@ public abstract class RubyInteger extends RubyNumeric {
         return RubyFixnum.one(context.runtime);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString to_s() {
         return to_s(getCurrentContext());
     }
@@ -874,7 +874,7 @@ public abstract class RubyInteger extends RubyNumeric {
         throw new RuntimeException("all numeric types must override this method");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString to_s(IRubyObject x) {
         return to_s(getCurrentContext(), x);
     }
@@ -1102,7 +1102,7 @@ public abstract class RubyInteger extends RubyNumeric {
     @JRubyMethod(name = "bit_length")
     public abstract IRubyObject bit_length(ThreadContext context);
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     boolean isOne() {
         return isOne(getCurrentContext());
     }
@@ -1141,17 +1141,17 @@ public abstract class RubyInteger extends RubyNumeric {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_uminus() {
         return op_uminus(getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_neg() {
         return to_f(getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_aref(IRubyObject other) {
         return op_aref(getCurrentContext(), other);
     }
@@ -1166,12 +1166,12 @@ public abstract class RubyInteger extends RubyNumeric {
         return op_rshift(getCurrentContext(), other);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_f() {
         return to_f(getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject size() {
         return size(getCurrentContext());
     }
@@ -1187,7 +1187,7 @@ public abstract class RubyInteger extends RubyNumeric {
     /** rb_int_induced_from
      *
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject induced_from(ThreadContext context, IRubyObject recv, IRubyObject other) {
         if (other instanceof RubyFixnum || other instanceof RubyBignum) return other;
 
@@ -1198,27 +1198,27 @@ public abstract class RubyInteger extends RubyNumeric {
         return other.callMethod(context, "to_i");
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject round() {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject ceil(){
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject floor(){
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject truncate(){
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public final IRubyObject op_idiv(ThreadContext context, IRubyObject arg) {
         return div(context, arg);
     }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -338,7 +338,7 @@ public class RubyKernel {
         return RubyIO.open(context, fileClass(context), args, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject getc(ThreadContext context, IRubyObject recv) {
         Warn.warn(context, "getc is obsolete; use STDIN.getc instead");
         IRubyObject defin = globalVariables(context).get("$stdin");
@@ -450,14 +450,14 @@ public class RubyKernel {
         return  exObj.isTrue();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyFloat new_float(IRubyObject recv, IRubyObject object) {
         return (RubyFloat) new_float(((RubyBasicObject) recv).getCurrentContext(), object, true);
     }
 
     private static final ByteList ZEROx = new ByteList(new byte[] { '0','x' }, false);
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyFloat new_float(final Ruby runtime, IRubyObject object) {
         return (RubyFloat) new_float(runtime.getCurrentContext(), object, true);
     }
@@ -473,7 +473,7 @@ public class RubyKernel {
         throw argumentError(context, str(context.runtime, "invalid value for Float(): ", newString(context, string)));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static double parseHexidecimalExponentString2(Ruby runtime, ByteList str) {
         return parseHexidecimalExponentString2(runtime.getCurrentContext(), str);
     }
@@ -910,7 +910,7 @@ public class RubyKernel {
         return asFixnum(context, Math.round((System.nanoTime() - startTime) / 1_000_000_000.0));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject exit(IRubyObject recv, IRubyObject[] args) {
         return exit(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -923,7 +923,7 @@ public class RubyKernel {
         throw exit(context, args, false);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject exit_bang(IRubyObject recv, IRubyObject[] args) {
         return exit_bang(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -1025,7 +1025,7 @@ public class RubyKernel {
         return str.op_format(context, arg);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.5.0")
     public static IRubyObject sprintf(IRubyObject recv, IRubyObject[] args) {
         return sprintf(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -1641,7 +1641,7 @@ public class RubyKernel {
         return context.runtime.newProc(Block.Type.LAMBDA, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static RubyProc proc_1_9(ThreadContext context, IRubyObject recv, Block block) {
         return proc(context, recv, block);
     }
@@ -2110,7 +2110,7 @@ public class RubyKernel {
         return newString(context, RubyFile.dirname(context, path.asJavaString()));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject singleton_class(IRubyObject recv) {
         return singleton_class(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -2144,7 +2144,7 @@ public class RubyKernel {
         return method.call(context, recv, entry.sourceModule, name, args, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject eql_p(IRubyObject self, IRubyObject obj) {
         return eql_p(((RubyBasicObject) self).getCurrentContext(), self, obj);
     }
@@ -2176,7 +2176,7 @@ public class RubyKernel {
      * @return
      * @deprecated Use {@link org.jruby.RubyKernel#initialize_copy(ThreadContext, IRubyObject, IRubyObject)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject initialize_copy(IRubyObject self, IRubyObject original) {
         return initialize_copy(((RubyBasicObject) self).getCurrentContext(), self, original);
     }
@@ -2198,12 +2198,12 @@ public class RubyKernel {
         return sites(context).initialize_copy.call(context, self, self, original);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static RubyBoolean respond_to_p(IRubyObject self, IRubyObject mname) {
         return ((RubyBasicObject) self).respond_to_p(mname);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static RubyBoolean respond_to_p(IRubyObject self, IRubyObject mname, IRubyObject includePrivate) {
         return ((RubyBasicObject) self).respond_to_p(mname, includePrivate);
     }
@@ -2218,7 +2218,7 @@ public class RubyKernel {
         return ((RubyBasicObject) self).respond_to_p(context, name, includePrivate.isTrue());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyFixnum hash(IRubyObject self) {
         return ((RubyBasicObject) self).hash(((RubyBasicObject) self).getCurrentContext());
     }
@@ -2265,7 +2265,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).frozen_p(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject inspect(IRubyObject self) {
         return inspect(((RubyBasicObject) self).getCurrentContext(), self);
     }
@@ -2330,7 +2330,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).singleton_methods(context, args);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject singleton_method(IRubyObject self, IRubyObject symbol) {
         return singleton_method(((RubyBasicObject) self).getCurrentContext(), self, symbol);
     }
@@ -2345,7 +2345,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).method(context, symbol, context.getCurrentStaticScope());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject to_s(IRubyObject self) {
         return to_s(((RubyBasicObject) self).getCurrentContext(), self);
     }
@@ -2355,7 +2355,7 @@ public class RubyKernel {
         return ((RubyBasicObject) self).to_s(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject extend(IRubyObject self, IRubyObject[] args) {
         return extend(((RubyBasicObject) self).getCurrentContext(), self, args);
     }
@@ -2489,12 +2489,12 @@ public class RubyKernel {
         return context.sites.Kernel;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public static IRubyObject methodMissing(ThreadContext context, IRubyObject recv, String name, Visibility lastVis, CallType lastCallType, IRubyObject[] args, Block block) {
         return methodMissing(context, recv, name, lastVis, lastCallType, args);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     private static IRubyObject caller(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         switch (args.length) {
             case 0:
@@ -2509,7 +2509,7 @@ public class RubyKernel {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     public static IRubyObject caller_locations(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 0:
@@ -2524,24 +2524,24 @@ public class RubyKernel {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public static IRubyObject require(IRubyObject recv, IRubyObject name, Block block) {
         return require(((RubyBasicObject) recv).getCurrentContext(), recv, name, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject op_match(ThreadContext context, IRubyObject self, IRubyObject arg) {
         Warn.warn(context, "deprecated Object#=~ is called on " + ((RubyBasicObject) self).type() +
                 "; it always returns nil");
         return ((RubyBasicObject) self).op_match(context, arg);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject autoload(final IRubyObject recv, IRubyObject symbol, IRubyObject file) {
         return autoload(((RubyBasicObject) recv).getCurrentContext(), recv, symbol, file);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject rand(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 0:
@@ -2553,13 +2553,13 @@ public class RubyKernel {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public static IRubyObject method(IRubyObject self, IRubyObject symbol) {
         return ((RubyBasicObject)self).method(symbol);
     }
 
     // defined in Ruby now but left here for backward compat
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject tap(ThreadContext context, IRubyObject recv, Block block) {
         if (block.getProcObject() != null) {
             block.getProcObject().call(context, recv);
@@ -2569,7 +2569,7 @@ public class RubyKernel {
         return recv;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject sleep(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 0:
@@ -2581,7 +2581,7 @@ public class RubyKernel {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject test(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 2:

--- a/core/src/main/java/org/jruby/RubyKeyError.java
+++ b/core/src/main/java/org/jruby/RubyKeyError.java
@@ -111,7 +111,7 @@ public class RubyKeyError extends RubyIndexError {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject receiver() {
         return receiver(getCurrentContext());
     }
@@ -122,7 +122,7 @@ public class RubyKeyError extends RubyIndexError {
         return receiver;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject key() {
         return key(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -196,12 +196,12 @@ public class RubyMarshal {
         throw typeError(context, "can't dump ", self, "");
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject dump(IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
         return dump(((RubyBasicObject) recv).getCurrentContext(), recv, args, unusedBlock);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject dump(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
         IRubyObject objectToDump = args[0];

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -329,12 +329,12 @@ public class RubyMatchData extends RubyObject {
         return arr;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject group(long n) {
         return group(getCurrentContext(), (int) n);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject group(int n) {
         return group(getCurrentContext(), n);
     }
@@ -343,7 +343,7 @@ public class RubyMatchData extends RubyObject {
         return RubyRegexp.nth_match(context, n, this);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public int getNameToBackrefNumber(String name) {
         return getNameToBackrefNumber(getCurrentContext(), name);
     }
@@ -359,7 +359,7 @@ public class RubyMatchData extends RubyObject {
 
     // This returns a list of values in the order the names are defined (named capture local var
     // feature uses this).
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject[] getNamedBackrefValues(Ruby runtime) {
         var context = runtime.getCurrentContext();
         final Regex pattern = getPattern(context);
@@ -412,7 +412,7 @@ public class RubyMatchData extends RubyObject {
         return start < 0 ? context.nil : asFixnum(context, regs.getEnd(index));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString inspect() {
         return inspect(getCurrentContext());
     }
@@ -498,7 +498,7 @@ public class RubyMatchData extends RubyObject {
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject values_at(IRubyObject[] args) {
         return values_at(getCurrentContext(), args);
     }
@@ -538,7 +538,7 @@ public class RubyMatchData extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final int backrefNumber(Ruby runtime, IRubyObject obj) {
         return backrefNumber(runtime.getCurrentContext(), obj);
     }
@@ -548,7 +548,7 @@ public class RubyMatchData extends RubyObject {
         return backrefNumber(context, getPattern(context), regs, obj);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int backrefNumber(Ruby runtime, Regex pattern, Region regs, IRubyObject obj) {
         return backrefNumber(runtime.getCurrentContext(), pattern, regs, obj);
     }
@@ -661,7 +661,7 @@ public class RubyMatchData extends RubyObject {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject at(final int nth) {
         return at(getCurrentContext(), nth);
     }
@@ -719,7 +719,7 @@ public class RubyMatchData extends RubyObject {
         return asFixnum(context, e);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject offset19(ThreadContext context, IRubyObject index) {
         return offset(context, index);
     }
@@ -838,7 +838,7 @@ public class RubyMatchData extends RubyObject {
         return ss.isNil() ? newEmptyString(context) : ss;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject string() {
         return string(getCurrentContext());
     }
@@ -895,7 +895,7 @@ public class RubyMatchData extends RubyObject {
         return asFixnum(context, hashCode());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyHash named_captures(ThreadContext context) {
         return named_captures(context, NULL_ARRAY);
     }
@@ -1033,18 +1033,18 @@ public class RubyMatchData extends RubyObject {
         return regs == null ? 1 : regs.getNumRegs();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     @Override
     public RubyArray to_a() {
         return match_array(getCurrentContext(), 0);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public IRubyObject op_aref(IRubyObject idx) {
         return op_aref(getCurrentContext(), idx);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public IRubyObject op_aref(IRubyObject idx, IRubyObject rest) {
         return op_aref(getCurrentContext(), idx, rest);
     }

--- a/core/src/main/java/org/jruby/RubyMath.java
+++ b/core/src/main/java/org/jruby/RubyMath.java
@@ -355,7 +355,7 @@ public class RubyMath {
         return asFloat(context, Math.cbrt(toDouble(context, x)));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubyFloat hypot19(ThreadContext context, IRubyObject recv, IRubyObject x, IRubyObject y) {
         return hypot(context, recv, x, y);
     }    

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -309,7 +309,7 @@ public class RubyMethod extends AbstractRubyMethod {
         return receiver;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject curry(ThreadContext context, IRubyObject[] args) {
         IRubyObject proc = to_proc(context);
         return sites(context).curry.call(context, proc, proc, args);

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -238,7 +238,7 @@ public class RubyModule extends RubyObject {
      * @param classIndex the ClassIndex for this type
      * @deprecated Use {@link org.jruby.RubyModule#classIndex(ClassIndex)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     void setClassIndex(ClassIndex classIndex) {
         classIndex(classIndex);
     }
@@ -469,12 +469,12 @@ public class RubyModule extends RubyObject {
     /** rb_module_new
      *
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule newModule(Ruby runtime) {
         return new RubyModule(runtime);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule newModule(Ruby runtime, String name, RubyModule parent, boolean setParent, String file, int line) {
         return newModule(runtime.getCurrentContext(), name, parent, setParent, file, line);
     }
@@ -494,7 +494,7 @@ public class RubyModule extends RubyObject {
         return module;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule newModule(Ruby runtime, String name, RubyModule parent, boolean setParent) {
         var context = runtime.getCurrentContext();
         RubyModule module = new RubyModule(runtime).baseName(name);
@@ -589,7 +589,7 @@ public class RubyModule extends RubyObject {
      * @param superClass
      * @deprecated Use {@link RubyModule#superClass(RubyClass)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void setSuperClass(RubyClass superClass) {
         superClass(superClass);
     }
@@ -626,7 +626,7 @@ public class RubyModule extends RubyObject {
         return methods;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public DynamicMethod putMethod(Ruby runtime, String id, DynamicMethod method) {
         return putMethod(getCurrentContext(), id, method);
     }
@@ -676,7 +676,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyModule getNonIncludedClass() {
         return this;
     }
@@ -716,12 +716,12 @@ public class RubyModule extends RubyObject {
      * @param name the new base name of the class
      * @deprecated Use {@link org.jruby.RubyModule#baseName(String)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void setBaseName(String name) {
         baseName(name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public String getName() {
         return getName(getCurrentContext());
     }
@@ -737,7 +737,7 @@ public class RubyModule extends RubyObject {
         return cachedName != null ? cachedName : calculateName(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString rubyName() {
         return rubyName(getCurrentContext());
     }
@@ -754,7 +754,7 @@ public class RubyModule extends RubyObject {
         return cachedRubyName != null ? cachedRubyName : calculateRubyName(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubySymbol symbolName() {
         return symbolName(getCurrentContext());
     }
@@ -775,7 +775,7 @@ public class RubyModule extends RubyObject {
         return symbolName == UNDEF ? null : (RubySymbol) symbolName;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString rubyBaseName() {
         return rubyBaseName(getCurrentContext());
     }
@@ -878,7 +878,7 @@ public class RubyModule extends RubyObject {
         return fullName;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public String getSimpleName() {
         return getSimpleName(getCurrentContext());
     }
@@ -1224,7 +1224,7 @@ public class RubyModule extends RubyObject {
      *
      * @return The module wrapper
      */
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public IncludedModuleWrapper newIncludeClass(RubyClass superClazz) {
         var context = getCurrentContext();
         IncludedModuleWrapper includedModule = new IncludedModuleWrapper(context.runtime, superClazz, this);
@@ -1235,7 +1235,7 @@ public class RubyModule extends RubyObject {
         return includedModule;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule getModule(String name) {
         return getModule(getCurrentContext(), name);
     }
@@ -1251,7 +1251,7 @@ public class RubyModule extends RubyObject {
         return (RubyModule) getConstantAt(context, name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass getClass(String name) {
         return getClass(getCurrentContext(), name);
     }
@@ -1270,12 +1270,12 @@ public class RubyModule extends RubyObject {
         return (RubyClass) getConstantAt(context, name);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public RubyClass fastGetClass(String internedName) {
         return getClass(getCurrentContext(), internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void prependModule(RubyModule module) {
         prependModule(getCurrentContext(), module);
     }
@@ -1329,13 +1329,13 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.8.0")
     public void prependModule(IRubyObject arg) {
         assert arg != null;
         prependModule(castAsModule(getCurrentContext(), arg));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public synchronized void includeModule(IRubyObject arg) {
         includeModule(getCurrentContext(), arg);
     }
@@ -1394,7 +1394,7 @@ public class RubyModule extends RubyObject {
      * definitions where you only specify the .class and not needing to add a name as a discriminator.  This
      * method is fairly inefficient since it is rescanning the class for all methods to find a single version.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void defineAnnotatedMethod(Class clazz, String name) {
         // FIXME: This is probably not very efficient, since it loads all methods for each call
         boolean foundMethod = false;
@@ -1414,7 +1414,7 @@ public class RubyModule extends RubyObject {
      * @param clazz
      * @deprecated Use {@link RubyModule#defineConstants(ThreadContext, Class)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final void defineAnnotatedConstants(Class clazz) {
         defineConstants(getCurrentContext(), clazz);
     }
@@ -1424,7 +1424,7 @@ public class RubyModule extends RubyObject {
      * @return ""
      * @deprecated Use {@link RubyModule#defineAnnotatedConstant(ThreadContext, Field)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final boolean defineAnnotatedConstant(Field field) {
         return defineAnnotatedConstant(getCurrentContext(), field);
     }
@@ -1465,7 +1465,7 @@ public class RubyModule extends RubyObject {
      * @deprecated Use {@link RubyModule#defineMethods(ThreadContext, Class[])} instead.
      */
     @Extension
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void defineAnnotatedMethods(Class clazz) {
         defineAnnotatedMethodsIndividually(clazz);
     }
@@ -1560,7 +1560,7 @@ public class RubyModule extends RubyObject {
         return new TypePopulator.ReflectiveTypePopulator(type);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final void defineAnnotatedMethodsIndividually(Class clazz) {
         var context = getCurrentContext();
         context.runtime.POPULATORS.get(clazz).populate(context, this, clazz);
@@ -1572,7 +1572,7 @@ public class RubyModule extends RubyObject {
      * @deprecated Use {@link RubyModule#defineMethods(ThreadContext, Class[])} instead and organize your
      * code around all JRubyMethod annotations in that .class being defined.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final boolean defineAnnotatedMethod(String name, List<JavaMethodDescriptor> methods, MethodFactory methodFactory) {
         if (methods.size() == 1 && methods.get(0).anno == null) return false;
         defineAnnotatedMethod(getCurrentContext(), name, methods, methodFactory);
@@ -1597,7 +1597,7 @@ public class RubyModule extends RubyObject {
         define(context, this, desc, dynamicMethod);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final boolean defineAnnotatedMethod(Method method, MethodFactory methodFactory) {
         if (method.getAnnotation(JRubyMethod.class) == null) return false;
 
@@ -1608,7 +1608,7 @@ public class RubyModule extends RubyObject {
         return true;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final boolean defineAnnotatedMethod(String name, JavaMethodDescriptor desc, MethodFactory methodFactory) {
         if (desc.anno == null) return false;
 
@@ -1810,7 +1810,7 @@ public class RubyModule extends RubyObject {
     /**
      * @deprecated Use {@link RubyModule#undefMethods(ThreadContext, String...)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void undefineMethod(String name) {
         getMethodLocation().addMethod(getCurrentContext(), name, UndefinedMethod.getInstance());
     }
@@ -1887,7 +1887,7 @@ public class RubyModule extends RubyObject {
         return isClass() ? "class" : "module";
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void addMethod(String id, DynamicMethod method) {
         addMethod(getCurrentContext(), id, method);
     }
@@ -1928,7 +1928,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final void addMethodInternal(String name, DynamicMethod method) {
         addMethodInternal(getCurrentContext(), name, method);
     }
@@ -2017,7 +2017,7 @@ public class RubyModule extends RubyObject {
         return searchWithCacheAndRefinements(name, refinedScope);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.1.0")
     public final CacheEntry searchWithCache(String id, boolean cacheUndef) {
         final CacheEntry entry = cacheHit(id);
         return entry != null ? entry : searchWithCacheMiss(getRuntime(), id);
@@ -2101,7 +2101,7 @@ public class RubyModule extends RubyObject {
         return methodEntry;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public final int getCacheToken() {
         return generation;
     }
@@ -2301,7 +2301,7 @@ public class RubyModule extends RubyObject {
     /**
      * Searches for a method up until the superclass, but include modules.
      */
-    @Deprecated
+    @Deprecated(since = "9.3.11.0")
     public DynamicMethod searchMethodLateral(String id) {
         for (RubyModule module = this; (module == this || (module instanceof IncludedModuleWrapper)); module = module.getSuperClass()) {
             DynamicMethod method = module.searchMethodCommon(id);
@@ -2345,7 +2345,7 @@ public class RubyModule extends RubyObject {
         return getMethods().get(id);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void invalidateCacheDescendants() {
         invalidateCacheDescendants(getCurrentContext());
     }
@@ -2404,7 +2404,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void invalidateCoreClasses() {
     }
 
@@ -2420,7 +2420,7 @@ public class RubyModule extends RubyObject {
         generationObject = generation = runtime.getNextModuleGeneration();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void invalidateConstantCache(String constantName) {
         invalidateConstantCache(getCurrentContext(), constantName);
     }
@@ -2429,7 +2429,7 @@ public class RubyModule extends RubyObject {
         context.runtime.getConstantInvalidator(constantName).invalidate();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void invalidateConstantCaches(Set<String> constantNames) {
         if (constantNames.size() > 0) {
             Ruby runtime = getCurrentContext().runtime;
@@ -2467,7 +2467,7 @@ public class RubyModule extends RubyObject {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void addModuleFunction(String name, DynamicMethod method) {
         var context = getCurrentContext();
         addMethod(context, name, method);
@@ -2479,12 +2479,12 @@ public class RubyModule extends RubyObject {
      * @param oldName
      * @deprecated Use {@link RubyModule#aliasMethod(ThreadContext, IRubyObject, IRubyObject)} instead
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public synchronized void defineAlias(String name, String oldName) {
         defineAlias(getCurrentContext(), name, oldName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void putAlias(String id, DynamicMethod method, String oldName) {
         putAlias(getCurrentContext(), id, method, oldName);
     }
@@ -2505,7 +2505,7 @@ public class RubyModule extends RubyObject {
         if (isRefinement()) addRefinedMethodEntry(context, id, method);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void putAlias(String id, CacheEntry entry, String oldName) {
         putAlias(getCurrentContext(), id, entry, oldName);
     }
@@ -2581,22 +2581,22 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineOrGetClassUnder(String name, RubyClass superClazz) {
         return defineClassUnder(getCurrentContext(), name, superClazz, null, null, -1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineOrGetClassUnder(String name, RubyClass superClazz, String file, int line) {
         return defineClassUnder(getCurrentContext(), name, superClazz, null, file, line);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineOrGetClassUnder(String name, RubyClass superClazz, ObjectAllocator allocator) {
         return defineClassUnder(getCurrentContext(), name, superClazz, allocator, null, -1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineOrGetClassUnder(String name, RubyClass superClazz, ObjectAllocator allocator,
                                            String file, int line) {
         return defineClassUnder(getCurrentContext(), name, superClazz, allocator, file, line);
@@ -2669,12 +2669,12 @@ public class RubyModule extends RubyObject {
     /** this method should be used only by interpreter or compiler
      *
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule defineOrGetModuleUnder(String name) {
         return defineOrGetModuleUnder(getCurrentContext(), name, null, -1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule defineOrGetModuleUnder(String name, String file, int line) {
         return defineOrGetModuleUnder(getCurrentContext(), name, file, line);
     }
@@ -2703,12 +2703,12 @@ public class RubyModule extends RubyObject {
      * @return ""
      * @deprecated Use {@link RubyModule#defineClassUnder(ThreadContext, String, RubyClass, ObjectAllocator)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyClass defineClassUnder(String name, RubyClass superClass, ObjectAllocator allocator) {
         return defineClassUnder(getCurrentContext(), name, superClass, allocator);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyModule defineModuleUnder(String name) {
         return defineModuleUnder(getCurrentContext(), name);
     }
@@ -2761,7 +2761,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void setMethodVisibility(IRubyObject[] methods, Visibility visibility) {
         setMethodVisibility(getCurrentContext(), methods, visibility);
     }
@@ -2780,7 +2780,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void exportMethod(String name, Visibility visibility) {
         exportMethod(getCurrentContext(), name, visibility);
     }
@@ -2843,27 +2843,27 @@ public class RubyModule extends RubyObject {
         return Helpers.respondsToMethod(searchMethod(name), checkVisibility);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     public boolean isMethodBound(String name, boolean checkVisibility, boolean checkRespondTo) {
         return checkRespondTo ? respondsToMethod(name, checkVisibility): isMethodBound(name, checkVisibility);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject newMethod(IRubyObject receiver, String methodName, boolean bound, Visibility visibility) {
         return newMethod(getCurrentContext(), receiver, methodName, null, bound, visibility, false, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject newMethod(IRubyObject receiver, String methodName, StaticScope refinedScope, boolean bound, Visibility visibility) {
         return newMethod(getCurrentContext(), receiver, methodName, refinedScope, bound, visibility, false, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject newMethod(IRubyObject receiver, final String methodName, boolean bound, Visibility visibility, boolean respondToMissing) {
         return newMethod(getCurrentContext(), receiver, methodName, null, bound, visibility, respondToMissing, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject newMethod(IRubyObject receiver, final String methodName, StaticScope scope, boolean bound, Visibility visibility, boolean respondToMissing) {
         return newMethod(getCurrentContext(), receiver, methodName, scope, bound, visibility, respondToMissing, true);
     }
@@ -2897,13 +2897,13 @@ public class RubyModule extends RubyObject {
 
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject newMethod(IRubyObject receiver, final String methodName, boolean bound, Visibility visibility,
                                  boolean respondToMissing, boolean priv) {
         return newMethod(getCurrentContext(), receiver, methodName, null, bound, visibility, respondToMissing, priv);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject newMethod(IRubyObject receiver, final String methodName, StaticScope scope, boolean bound,
                                  Visibility visibility, boolean respondToMissing, boolean priv) {
         return newMethod(getCurrentContext(), receiver, methodName, scope, bound, visibility, respondToMissing, priv);
@@ -3014,7 +3014,7 @@ public class RubyModule extends RubyObject {
         return name;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.1.2")
     public IRubyObject define_method(ThreadContext context, IRubyObject[] args, Block block) {
         return switch (args.length) {
             case 1 -> define_method(context, args[0], block);
@@ -3041,7 +3041,7 @@ public class RubyModule extends RubyObject {
         return new ProcMethod(this, proc, visibility, name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject name() {
         return name(getCurrentContext());
     }
@@ -3051,7 +3051,7 @@ public class RubyModule extends RubyObject {
         return getBaseName() == null ? context.nil : rubyName(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final IRubyObject cloneMethods(RubyModule clone) {
         return cloneMethods(getCurrentContext(), clone);
     }
@@ -3150,7 +3150,7 @@ public class RubyModule extends RubyObject {
         return newArray(context, getAncestorList());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray ancestors() {
         return ancestors(getCurrentContext());
     }
@@ -3308,7 +3308,7 @@ public class RubyModule extends RubyObject {
         return super.freeze(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_le(IRubyObject arg) {
         return op_le(getCurrentContext(), arg);
     }
@@ -3339,7 +3339,7 @@ public class RubyModule extends RubyObject {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_lt(IRubyObject obj) {
         return op_lt(getCurrentContext(), obj);
     }
@@ -3352,7 +3352,7 @@ public class RubyModule extends RubyObject {
         return obj == this ? context.fals : op_le(context, obj);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_ge(IRubyObject obj) {
         return op_ge(getCurrentContext(), obj);
     }
@@ -3365,7 +3365,7 @@ public class RubyModule extends RubyObject {
         return castAsModule(context, obj, "compared with non class/module").op_le(context, this);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_gt(IRubyObject obj) {
         return op_gt(getCurrentContext(), obj);
     }
@@ -3394,7 +3394,7 @@ public class RubyModule extends RubyObject {
         return context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_cmp(IRubyObject obj) {
         return op_cmp(getCurrentContext(), obj);
     }
@@ -3498,7 +3498,7 @@ public class RubyModule extends RubyObject {
         return attr_reader(context, args);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public IRubyObject attr_reader(IRubyObject[] args) {
         return attr_reader(getCurrentContext(), args);
     }
@@ -3543,7 +3543,7 @@ public class RubyModule extends RubyObject {
     }
 
 
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public IRubyObject attr_accessor(IRubyObject[] args) {
         return attr_accessor(getCurrentContext(), args);
     }
@@ -3585,13 +3585,13 @@ public class RubyModule extends RubyObject {
      * @param not if true only find methods not matching supplied visibility
      * @return a RubyArray of instance method names
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     private RubyArray instance_methods(IRubyObject[] args, Visibility visibility, boolean not) {
         boolean includeSuper = args.length > 0 ? args[0].isTrue() : true;
         return instanceMethods(getCurrentContext(), visibility, includeSuper, true, not);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray instanceMethods(IRubyObject[] args, Visibility visibility, boolean obj, boolean not) {
         return instanceMethods(getCurrentContext(), args, visibility, obj, not);
     }
@@ -3601,7 +3601,7 @@ public class RubyModule extends RubyObject {
         return instanceMethods(context, visibility, includeSuper, obj, not);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray instanceMethods(Visibility visibility, boolean includeSuper, boolean obj, boolean not) {
         return instanceMethods(getCurrentContext(), visibility, includeSuper, obj, not);
     }
@@ -3634,7 +3634,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void addMethodSymbols(Ruby runtime, Set<String> seen, RubyArray ary, boolean not, Visibility visibility) {
         addMethodSymbols(getCurrentContext(), seen, ary, not, visibility);
     }
@@ -3652,12 +3652,12 @@ public class RubyModule extends RubyObject {
         });
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyArray<?> instance_methods19(IRubyObject[] args) {
         return instance_methods(args);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyArray<?> instance_methods(IRubyObject[] args) {
         return instance_methods(getCurrentContext(), args);
     }
@@ -3669,12 +3669,12 @@ public class RubyModule extends RubyObject {
         return instanceMethods(context, args, PRIVATE, false, true);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyArray<?> public_instance_methods19(IRubyObject[] args) {
         return public_instance_methods(args);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyArray<?> public_instance_methods(IRubyObject[] args) {
         return public_instance_methods(getCurrentContext(), args);
     }
@@ -3692,12 +3692,12 @@ public class RubyModule extends RubyObject {
                 false, null, false, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject instance_method(IRubyObject symbol) {
         return instance_method(getCurrentContext(), symbol);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject public_instance_method(IRubyObject symbol) {
         return public_instance_method(getCurrentContext(), symbol);
     }
@@ -3707,7 +3707,7 @@ public class RubyModule extends RubyObject {
         return newMethod(context, null, checkID(context, symbol).idString(), null, false, PUBLIC, false, true);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyArray protected_instance_methods(IRubyObject[] args) {
         return protected_instance_methods(getCurrentContext(), args);
     }
@@ -3722,7 +3722,7 @@ public class RubyModule extends RubyObject {
         return instanceMethods(context, args, PROTECTED, false, false);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyArray private_instance_methods(IRubyObject[] args) {
         return private_instance_methods(getCurrentContext(), args);
     }
@@ -3749,7 +3749,7 @@ public class RubyModule extends RubyObject {
         return list;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule prepend_features(IRubyObject include) {
         return prepend_features(getCurrentContext(), include);
     }
@@ -3764,7 +3764,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule append_features(IRubyObject include) {
         return append_features(getCurrentContext(), include);
     }
@@ -3791,7 +3791,7 @@ public class RubyModule extends RubyObject {
     }
 
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject extend_object(IRubyObject obj) {
         return extend_object(getCurrentContext(), obj);
     }
@@ -3807,7 +3807,7 @@ public class RubyModule extends RubyObject {
         return obj;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyModule include(IRubyObject[] modules) {
         return include(getCurrentContext(), modules);
     }
@@ -3933,7 +3933,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject rbPublic(ThreadContext context, IRubyObject[] args) {
         _public(context, args);
         return this;
@@ -3954,7 +3954,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject rbProtected(ThreadContext context, IRubyObject[] args) {
         _protected(context, args);
         return this;
@@ -3975,7 +3975,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject rbPrivate(ThreadContext context, IRubyObject[] args) {
         _private(context, args);
         return this;
@@ -4104,7 +4104,7 @@ public class RubyModule extends RubyObject {
         return method.getVisibility();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule public_class_method(IRubyObject[] args) {
         return public_class_method(getCurrentContext(), args);
     }
@@ -4116,7 +4116,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule private_class_method(IRubyObject[] args) {
         return private_class_method(getCurrentContext(), args);
     }
@@ -4250,7 +4250,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(RubyModule module, org.jruby.runtime.marshal.MarshalStream output) throws java.io.IOException {
         var context = module.getRuntime().getCurrentContext();
@@ -4263,7 +4263,7 @@ public class RubyModule extends RubyObject {
         output.writeString(out, MarshalDumper.getPathFromClass(context, module).idString());
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyModule unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         String name = RubyString.byteListToString(input.unmarshalString());
@@ -4508,12 +4508,12 @@ public class RubyModule extends RubyObject {
         return context.fals;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject class_variable_get19(IRubyObject name) {
         return class_variable_get(name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject class_variable_get(IRubyObject name) {
         return class_variable_get(getCurrentContext(), name);
     }
@@ -4526,7 +4526,7 @@ public class RubyModule extends RubyObject {
         return getClassVar(context, name, validateClassVariable(context, name));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject class_variable_set(IRubyObject name, IRubyObject value) {
         return class_variable_set(getCurrentContext(), name, value);
     }
@@ -4539,7 +4539,7 @@ public class RubyModule extends RubyObject {
         return setClassVar(context, validateClassVariable(context, name), value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject class_variable_set19(IRubyObject name, IRubyObject value) {
         return class_variable_set(name, value);
     }
@@ -4552,7 +4552,7 @@ public class RubyModule extends RubyObject {
         return removeClassVariable(context, validateClassVariable(context, name));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject remove_class_variable19(ThreadContext context, IRubyObject name) {
         return remove_class_variable(context, name);
     }
@@ -4806,7 +4806,7 @@ public class RubyModule extends RubyObject {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject const_set(IRubyObject name, IRubyObject value) {
         return const_set(getCurrentContext(), name, value);
     }
@@ -4924,7 +4924,7 @@ public class RubyModule extends RubyObject {
         return constantNames;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void deprecateConstant(Ruby runtime, String name) {
         deprecateConstant(runtime.getCurrentContext(), name);
     }
@@ -5031,7 +5031,7 @@ public class RubyModule extends RubyObject {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final void setConstantVisibility(Ruby runtime, String name, boolean hidden) {
         setConstantVisibility(runtime.getCurrentContext(), name, hidden);
     }
@@ -5061,7 +5061,7 @@ public class RubyModule extends RubyObject {
         return refinementModules;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject refined_class(ThreadContext context) {
         return getRefinedClassOrThrow(context, false);
     }
@@ -5090,7 +5090,7 @@ public class RubyModule extends RubyObject {
     ////////////////// CLASS VARIABLE API METHODS ////////////////
     //
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setClassVar(String name, IRubyObject value) {
         return setClassVar(getCurrentContext(), name, value);
     }
@@ -5115,12 +5115,12 @@ public class RubyModule extends RubyObject {
         return highest.storeClassVariable(context, name, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastSetClassVar(final String internedName, final IRubyObject value) {
         return setClassVar(getCurrentContext(), internedName, value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getClassVar(String name) {
         return getClassVar(getCurrentContext(), name);
     }
@@ -5141,7 +5141,7 @@ public class RubyModule extends RubyObject {
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getClassVar(IRubyObject nameObject, String name) {
         return getClassVar(getCurrentContext(), nameObject, name);
     }
@@ -5156,7 +5156,7 @@ public class RubyModule extends RubyObject {
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getClassVarQuiet(String name) {
         return getClassVarQuiet(getCurrentContext(), name);
     }
@@ -5191,7 +5191,7 @@ public class RubyModule extends RubyObject {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastGetClassVar(String internedName) {
         return getClassVar(getCurrentContext(), internedName);
     }
@@ -5214,12 +5214,12 @@ public class RubyModule extends RubyObject {
         return false;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public boolean fastIsClassVarDefined(String internedName) {
         return isClassVarDefined(internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject removeClassVariable(String name) {
         return removeClassVariable(getCurrentContext(), name);
     }
@@ -5239,7 +5239,7 @@ public class RubyModule extends RubyObject {
     ////////////////// CONSTANT API METHODS ////////////////
     //
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantAtSpecial(String name) {
         return getConstantAtSpecial(getCurrentContext(), name);
     }
@@ -5259,7 +5259,7 @@ public class RubyModule extends RubyObject {
         return value == UNDEF ? resolveUndefConstant(context, name) : value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantAt(String name) {
         return getConstantAt(getCurrentContext(), name);
     }
@@ -5268,7 +5268,7 @@ public class RubyModule extends RubyObject {
         return getConstantAt(context, name, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantAt(String name, boolean includePrivate) {
         return getConstantAt(getCurrentContext(), name, includePrivate);
     }
@@ -5279,12 +5279,12 @@ public class RubyModule extends RubyObject {
         return value == UNDEF ? resolveUndefConstant(context, name) : value;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastGetConstantAt(String internedName) {
         return getConstantAt(getCurrentContext(), internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstant(String name) {
         return getConstant(getCurrentContext(), name);
     }
@@ -5299,7 +5299,7 @@ public class RubyModule extends RubyObject {
         return getConstant(context, name, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstant(String name, boolean inherit) {
         return getConstant(getCurrentContext(), name, inherit);
     }
@@ -5308,7 +5308,7 @@ public class RubyModule extends RubyObject {
         return getConstant(context, name, inherit, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public SourceLocation getConstantSourceLocation(String name, boolean inherit, boolean includeObject) {
         return getConstantSourceLocation(getCurrentContext(), name, inherit, includeObject);
     }
@@ -5324,7 +5324,7 @@ public class RubyModule extends RubyObject {
         return location;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstant(String name, boolean inherit, boolean includeObject) {
         return getConstant(getCurrentContext(), name, inherit, includeObject);
     }
@@ -5339,17 +5339,17 @@ public class RubyModule extends RubyObject {
         return value != null ? value : callMethod(context, "const_missing", asSymbol(context, name));
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastGetConstant(String internedName) {
         return getConstant(getCurrentContext(), internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastGetConstant(String internedName, boolean inherit) {
         return getConstant(getCurrentContext(), internedName, inherit);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantNoConstMissing(String name) {
         return getConstantNoConstMissing(getCurrentContext(), name);
     }
@@ -5358,7 +5358,7 @@ public class RubyModule extends RubyObject {
         return getConstantNoConstMissing(context, name, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantNoConstMissing(String name, boolean inherit) {
         return getConstantNoConstMissing(getCurrentContext(), name, inherit);
     }
@@ -5367,7 +5367,7 @@ public class RubyModule extends RubyObject {
         return getConstantNoConstMissing(context, name, inherit, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantNoConstMissing(String name, boolean inherit, boolean includeObject) {
         return getConstantNoConstMissing(getCurrentContext(), name, inherit, includeObject);
     }
@@ -5382,7 +5382,7 @@ public class RubyModule extends RubyObject {
         return constant;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject getConstantNoConstMissingSkipAutoload(String name) {
         return getConstantNoConstMissingSkipAutoload(getCurrentContext(), name);
     }
@@ -5391,7 +5391,7 @@ public class RubyModule extends RubyObject {
         return getConstantSkipAutoload(context, name, true, true, true);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public IRubyObject getConstantNoConstMissingSKipAutoload(String name) {
         return getConstantSkipAutoload(getCurrentContext(), name, true, true, true);
     }
@@ -5444,7 +5444,7 @@ public class RubyModule extends RubyObject {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantFrom(String name) {
         return getConstantFrom(getCurrentContext(), name);
     }
@@ -5456,7 +5456,7 @@ public class RubyModule extends RubyObject {
         return value != null ? value : getConstantFromConstMissing(context, name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantWithAutoload(String name, IRubyObject failedAutoloadValue, boolean includePrivate) {
         return getConstantWithAutoload(getCurrentContext(), name, failedAutoloadValue, includePrivate);
     }
@@ -5492,12 +5492,12 @@ public class RubyModule extends RubyObject {
         return autoloadModule != null ? failedAutoloadValue : null;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastGetConstantFrom(String internedName) {
         return getConstantFrom(getCurrentContext(), internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantFromNoConstMissing(String name) {
         return getConstantFromNoConstMissing(getCurrentContext(), name);
     }
@@ -5506,7 +5506,7 @@ public class RubyModule extends RubyObject {
         return getConstantFromNoConstMissing(context, name, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantFromNoConstMissing(String name, boolean includePrivate) {
         return getConstantFromNoConstMissing(getCurrentContext(), name, includePrivate);
     }
@@ -5529,12 +5529,12 @@ public class RubyModule extends RubyObject {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastGetConstantFromNoConstMissing(String internedName) {
         return getConstantFromNoConstMissing(getCurrentContext(), internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantFromConstMissing(String name) {
         return getConstantFromConstMissing(getCurrentContext(), name);
     }
@@ -5543,12 +5543,12 @@ public class RubyModule extends RubyObject {
         return callMethod(context, "const_missing", context.runtime.fastNewSymbol(name));
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastGetConstantFromConstMissing(String internedName) {
         return getConstantFromConstMissing(getCurrentContext(), internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject resolveUndefConstant(String name) {
         return resolveUndefConstant(getCurrentContext(), name);
     }
@@ -5557,7 +5557,7 @@ public class RubyModule extends RubyObject {
         return getAutoloadConstant(context, name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setConstantQuiet(String name, IRubyObject value) {
         return setConstantQuiet(getCurrentContext(), name, value);
     }
@@ -5575,7 +5575,7 @@ public class RubyModule extends RubyObject {
         return setConstantCommon(context, name, value, null, false, null, -1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setConstant(String name, IRubyObject value) {
         return setConstant(getCurrentContext(), name, value);
     }
@@ -5592,7 +5592,7 @@ public class RubyModule extends RubyObject {
         return setConstantCommon(context, name, value, null, true, null, -1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setConstant(String name, IRubyObject value, String file, int line) {
         return setConstant(getCurrentContext(), name, value, file, line);
     }
@@ -5601,7 +5601,7 @@ public class RubyModule extends RubyObject {
         return setConstantCommon(context, name, value, null, true, file, line);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setConstant(String name, IRubyObject value, boolean hidden) {
         return setConstant(getCurrentContext(), name, value, hidden);
     }
@@ -5747,7 +5747,7 @@ public class RubyModule extends RubyObject {
      *
      */
     @Extension
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void defineConstant(String name, IRubyObject value) {
         var context = getCurrentContext();
         assert value != null;
@@ -5757,12 +5757,12 @@ public class RubyModule extends RubyObject {
         setConstant(context, name, value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isConstantDefined(String name, boolean inherit) {
         return constDefinedInner(getCurrentContext(), name, false, inherit, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean constDefined(String name) {
         return constDefined(getCurrentContext(), name);
     }
@@ -5772,7 +5772,7 @@ public class RubyModule extends RubyObject {
         return constDefinedInner(context, name, false, true, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean constDefinedAt(String name) {
         return constDefinedAt(getCurrentContext(), name);
     }
@@ -5782,7 +5782,7 @@ public class RubyModule extends RubyObject {
         return constDefinedInner(context, name, true, false, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean constDefinedFrom(String name) {
         return constDefinedFrom(getCurrentContext(), name);
     }
@@ -5792,7 +5792,7 @@ public class RubyModule extends RubyObject {
         return constDefinedInner(context, name, true, true, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean publicConstDefinedFrom(String name) {
         return publicConstDefinedFrom(getCurrentContext(), name);
     }
@@ -5844,7 +5844,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean autoloadingValue(Ruby runtime, String name) {
         return autoloadingValue(runtime.getCurrentContext(), name);
     }
@@ -5882,7 +5882,7 @@ public class RubyModule extends RubyObject {
         return null; // autoload has yet to run
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isConstantDefined(String name) {
         return isConstantDefined(getCurrentContext(), name);
     }
@@ -5999,7 +5999,7 @@ public class RubyModule extends RubyObject {
         return getClassVariablesForRead().containsKey(name);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public boolean fastHasClassVariable(String internedName) {
         return hasClassVariable(internedName);
     }
@@ -6010,12 +6010,12 @@ public class RubyModule extends RubyObject {
         return getClassVariablesForRead().get(name);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastFetchClassVariable(String internedName) {
         return fetchClassVariable(internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject storeClassVariable(String name, IRubyObject value) {
         return storeClassVariable(getCurrentContext(), name, value);
     }
@@ -6027,12 +6027,12 @@ public class RubyModule extends RubyObject {
         return value;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastStoreClassVariable(String internedName, IRubyObject value) {
         return storeClassVariable(getCurrentContext(), internedName, value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject deleteClassVariable(String name) {
         return deleteClassVariable(getCurrentContext(), name);
     }
@@ -6047,7 +6047,7 @@ public class RubyModule extends RubyObject {
         return new ArrayList<String>(getClassVariablesForRead().keySet());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final String validateClassVariable(String name) {
         return validateClassVariable(getCurrentContext(), name);
     }
@@ -6058,14 +6058,14 @@ public class RubyModule extends RubyObject {
         throw context.runtime.newNameError("'%1$s' is not allowed as a class variable name", this, name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final String validateClassVariable(IRubyObject nameObj, String name) {
         if (IdUtil.isValidClassVariableName(name)) return name;
 
         throw getCurrentContext().runtime.newNameError("'%1$s' is not allowed as a class variable name", this, nameObj);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected String validateClassVariable(Ruby runtime, IRubyObject object) {
         return validateClassVariable(runtime.getCurrentContext(), object);
     }
@@ -6080,7 +6080,7 @@ public class RubyModule extends RubyObject {
         return name.idString();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final void ensureClassVariablesSettable() {
         checkAndRaiseIfFrozen(getCurrentContext());
     }
@@ -6097,12 +6097,12 @@ public class RubyModule extends RubyObject {
         return constantTableContains(name);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public boolean fastHasConstant(String internedName) {
         return hasConstant(internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject fetchConstant(String name) {
         return fetchConstant(getCurrentContext(), name);
     }
@@ -6112,7 +6112,7 @@ public class RubyModule extends RubyObject {
         return fetchConstant(context, name, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject fetchConstant(String name, boolean includePrivate) {
         return fetchConstant(getCurrentContext(), name, includePrivate);
     }
@@ -6123,7 +6123,7 @@ public class RubyModule extends RubyObject {
         return entry != null ? entry.value : null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public ConstantEntry fetchConstantEntry(String name, boolean includePrivate) {
         return fetchConstantEntry(getCurrentContext(), name, includePrivate);
     }
@@ -6152,12 +6152,12 @@ public class RubyModule extends RubyObject {
         return entry;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastFetchConstant(String internedName) {
         return fetchConstant(getCurrentContext(), internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject storeConstant(String name, IRubyObject value) {
         return storeConstant(getCurrentContext(), name, value);
     }
@@ -6169,7 +6169,7 @@ public class RubyModule extends RubyObject {
         return constantTableStore(name, value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject storeConstant(String name, IRubyObject value, boolean hidden, String file, int line) {
         return storeConstant(getCurrentContext(), name, value, hidden, file, line);
     }
@@ -6186,7 +6186,7 @@ public class RubyModule extends RubyObject {
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject storeConstant(String name, IRubyObject value, boolean hidden) {
         assert value != null : "value is null";
 
@@ -6201,12 +6201,12 @@ public class RubyModule extends RubyObject {
         return constantTableStore(name, value, hidden, deprecated);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject fastStoreConstant(String internedName, IRubyObject value) {
         return storeConstant(getCurrentContext(), internedName, value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject deleteConstant(String name) {
         return deleteConstant(getCurrentContext(), name);
     }
@@ -6219,12 +6219,12 @@ public class RubyModule extends RubyObject {
         return constantTableRemove(name);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public List<Variable<IRubyObject>> getStoredConstantList() {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public List<String> getStoredConstantNameList() {
         return new ArrayList<>(getConstantMap().keySet());
     }
@@ -6252,7 +6252,7 @@ public class RubyModule extends RubyObject {
         return publicNames;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final String validateConstant(IRubyObject name) {
         return validateConstant(getCurrentContext(), name);
     }
@@ -6270,7 +6270,7 @@ public class RubyModule extends RubyObject {
         }).idString();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final String validateConstant(String name, IRubyObject errorName) {
         return validateConstant(getCurrentContext(), name, errorName);
     }
@@ -6289,7 +6289,7 @@ public class RubyModule extends RubyObject {
         }).idString();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final void ensureConstantsSettable() {
         checkAndRaiseIfFrozen(getCurrentContext());
     }
@@ -6387,7 +6387,7 @@ public class RubyModule extends RubyObject {
         return entry.value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final void defineAutoload(String symbol, RubyString path) {
         defineAutoload(getCurrentContext(), symbol, path);
     }
@@ -6404,7 +6404,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final IRubyObject finishAutoload(String name) {
         return finishAutoload(getCurrentContext(), name);
     }
@@ -6427,7 +6427,7 @@ public class RubyModule extends RubyObject {
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject getAutoloadConstant(String name) {
         return getAutoloadConstant(getCurrentContext(), name);
     }
@@ -6441,7 +6441,7 @@ public class RubyModule extends RubyObject {
         return getAutoloadConstant(context, name, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected IRubyObject getAutoloadConstant(String name, boolean loadConstant) {
         return getAutoloadConstant(getCurrentContext(), name, loadConstant);
     }
@@ -6537,7 +6537,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject initialize(Block block) {
         return initialize(getCurrentContext());
     }
@@ -6622,7 +6622,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public interface AutoloadMethod {
         void load(Ruby runtime);
         RubyString getFile();
@@ -6924,10 +6924,10 @@ public class RubyModule extends RubyObject {
      * @see ClassIndex
      * @deprecated use RubyModule#getClassIndex()
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public int index;
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static final Set<String> SCOPE_CAPTURING_METHODS = new HashSet<String>(Arrays.asList(
             "eval",
             "module_eval",
@@ -6940,25 +6940,25 @@ public class RubyModule extends RubyObject {
             "local_variables"
     ));
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public boolean fastIsConstantDefined(String internedName){
         return isConstantDefined(getCurrentContext(), internedName);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static class ModuleKernelMethods {
-        @Deprecated
+        @Deprecated(since = "9.3.0.0")
         public static IRubyObject autoload(ThreadContext context, IRubyObject self, IRubyObject symbol, IRubyObject file) {
             return ((RubyModule) self).autoload(context, symbol, file);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.3.0.0")
         public static IRubyObject autoload_p(ThreadContext context, IRubyObject self, IRubyObject symbol) {
             return ((RubyModule) self).autoload_p(context, symbol);
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.1.0")
     public synchronized void defineAliases(List<String> aliases, String oldId) {
         var context = getCurrentContext();
         testFrozen("module");
@@ -7036,12 +7036,12 @@ public class RubyModule extends RubyObject {
         return context.sites.Module;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject const_get(IRubyObject symbol) {
         return const_get(getCurrentContext(), symbol);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject const_get(ThreadContext context, IRubyObject... args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -7051,12 +7051,12 @@ public class RubyModule extends RubyObject {
         return constGetCommon(context, symbol, inherit);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject const_get_1_9(ThreadContext context, IRubyObject[] args) {
         return const_get(context, args);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject const_get_2_0(ThreadContext context, IRubyObject[] args) {
         return const_get(context, args);
     }

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -197,7 +197,7 @@ public class RubyNil extends RubyObject implements Constantizable {
         return context.tru;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public IRubyObject nil_p() {
         return nil_p(getCurrentContext());
     }
@@ -264,12 +264,12 @@ public class RubyNil extends RubyObject implements Constantizable {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     public IRubyObject taint(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final ObjectAllocator NIL_ALLOCATOR = NOT_ALLOCATABLE_ALLOCATOR;
 }

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -116,7 +116,7 @@ public class RubyNumeric extends RubyObject {
         super(runtime, metaClass, useObjectSpace);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public RubyNumeric(Ruby runtime, RubyClass metaClass, boolean useObjectSpace, boolean canBeTainted) {
         super(runtime, metaClass, useObjectSpace, canBeTainted);
     }
@@ -152,7 +152,7 @@ public class RubyNumeric extends RubyObject {
      * fit in 64 bits, it will be truncated.
      * @deprecated Use {@link org.jruby.RubyNumeric#asLong(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public long getLongValue() {
         return asLong(getCurrentContext());
     }
@@ -162,7 +162,7 @@ public class RubyNumeric extends RubyObject {
      * fit in 32 bits, it will be truncated.
      * @deprecated Use {@link org.jruby.RubyNumeric#asInt(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public int getIntValue() { return asInt(getRuntime().getCurrentContext()); }
 
 
@@ -208,12 +208,12 @@ public class RubyNumeric extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.RubyNumeric#asDouble(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public double getDoubleValue() {
         return asDouble(getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public BigInteger getBigIntegerValue() {
         return asBigInteger(getCurrentContext());
     }
@@ -230,7 +230,7 @@ public class RubyNumeric extends RubyObject {
     /** rb_num2int, NUM2INT
      * if you know it is Integer use {@link org.jruby.api.Convert#toInt(ThreadContext, IRubyObject)}.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int num2int(IRubyObject arg) {
         long num = num2long(arg);
 
@@ -265,7 +265,7 @@ public class RubyNumeric extends RubyObject {
     /**
      * NUM2CHR
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static byte num2chr(IRubyObject arg) {
         if (arg instanceof RubyString) {
             if (((RubyString) arg).size() > 0) {
@@ -283,7 +283,7 @@ public class RubyNumeric extends RubyObject {
         return arg instanceof RubyFixnum ? ((RubyFixnum) arg).value : other2long(arg);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     private static long other2long(IRubyObject arg) throws RaiseException {
         if (arg instanceof RubyFloat flote) return float2long(flote);
         if (arg instanceof RubyBignum bignum) return RubyBignum.big2long(bignum);
@@ -294,7 +294,7 @@ public class RubyNumeric extends RubyObject {
         return ((RubyInteger) TypeConverter.convertToType(arg, integerClass(context), "to_int")).asLong(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static long float2long(RubyFloat flt) {
         final double aFloat = flt.value;
         if (aFloat <= (double) Long.MAX_VALUE && aFloat >= (double) Long.MIN_VALUE) {
@@ -354,7 +354,7 @@ public class RubyNumeric extends RubyObject {
     /**
      * @deprecated Use {@link org.jruby.api.Convert#asFloat(ThreadContext, long)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject dbl2num(Ruby runtime, double val) {
         return RubyFloat.newFloat(runtime, val);
     }
@@ -363,7 +363,7 @@ public class RubyNumeric extends RubyObject {
      *
      * @deprecated Use {@link org.jruby.api.Convert#asInteger(ThreadContext, double)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyInteger dbl2ival(Ruby runtime, double val) {
         return asInteger(runtime.getCurrentContext(), val);
     }
@@ -371,7 +371,7 @@ public class RubyNumeric extends RubyObject {
     /**
      * @deprecated Use {@link org.jruby.api.Convert#toDouble(ThreadContext, IRubyObject)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static double num2dbl(IRubyObject arg) {
         return toDouble(arg.getRuntime().getCurrentContext(), arg);
     }
@@ -379,7 +379,7 @@ public class RubyNumeric extends RubyObject {
     /** rb_num2dbl and NUM2DBL
      * @deprecated Use {@link org.jruby.api.Convert#toDouble(ThreadContext, IRubyObject)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static double num2dbl(ThreadContext context, IRubyObject arg) {
         return toDouble(context, arg);
     }
@@ -397,26 +397,26 @@ public class RubyNumeric extends RubyObject {
      * @return
      * @deprecated Use {@link RubyFixnum#getValue()}
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static long fix2long(IRubyObject arg) {
         return ((RubyFixnum) arg).value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int fix2int(IRubyObject arg) {
         long num = arg instanceof RubyFixnum fixnum ? fixnum.getValue() : num2long(arg);
         checkInt(arg, num);
         return (int) num;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int fix2int(RubyFixnum arg) {
         long num = arg.value;
         checkInt(arg, num);
         return (int) num;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyInteger str2inum(Ruby runtime, RubyString str, int base) {
         return (RubyInteger) str2inum(runtime, str, base, false, true);
     }
@@ -427,17 +427,17 @@ public class RubyNumeric extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.api.Convert#asFixnum(ThreadContext, long)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyNumeric int2fix(Ruby runtime, long val) {
         return RubyFixnum.newFixnum(runtime, val);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject num2fix(IRubyObject val) {
         return num2fix(((RubyBasicObject) val).getCurrentContext(), val);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     // mri: rb_num2fix (appears unused in current MRI source)
     public static IRubyObject num2fix(ThreadContext context, IRubyObject val) {
         return switch(val) {
@@ -485,7 +485,7 @@ public class RubyNumeric extends RubyObject {
         return ConvertBytes.byteListToInum(runtime, s, base, strict, exception);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyInteger str2inum(Ruby runtime, RubyString str, int base, boolean strict) {
         return (RubyInteger) str2inum(runtime, str, base, strict, true);
     }
@@ -628,7 +628,7 @@ public class RubyNumeric extends RubyObject {
     /** rb_num_coerce_bin
      *  coercion taking two arguments
      */
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     protected final IRubyObject coerceBin(ThreadContext context, String method, IRubyObject other) {
         RubyArray ary = doCoerce(context, other, true);
         return (ary.eltInternal(0)).callMethod(context, method, ary.eltInternal(1));
@@ -770,7 +770,7 @@ public class RubyNumeric extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.RubyNumeric#coerce(ThreadContext, IRubyObject)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject coerce(IRubyObject other) {
         return coerce(getCurrentContext(), other);
     }
@@ -785,7 +785,7 @@ public class RubyNumeric extends RubyObject {
                 newArray(context, RubyKernel.new_float(context, other), RubyKernel.new_float(context, this));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_uplus() {
         return op_uplus(getCurrentContext());
     }
@@ -1010,12 +1010,12 @@ public class RubyNumeric extends RubyObject {
 
     public boolean isReal() { return true; } // only RubyComplex isn't real
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject scalar_p() {
         return asBoolean(getCurrentContext(), isReal());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject integer_p() {
         return integer_p(getCurrentContext());
     }
@@ -1040,7 +1040,7 @@ public class RubyNumeric extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.RubyNumeric#isZero(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isZero() {
         return isZero(getCurrentContext());
     }
@@ -1464,7 +1464,7 @@ public class RubyNumeric extends RubyObject {
         return sites(context).denominator.call(context, rational, rational);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyRational convertToRational() {
         return convertToRational(getCurrentContext());
     }
@@ -1598,7 +1598,7 @@ public class RubyNumeric extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.RubyNumeric#isNegativeNumber(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isNegative() {
         return isNegativeNumber(getCurrentContext());
     }
@@ -1611,7 +1611,7 @@ public class RubyNumeric extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.RubyNumeric#isPositiveNumber(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isPositive() {
         return isPositiveNumber(getCurrentContext());
     }
@@ -1637,7 +1637,7 @@ public class RubyNumeric extends RubyObject {
         return context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.5.0")
     public final IRubyObject rbClone(IRubyObject[] args) {
         ThreadContext context = metaClass.runtime.getCurrentContext();
         switch (args.length) {
@@ -1740,17 +1740,17 @@ public class RubyNumeric extends RubyObject {
         return l >= RubyFixnum.MIN;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject floor() {
         return floor(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject ceil() {
         return ceil(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject round() {
         return round(getCurrentContext());
     }
@@ -1758,7 +1758,7 @@ public class RubyNumeric extends RubyObject {
     /** num_truncate
      *
      */
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject truncate() {
         return truncate(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -109,7 +109,7 @@ public class RubyObject extends RubyBasicObject {
         super(metaClass);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     protected RubyObject(Ruby runtime, RubyClass metaClass, boolean useObjectSpace, boolean canBeTainted) {
         super(runtime, metaClass, useObjectSpace, canBeTainted);
     }
@@ -226,7 +226,7 @@ public class RubyObject extends RubyBasicObject {
      * @deprecated no longer used - uses Java's System.out
      * @param obj to puts
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void puts(Object obj) {
         System.out.println(obj.toString());
     }
@@ -336,7 +336,7 @@ public class RubyObject extends RubyBasicObject {
      * Tries to convert this object to the specified Ruby type, using
      * a specific conversion method.
      */
-    @Deprecated
+    @Deprecated(since = "1.1.6")
     public final IRubyObject convertToType(RubyClass target, int convertMethodIndex) {
         throw new RuntimeException("Not supported; use the String versions");
     }
@@ -351,7 +351,7 @@ public class RubyObject extends RubyBasicObject {
      * arguments in the args-array is optional, but can contain the
      * filename and line of the string under evaluation.
      */
-    @Deprecated
+    @Deprecated(since = "1.1.2")
     public IRubyObject specificEval(ThreadContext context, RubyModule mod, IRubyObject[] args, Block block, EvalType evalType) {
         if (block.isGiven()) {
             if (args.length > 0) throw argumentError(context, args.length, 0);

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -83,7 +83,7 @@ public class RubyObjectSpace {
         return ObjectSpace;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject define_finalizer(IRubyObject recv, IRubyObject[] args, Block block) {
         return define_finalizer(recv.getRuntime().getCurrentContext(), recv, args, block);
     }
@@ -121,7 +121,7 @@ public class RubyObjectSpace {
         return block.getBinding().getSelf() == object;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject undefine_finalizer(IRubyObject recv, IRubyObject obj, Block block) {
         return undefine_finalizer(((RubyBasicObject) recv).getCurrentContext(), recv, obj, block);
     }
@@ -132,7 +132,7 @@ public class RubyObjectSpace {
         return recv;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject id2ref(IRubyObject recv, IRubyObject id) {
         return id2ref(((RubyBasicObject) recv).getCurrentContext(), recv, id);
     }

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -80,7 +80,7 @@ public class RubyProc extends RubyObject implements DataType {
         this.type = type;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     protected RubyProc(Ruby runtime, RubyClass rubyClass, Block.Type type, ISourcePosition sourcePosition) {
         this(runtime, rubyClass, type, sourcePosition.getFile(), sourcePosition.getLine());
     }
@@ -111,7 +111,7 @@ public class RubyProc extends RubyObject implements DataType {
 
     // Proc class
 
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public static RubyProc newProc(Ruby runtime, Block.Type type) {
         throw runtime.newRuntimeError("deprecated RubyProc.newProc with no block; do not use");
     }
@@ -127,7 +127,7 @@ public class RubyProc extends RubyObject implements DataType {
         return proc;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static RubyProc newProc(Ruby runtime, Block block, Block.Type type, ISourcePosition sourcePosition) {
         RubyProc proc = new RubyProc(runtime, runtime.getProc(), type, sourcePosition);
         proc.setup(runtime, block);
@@ -300,7 +300,7 @@ public class RubyProc extends RubyObject implements DataType {
      *
      * Note: nothing should be calling this any more.
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject[] prepareArgs(ThreadContext context, Block.Type type, BlockBody blockBody, IRubyObject[] args) {
         if (type == Block.Type.LAMBDA) return args;
 
@@ -380,7 +380,7 @@ public class RubyProc extends RubyObject implements DataType {
         return newBlock.call(context, args, passedBlock);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum arity() {
         return arity(getCurrentContext());
     }
@@ -472,17 +472,17 @@ public class RubyProc extends RubyObject implements DataType {
         return context.sites.Proc;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public final IRubyObject call(ThreadContext context, IRubyObject[] args, IRubyObject self, Block passedBlock) {
         return block.call(context, args, passedBlock);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rbClone() {
         return rbClone(getRuntime().getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject dup() {
         return dup(getRuntime().getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -165,7 +165,7 @@ public class RubyProcess {
 
     private static final ObjectMarshal PROCESS_STATUS_MARSHAL = new ObjectMarshal() {
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type,
                               org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
@@ -196,7 +196,7 @@ public class RubyProcess {
         }
 
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             var context = runtime.getCurrentContext();
@@ -290,7 +290,7 @@ public class RubyProcess {
             return asBoolean(context, PosixShim.WAIT_MACROS.WIFSTOPPED(status));
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject stopped_p() {
             return stopped_p(getCurrentContext());
         }
@@ -300,7 +300,7 @@ public class RubyProcess {
             return asBoolean(context, PosixShim.WAIT_MACROS.WIFSIGNALED(status));
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject signaled() {
             return signaled(getCurrentContext());
         }
@@ -310,12 +310,12 @@ public class RubyProcess {
             return asBoolean(context, PosixShim.WAIT_MACROS.WIFEXITED(status));
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject exited() {
             return exited(getCurrentContext());
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject stopsig() {
             return stopsig(getCurrentContext());
         }
@@ -326,7 +326,7 @@ public class RubyProcess {
                     asFixnum(context, PosixShim.WAIT_MACROS.WSTOPSIG(status)) : context.nil;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject termsig() {
             return termsig(getCurrentContext());
         }
@@ -337,7 +337,7 @@ public class RubyProcess {
                 asFixnum(context, PosixShim.WAIT_MACROS.WTERMSIG(status)) : context.nil;
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject exitstatus() {
             return exitstatus(getCurrentContext());
         }
@@ -394,7 +394,7 @@ public class RubyProcess {
             return asBoolean(context, PosixShim.WAIT_MACROS.WCOREDUMP(status));
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject coredump_p() {
             return coredump_p(getCurrentContext());
         }
@@ -412,7 +412,7 @@ public class RubyProcess {
             return runtime.newFixnum(status);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject to_s(Ruby runtime) {
             return to_s(getCurrentContext());
         }
@@ -427,7 +427,7 @@ public class RubyProcess {
             return pid == PROCESS_STATUS_UNINITIALIZED;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject inspect(Ruby runtime) {
             return inspect(runtime.getCurrentContext());
         }
@@ -463,19 +463,19 @@ public class RubyProcess {
             return sb.toString();
         }
 
-        @Deprecated
+        @Deprecated(since = "9.0.0.0")
         public IRubyObject to_i() {
             return to_i(getCurrentContext().runtime);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.0.0.0")
         public IRubyObject op_rshift(Ruby runtime, IRubyObject other) {
             var context = getCurrentContext();
             long shiftValue = toLong(context, other);
             return asFixnum(context, status >> shiftValue);
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject op_and(IRubyObject arg) {
             return op_and(getCurrentContext(), arg);
         }
@@ -483,7 +483,7 @@ public class RubyProcess {
 
     @JRubyModule(name="Process::UID")
     public static class UserID {
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject change_privilege(IRubyObject self, IRubyObject arg) {
             return change_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
         }
@@ -493,7 +493,7 @@ public class RubyProcess {
             throw notImplementedError(context, "Process::UID::change_privilege not implemented yet");
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject eid(IRubyObject self) {
             return euid(((RubyBasicObject) self).getCurrentContext(), null);
         }
@@ -502,7 +502,7 @@ public class RubyProcess {
             return euid(context, self);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject eid(IRubyObject self, IRubyObject arg) {
             return eid(((RubyBasicObject) self).getCurrentContext(), arg);
         }
@@ -514,7 +514,7 @@ public class RubyProcess {
             return euid_set(runtime, arg);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject grant_privilege(IRubyObject self, IRubyObject arg) {
             return grant_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
         }
@@ -529,7 +529,7 @@ public class RubyProcess {
             return switch_rb(context, self, Block.NULL_BLOCK);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject re_exchangeable_p(IRubyObject self) {
             return re_exchangeable_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -539,7 +539,7 @@ public class RubyProcess {
             throw notImplementedError(context, "Process::UID::re_exchangeable? not implemented yet");
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject rid(IRubyObject self) {
             return rid(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -551,7 +551,7 @@ public class RubyProcess {
             return uid(runtime);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject sid_available_p(IRubyObject self) {
             return sid_available_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -588,7 +588,7 @@ public class RubyProcess {
 
     @JRubyModule(name="Process::GID")
     public static class GroupID {
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject change_privilege(IRubyObject self, IRubyObject arg) {
             return change_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
         }
@@ -598,7 +598,7 @@ public class RubyProcess {
             throw notImplementedError(context, "Process::GID::change_privilege not implemented yet");
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject eid(IRubyObject self) {
             return eid(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -610,7 +610,7 @@ public class RubyProcess {
             return egid(runtime.getCurrentContext(), null);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject eid(IRubyObject self, IRubyObject arg) {
             return eid(((RubyBasicObject) self).getCurrentContext(), arg);
         }
@@ -622,7 +622,7 @@ public class RubyProcess {
             return RubyProcess.egid_set(runtime.getCurrentContext(), arg);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject grant_privilege(IRubyObject self, IRubyObject arg) {
             return grant_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
         }
@@ -637,7 +637,7 @@ public class RubyProcess {
             return switch_rb(context, self, Block.NULL_BLOCK);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject re_exchangeable_p(IRubyObject self) {
             return re_exchangeable_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -647,7 +647,7 @@ public class RubyProcess {
             throw notImplementedError(context, "Process::GID::re_exchangeable? not implemented yet");
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject rid(IRubyObject self) {
             return rid(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -659,7 +659,7 @@ public class RubyProcess {
             return gid(runtime);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject sid_available_p(IRubyObject self) {
             return sid_available_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -696,7 +696,7 @@ public class RubyProcess {
 
     @JRubyModule(name="Process::Sys")
     public static class Sys {
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject getegid(IRubyObject self) {
             return egid(((RubyBasicObject) self).getCurrentContext(), null);
         }
@@ -705,7 +705,7 @@ public class RubyProcess {
             return egid(context, self);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject geteuid(IRubyObject self) {
             return euid(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -714,7 +714,7 @@ public class RubyProcess {
             return euid(context, self);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject getgid(IRubyObject self) {
             return gid(((RubyBasicObject) self).getCurrentContext());
         }
@@ -723,7 +723,7 @@ public class RubyProcess {
             return gid(context, self);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject getuid(IRubyObject self) {
             return uid(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -732,7 +732,7 @@ public class RubyProcess {
             return uid(context, self);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject setegid(IRubyObject recv, IRubyObject arg) {
             return egid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
         }
@@ -741,7 +741,7 @@ public class RubyProcess {
             return egid_set(context, recv, arg);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject seteuid(IRubyObject recv, IRubyObject arg) {
             return euid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
         }
@@ -750,7 +750,7 @@ public class RubyProcess {
             return euid_set(context, arg);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject setgid(IRubyObject recv, IRubyObject arg) {
             return gid_set(((RubyBasicObject) recv).getCurrentContext().runtime, arg);
         }
@@ -759,7 +759,7 @@ public class RubyProcess {
             return gid_set(context.runtime, arg);
         }
 
-        @Deprecated
+        @Deprecated(since = "1.2")
         public static IRubyObject setuid(IRubyObject recv, IRubyObject arg) {
             return uid_set(((RubyBasicObject) recv).getCurrentContext(), null, arg);
         }
@@ -774,7 +774,7 @@ public class RubyProcess {
         return RubyKernel.abort(context, recv, args);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject exit_bang(IRubyObject recv, IRubyObject[] args) {
         return exit_bang(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -784,7 +784,7 @@ public class RubyProcess {
         return RubyKernel.exit_bang(context, recv, args);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject groups(IRubyObject recv) {
         return groups(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -1057,7 +1057,7 @@ public class RubyProcess {
         return rlimitResourceName2int(name, 0);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject getpgrp(IRubyObject recv) {
         return getpgrp(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -1067,12 +1067,12 @@ public class RubyProcess {
         return asFixnum(context, context.runtime.getPosix().getpgrp());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject getpgrp(Ruby runtime) {
         return asFixnum(runtime.getCurrentContext(), runtime.getPosix().getpgrp());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject groups_set(IRubyObject recv, IRubyObject arg) {
         return groups_set(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
@@ -1082,7 +1082,7 @@ public class RubyProcess {
         throw notImplementedError(context, "Process#groups not yet implemented");
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject waitpid(IRubyObject recv, IRubyObject[] args) {
         return waitpid(((RubyBasicObject) recv).getCurrentContext(), args);
     }
@@ -1098,7 +1098,7 @@ public class RubyProcess {
         return context.tru;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject waitpid(Ruby runtime, IRubyObject[] args) {
         return waitpid(runtime.getCurrentContext(), args);
     }
@@ -1125,7 +1125,7 @@ public class RubyProcess {
         return RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], res);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static long waitpid(Ruby runtime, long pid, int flags) {
         return waitpid(runtime.getCurrentContext(), pid, flags);
     }
@@ -1218,7 +1218,7 @@ public class RubyProcess {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject wait(IRubyObject recv, IRubyObject[] args) {
         return wait(((RubyBasicObject) recv).getCurrentContext(), args);
     }
@@ -1227,7 +1227,7 @@ public class RubyProcess {
         return wait(context, args);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject wait(Ruby runtime, IRubyObject[] args) {
         return wait(((RubyBasicObject) args[0]).getCurrentContext(), args);
     }
@@ -1249,7 +1249,7 @@ public class RubyProcess {
     }
 
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject waitall(IRubyObject recv) {
         return waitall(((RubyBasicObject) recv).getCurrentContext());
     }
@@ -1258,7 +1258,7 @@ public class RubyProcess {
         return waitall(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject waitall(Ruby runtime) {
         return waitall(runtime.getCurrentContext());
     }
@@ -1279,7 +1279,7 @@ public class RubyProcess {
         return results;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject setsid(IRubyObject recv) {
         return setsid(((RubyBasicObject) recv).getCurrentContext().runtime);
     }
@@ -1288,12 +1288,12 @@ public class RubyProcess {
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().setsid()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setsid(Ruby runtime) {
         return setsid(runtime.getCurrentContext(), null);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject setpgrp(IRubyObject recv) {
         return setpgrp(((RubyBasicObject) recv).getCurrentContext().runtime);
     }
@@ -1302,12 +1302,12 @@ public class RubyProcess {
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().setpgid(0, 0)));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setpgrp(Ruby runtime) {
         return setpgrp(runtime.getCurrentContext(), null);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject egid_set(IRubyObject recv, IRubyObject arg) {
         return egid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
     }
@@ -1316,7 +1316,7 @@ public class RubyProcess {
         return egid_set(context, arg);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject egid_set(Ruby runtime, IRubyObject arg) {
         return egid_set(runtime.getCurrentContext(), arg);
     }
@@ -1334,7 +1334,7 @@ public class RubyProcess {
         return asFixnum(context, 0);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject euid(IRubyObject recv) {
         return euid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -1343,12 +1343,12 @@ public class RubyProcess {
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().geteuid()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject euid(Ruby runtime) {
         return euid(runtime.getCurrentContext(), null);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject uid_set(IRubyObject recv, IRubyObject arg) {
         return uid_set(((RubyBasicObject) recv).getCurrentContext(), null, arg);
     }
@@ -1357,12 +1357,12 @@ public class RubyProcess {
         checkErrno(context, context.runtime.getPosix().setuid(toInt(context, arg)));
         return asFixnum(context, 0);
     }
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject uid_set(Ruby runtime, IRubyObject arg) {
         return uid_set(runtime.getCurrentContext(), null, arg);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject gid(IRubyObject recv) {
         return gid(((RubyBasicObject) recv).getCurrentContext());
     }
@@ -1376,12 +1376,12 @@ public class RubyProcess {
                 asFixnum(context, checkErrno(context, context.runtime.getPosix().getgid()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject gid(Ruby runtime) {
         return gid(runtime.getCurrentContext());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject maxgroups(IRubyObject recv) {
         return maxgroups(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -1391,7 +1391,7 @@ public class RubyProcess {
         throw notImplementedError(context, "Process#maxgroups not yet implemented");
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject getpriority(IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
         return getpriority(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2);
     }
@@ -1404,12 +1404,12 @@ public class RubyProcess {
         return asFixnum(context, result);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject getpriority(Ruby runtime, IRubyObject arg1, IRubyObject arg2) {
         return getpriority(runtime.getCurrentContext(), null, arg1, arg2);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject uid(IRubyObject recv) {
         return uid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -1417,7 +1417,7 @@ public class RubyProcess {
     public static IRubyObject uid(ThreadContext context, IRubyObject recv) {
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().getuid()));
     }
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject uid(Ruby runtime) {
         return uid(runtime.getCurrentContext(), null);
     }
@@ -1433,7 +1433,7 @@ public class RubyProcess {
         return waitpid2(runtime.getCurrentContext(), runtime.getProcess(), args);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject initgroups(IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
         return initgroups(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2);
     }
@@ -1443,7 +1443,7 @@ public class RubyProcess {
         throw notImplementedError(context, "Process#initgroups not yet implemented");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject maxgroups_set(IRubyObject recv, IRubyObject arg) {
         return maxgroups_set(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
@@ -1453,7 +1453,7 @@ public class RubyProcess {
         throw notImplementedError(context, "Process#maxgroups_set not yet implemented");
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject ppid(IRubyObject recv) {
         return ppid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -1467,7 +1467,7 @@ public class RubyProcess {
         return ppid(runtime.getCurrentContext(), null);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject gid_set(IRubyObject recv, IRubyObject arg) {
         return gid_set(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
@@ -1478,12 +1478,12 @@ public class RubyProcess {
         return asFixnum(context, result);
 
     }
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject gid_set(Ruby runtime, IRubyObject arg) {
         return gid_set(runtime.getCurrentContext(), null, arg);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject wait2(IRubyObject recv, IRubyObject[] args) {
         return waitpid2(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -1492,7 +1492,7 @@ public class RubyProcess {
         return waitpid2(context.runtime, args);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject euid_set(IRubyObject recv, IRubyObject arg) {
         return euid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
     }
@@ -1501,7 +1501,7 @@ public class RubyProcess {
         return euid_set(context, arg);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject euid_set(Ruby runtime, IRubyObject arg) {
         return euid_set(runtime.getCurrentContext(), arg);
     }
@@ -1522,7 +1522,7 @@ public class RubyProcess {
         return asFixnum(context, 0);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject setpriority(IRubyObject recv, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
         return setpriority(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2, arg3);
     }
@@ -1536,12 +1536,12 @@ public class RubyProcess {
         return asFixnum(context, checkErrno(context, posix.setpriority(which, who, prio)));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setpriority(Ruby runtime, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
         return setpriority(runtime.getCurrentContext(), null, arg1, arg2, arg3);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject setpgid(IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
         return setpgid(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2);
     }
@@ -1552,12 +1552,12 @@ public class RubyProcess {
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().setpgid(pid, gid)));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setpgid(Ruby runtime, IRubyObject arg1, IRubyObject arg2) {
         return setpgid(runtime.getCurrentContext(), null, arg1, arg2);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject getpgid(IRubyObject recv, IRubyObject arg) {
         return getpgid(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
@@ -1567,12 +1567,12 @@ public class RubyProcess {
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().getpgid(pgid)));
 
     }
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject getpgid(Ruby runtime, IRubyObject arg) {
         return getpgid(runtime.getCurrentContext(), null, arg);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject getrlimit(IRubyObject recv, IRubyObject arg) {
         return getrlimit(((RubyBasicObject) recv).getCurrentContext(), arg);
     }
@@ -1581,7 +1581,7 @@ public class RubyProcess {
         return getrlimit(context, arg);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject getrlimit(Ruby runtime, IRubyObject arg) {
         return getrlimit(runtime.getCurrentContext(), arg);
     }
@@ -1602,7 +1602,7 @@ public class RubyProcess {
         return newArray(context, asFixnum(context, rlimit.rlimCur()), asFixnum(context, rlimit.rlimMax()));
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject egid(IRubyObject recv) {
         return egid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -1612,7 +1612,7 @@ public class RubyProcess {
                 asFixnum(context, checkErrno(context, context.runtime.getPosix().getegid()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject egid(Ruby runtime) {
         return egid(runtime.getCurrentContext(), null);
     }
@@ -1632,7 +1632,7 @@ public class RubyProcess {
         return negative ? -signalValue : signalValue;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject kill(IRubyObject recv, IRubyObject[] args) {
         return kill(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -1727,7 +1727,7 @@ public class RubyProcess {
 
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject kill(Ruby runtime, IRubyObject[] args) {
         return kill(runtime.getCurrentContext(), null, args);
     }
@@ -1751,7 +1751,7 @@ public class RubyProcess {
                 CallBlock.newCallClosure(context, recv, Signature.NO_ARGUMENTS, callback));
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject times(IRubyObject recv, Block unusedBlock) {
         return times(((RubyBasicObject) recv).getCurrentContext(), recv, unusedBlock);
     }
@@ -1760,7 +1760,7 @@ public class RubyProcess {
         return times(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject times(Ruby runtime) {
         return times(runtime.getCurrentContext());
     }
@@ -1896,7 +1896,7 @@ public class RubyProcess {
                 asFloat(context, 1000000000.0 / nanos) : makeClockResult(context, nanos, unit);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject pid(IRubyObject recv) {
         return pid(((RubyBasicObject) recv).getCurrentContext());
     }
@@ -1904,7 +1904,7 @@ public class RubyProcess {
     public static IRubyObject pid(ThreadContext context, IRubyObject recv) {
         return pid(context);
     }
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject pid(Ruby runtime) {
         return pid(runtime.getCurrentContext());
     }
@@ -1917,7 +1917,7 @@ public class RubyProcess {
         throw notImplementedError(context, "fork is not available on this platform");
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject fork19(ThreadContext context, IRubyObject recv, Block block) {
         return fork(context, recv, block);
     }
@@ -1934,7 +1934,7 @@ public class RubyProcess {
                 asFixnum(context, ShellLauncher.runExternalWithoutWait(context.runtime, args));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject exit(IRubyObject recv, IRubyObject[] args) {
         return exit(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -1944,7 +1944,7 @@ public class RubyProcess {
         return RubyKernel.exit(context, recv, args);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setproctitle(IRubyObject recv, IRubyObject name) {
         return setproctitle(((RubyBasicObject) recv).getCurrentContext(), recv, name);
     }
@@ -1989,7 +1989,7 @@ public class RubyProcess {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public static IRubyObject waitpid2(IRubyObject recv, IRubyObject[] args) {
         return waitpid2(((RubyBasicObject) recv).getCurrentContext().runtime, args);
     }

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -59,7 +59,7 @@ public class RubyRandom extends RubyRandomBase {
 
         // RandomType(Ruby runtime) { this(randomSeed(runtime)); }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         RandomType(IRubyObject seed) {
             this(((RubyBasicObject) seed).getCurrentContext(), seed);
         }
@@ -115,7 +115,7 @@ public class RubyRandom extends RubyRandomBase {
             }
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         RandomType(IRubyObject vseed, RubyBignum state, int left) {
             this(((RubyBasicObject) vseed).getCurrentContext(), vseed, state, left);
         }
@@ -228,7 +228,7 @@ public class RubyRandom extends RubyRandomBase {
         return Random;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyRandom newRandom(Ruby runtime, RubyClass randomClass, IRubyObject seed) {
         return newRandom(runtime.getCurrentContext(), randomClass, seed);
     }
@@ -442,7 +442,7 @@ public class RubyRandom extends RubyRandomBase {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     static IRubyObject randKernel(ThreadContext context, IRubyObject[] args) {
         RandomType random = getDefaultRand(context);
         if (args.length == 0) {
@@ -453,7 +453,7 @@ public class RubyRandom extends RubyRandomBase {
         return randKernel(context, context.runtime.getRandomClass(), arg);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject rand(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return switch (args.length) {
             case 0 -> randDefault(context, recv);
@@ -462,7 +462,7 @@ public class RubyRandom extends RubyRandomBase {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject randObj(ThreadContext context, IRubyObject[] args) {
         return (args.length == 0) ? rand(context) : rand(context, args[0]);
     }

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -240,7 +240,7 @@ public class RubyRange extends RubyObject {
         return len;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     final int[] begLenInt(int len, final int err) {
         return begLenInt(getCurrentContext(), len, err);
     }
@@ -371,7 +371,7 @@ public class RubyRange extends RubyObject {
         return asBoolean(context, isExclusive);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean exclude_end_p() {
         return exclude_end_p(getRuntime().getCurrentContext());
     }
@@ -1327,7 +1327,7 @@ public class RubyRange extends RubyObject {
 
     private static final ObjectMarshal RANGE_MARSHAL = new ObjectMarshal() {
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type,
                               org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
@@ -1359,7 +1359,7 @@ public class RubyRange extends RubyObject {
         }
 
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             var context = runtime.getCurrentContext();

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -301,7 +301,7 @@ public class RubyRational extends RubyNumeric {
     /** nurat_s_new
      * 
      */
-    @Deprecated
+    @Deprecated(since = "1.1.4")
     public static IRubyObject newInstance(ThreadContext context, IRubyObject clazz, IRubyObject[]args) {
         switch (args.length) {
             case 1: return newInstance(context, (RubyClass) clazz, args[0]);
@@ -327,7 +327,7 @@ public class RubyRational extends RubyNumeric {
         return canonicalizeInternal(context, clazz, maybeInt.convertToInteger(), RubyFixnum.one(context.runtime));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static IRubyObject newInstance(ThreadContext context, IRubyObject clazz, IRubyObject num, IRubyObject den) {
         return newInstance(context, (RubyClass) clazz, num, den);
     }
@@ -392,7 +392,7 @@ public class RubyRational extends RubyNumeric {
         return x;
     }
     
-    @Deprecated
+    @Deprecated(since = "1.1.4")
     public static IRubyObject convert(ThreadContext context, IRubyObject clazz, IRubyObject[]args) {
         switch (args.length) {
         case 1: return convert(context, clazz, args[0]);        
@@ -637,7 +637,7 @@ public class RubyRational extends RubyNumeric {
         return signum(context) > 0;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final int signum() {
         return signum(getCurrentContext());
     }
@@ -715,7 +715,7 @@ public class RubyRational extends RubyNumeric {
         return f_addsub(context, getMetaClass(), num, den, other.num, other.den, true);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_add(ThreadContext context, IRubyObject other) { return op_plus(context, other); }
 
     /** nurat_sub */
@@ -737,7 +737,7 @@ public class RubyRational extends RubyNumeric {
         return f_addsub(context, getMetaClass(), num, den, other.num, other.den, false);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_sub(ThreadContext context, IRubyObject other) { return op_minus(context, other); }
 
     @Override
@@ -1301,7 +1301,7 @@ public class RubyRational extends RubyNumeric {
      * @return
      * @deprecated USe {@link org.jruby.RubyRational#asDouble(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public double getDoubleValue(ThreadContext context) {
         return asDouble(context);
     }
@@ -1416,7 +1416,7 @@ public class RubyRational extends RubyNumeric {
 
     private static final ObjectMarshal RATIONAL_MARSHAL = new ObjectMarshal() {
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) {
             throw typeError(runtime.getCurrentContext(), "marshal_dump should be used instead for Rational");
@@ -1427,7 +1427,7 @@ public class RubyRational extends RubyNumeric {
         }
 
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type,
                                     org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
@@ -1573,32 +1573,32 @@ public class RubyRational extends RubyNumeric {
         return ((RubyRational) x).op_div(context, y);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_floor(ThreadContext context) {
         return floor(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_floor(ThreadContext context, IRubyObject n) {
         return floor(context, n);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_ceil(ThreadContext context) {
         return ceil(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_ceil(ThreadContext context, IRubyObject n) {
         return ceil(context, n);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_idiv(ThreadContext context, IRubyObject other) {
         return idiv(context, other);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject op_fdiv(ThreadContext context, IRubyObject other) {
         return fdiv(context, other);
     }

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -384,7 +384,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return re;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RegexpOptions getOptions() {
         return getOptions(getCurrentContext());
     }
@@ -396,7 +396,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return options;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final Regex getPattern() {
         return getPattern(getCurrentContext());
     }
@@ -441,7 +441,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return enc;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final Regex preparePattern(RubyString str) {
         return preparePattern(getCurrentContext(), str);
     }
@@ -517,7 +517,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return processElementIntoResult(context, null, arg0, arg1, options, null, context.encodingHolder());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public static RubyString preprocessDRegexp(Ruby runtime, IRubyObject arg0, IRubyObject arg1, RegexpOptions options) {
         var context = runtime.getCurrentContext();
         return processElementIntoResult(context, null, arg0, arg1, options, null, context.encodingHolder());
@@ -527,19 +527,19 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return processElementIntoResult(context, null, arg0, arg1, arg2, options, null, context.encodingHolder());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public static RubyString preprocessDRegexp(Ruby runtime, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, RegexpOptions options) {
         var context = runtime.getCurrentContext();
         return processElementIntoResult(context, null, arg0, arg1, arg2, options, null, context.encodingHolder());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public static RubyString preprocessDRegexp(Ruby runtime, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, RegexpOptions options) {
         var context = runtime.getCurrentContext();
         return processElementIntoResult(context, null, arg0, arg1, arg2, arg3, options, null, context.encodingHolder());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public static RubyString preprocessDRegexp(Ruby runtime, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, IRubyObject arg4, RegexpOptions options) {
         var context = runtime.getCurrentContext();
         return processElementIntoResult(context, null, arg0, arg1, arg2, arg3, arg4, options, null, context.encodingHolder());
@@ -922,7 +922,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return RE_OPTION_IGNORECASE;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize_m(IRubyObject arg) {
         return initialize_m(getCurrentContext(), arg);
     }
@@ -934,7 +934,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 regexpInitializeString(context, arg.convertToString(), new RegexpOptions(), null);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize_m(IRubyObject arg0, IRubyObject arg1) {
         return initialize_m(getCurrentContext(), arg0, arg1);
     }
@@ -961,7 +961,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return regexpInitializeString(context, arg0.convertToString(), regexpOptions, timeout);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize_m(IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return initialize_m(getCurrentContext(), arg0, arg1, arg2);
     }
@@ -1009,7 +1009,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return regexpInitialize(bytes, enc, options, timeout);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public final RubyRegexp regexpInitialize(ByteList bytes, Encoding enc, RegexpOptions options) {
         return regexpInitialize(bytes, enc, options, null);
     }
@@ -1322,7 +1322,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public final RubyBoolean startWithP(ThreadContext context, RubyString str) {
         return startsWith(context, str) ? context.tru : context.fals;
     }
@@ -1392,7 +1392,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return asFixnum(context, getOptions(context).toOptions());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject options() {
         return options(getCurrentContext());
     }
@@ -1414,7 +1414,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return newString(context, newStr);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject source() {
         return source(getCurrentContext());
     }
@@ -1440,7 +1440,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
 
     private final static int EMBEDDABLE = RE_OPTION_MULTILINE|RE_OPTION_IGNORECASE|RE_OPTION_EXTENDED;
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString to_s() {
         return to_s(getCurrentContext());
     }
@@ -1645,7 +1645,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return pattern != null && pattern.isLinear() ? context.tru : context.fals;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject nth_match(int nth, IRubyObject match) {
         return nth_match(((RubyBasicObject) match).getCurrentContext(), nth, match);
     }
@@ -1678,7 +1678,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 context.nil : match.str.makeSharedString(context.runtime, start, end - start);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject last_match(IRubyObject match) {
         return last_match(((RubyBasicObject) match).getCurrentContext(), match);
     }
@@ -1691,7 +1691,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     }
 
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject match_pre(IRubyObject match) {
         return match_pre(((RubyBasicObject) match).getCurrentContext(), match);
     }
@@ -1708,7 +1708,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 context.nil : match.str.makeShared(context.runtime, 0,  match.begin);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject match_post(IRubyObject match) {
         return match_post(((RubyBasicObject) match).getCurrentContext(), match);
     }
@@ -1726,7 +1726,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject match_last(IRubyObject match) {
         return match_last(((RubyBasicObject) match).getCurrentContext(), match);
     }
@@ -1917,7 +1917,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return newRegexp(input.getRuntime(), input.unmarshalString(), RegexpOptions.fromJoniOptions(input.readSignedByte()));
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(RubyRegexp regexp, org.jruby.runtime.marshal.MarshalStream output) throws java.io.IOException {
         var context = regexp.getRuntime().getCurrentContext();
@@ -1942,7 +1942,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         output.writeByte(out, options);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public final int search(ThreadContext context, RubyString str, int pos, boolean reverse, IRubyObject[] holder) {
         int result = searchString(context, str, pos, reverse);
         if (holder != null) {
@@ -1953,12 +1953,12 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return result;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject getBackRef(ThreadContext context) {
         return context.getBackRef();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isSimpleString() {
         return isSimpleString(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -160,7 +160,7 @@ public class RubySignal {
         return names;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject __jtrap_kernel(final IRubyObject recv, IRubyObject block, IRubyObject sig) {
         return __jtrap_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, block, sig);
     }
@@ -170,7 +170,7 @@ public class RubySignal {
         return SIGNAL_FACADE.trap(context, recv, block, sig);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject __jtrap_platform_kernel(final IRubyObject recv, IRubyObject sig) {
         return __jtrap_platform_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, sig);
     }
@@ -180,7 +180,7 @@ public class RubySignal {
         return SIGNAL_FACADE.restorePlatformDefault(context, recv, sig);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject __jtrap_osdefault_kernel(final IRubyObject recv, IRubyObject sig) {
         return __jtrap_osdefault_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, sig);
     }
@@ -190,7 +190,7 @@ public class RubySignal {
         return SIGNAL_FACADE.restoreOSDefault(context, recv, sig);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject __jtrap_restore_kernel(final IRubyObject recv, IRubyObject sig) {
         return __jtrap_restore_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, sig);
     }

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -241,7 +241,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         setCodeRange(cr);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final Encoding toEncoding(Ruby runtime) {
         return encodingService(getCurrentContext()).findEncoding(this);
     }
@@ -351,7 +351,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return checkEncoding((CodeRangeable) other);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     final Encoding checkEncoding(EncodingCapable other) {
         var context = ((RubyBasicObject) other).getCurrentContext();
         Encoding enc = isCompatibleWith(other);
@@ -410,7 +410,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return eqlAndComparable(other);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     private boolean eql19(IRubyObject other) {
         return eqlAndComparable(other);
     }
@@ -513,17 +513,17 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     // Deprecated String construction routines
 
-    @Deprecated
+    @Deprecated(since = "1.1.6")
     public RubyString newString(CharSequence s) {
         return new RubyString(getRuntime(), getType(), s);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.1.6")
     public RubyString newString(ByteList s) {
         return new RubyString(getRuntime(), getMetaClass(), s);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.1.2")
     public static RubyString newString(Ruby runtime, RubyClass clazz, CharSequence str) {
         return new RubyString(runtime, clazz, str);
     }
@@ -670,7 +670,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return RubyString.newString(runtime,  new ByteList(RubyEncoding.encode(str, rubyInt), internal));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static RubyString newExternalStringWithEncoding(Ruby runtime, String string, Encoding encoding) {
         return EncodingUtils.newExternalStringWithEncoding(runtime, string, encoding);
     }
@@ -718,17 +718,17 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return str;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString newStringShared(Ruby runtime, byte[] bytes) {
         return newStringShared(runtime, bytes, 0, bytes.length, ASCIIEncoding.INSTANCE);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString newStringShared(Ruby runtime, byte[] bytes, Encoding encoding) {
         return newStringShared(runtime, bytes, 0, bytes.length, encoding);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString newStringShared(Ruby runtime, byte[] bytes, int start, int length) {
         return newStringShared(runtime, bytes, start, length, ASCIIEncoding.INSTANCE);
     }
@@ -1103,7 +1103,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         value.invalidate();
     }
 
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     public final void modify19() {
         modifyAndClearCodeRange();
     }
@@ -1466,7 +1466,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return context.runtime.freezeAndDedupString(this);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject plus_at() {
         return plus_at(getCurrentContext());
     }
@@ -1476,7 +1476,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return isFrozen() | isChilled() ? this.dup() : this;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_plus19(ThreadContext context, IRubyObject arg) {
         return op_plus(context, arg);
     }
@@ -1494,7 +1494,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return resultStr;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_mul19(ThreadContext context, IRubyObject other) {
         return op_mul(context, other);
     }
@@ -1655,7 +1655,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     // Needs to remain in place until StringIO has migrated to the new methods
     // See https://github.com/ruby/stringio/issues/83
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public final RubyString cat19(RubyString str2) {
         return catWithCodeRange(str2);
     }
@@ -1678,7 +1678,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     // Needs to remain in place until StringIO has migrated to the new methods
     // See https://github.com/ruby/stringio/issues/83
     // jruby-rack also uses this and must be updated: https://github.com/jruby/jruby-rack/issues/267
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public final int cat19(ByteList other, int codeRange) {
         return catWithCodeRange(other, codeRange);
     }
@@ -1763,12 +1763,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyString replace19(IRubyObject other) {
         return replace(getCurrentContext(), other);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString initialize_copy(IRubyObject other) {
         return initialize_copy(getCurrentContext(), other);
     }
@@ -1778,7 +1778,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return replace(context, other);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject replace(IRubyObject other) {
         return replace(getCurrentContext(), other);
     }
@@ -1802,7 +1802,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return otherStr;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString clear() {
         return clear(getCurrentContext());
     }
@@ -1819,7 +1819,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject reverse19(ThreadContext context) {
         return reverse(context);
     }
@@ -1831,7 +1831,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return str;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyString reverse_bang19(ThreadContext context) {
         return reverse_bang(context);
     }
@@ -1979,17 +1979,17 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (other instanceof RubyString) throw typeError(context, "type mismatch: String given");
         return sites(context).op_match.call(context, other, other, this);
     }
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject match19(ThreadContext context, IRubyObject pattern) {
         return match(context, pattern, Block.NULL_BLOCK);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject match19(ThreadContext context, IRubyObject pattern, IRubyObject pos, Block block) {
         return match(context, pattern, pos, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject match19(ThreadContext context, IRubyObject[] args, Block block) {
         return match(context, args, block);
     }
@@ -2002,7 +2002,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      * @param pattern Regexp or String
      */
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject match(ThreadContext context, IRubyObject pattern) {
         return match(context, pattern, Block.NULL_BLOCK);
     }
@@ -2042,7 +2042,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return getPattern(context, pattern).matchP(context, this, toInt(context, pos));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_ge19(ThreadContext context, IRubyObject other) {
         return op_ge(context, other);
     }
@@ -2053,7 +2053,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             asBoolean(context, op_cmp(otherStr) >= 0) : RubyComparable.op_ge(context, this, other);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_gt19(ThreadContext context, IRubyObject other) {
         return op_gt(context, other);
     }
@@ -2064,7 +2064,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             asBoolean(context, op_cmp(otherStr) > 0) : RubyComparable.op_gt(context, this, other);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_le19(ThreadContext context, IRubyObject other) {
         return op_le(context, other);
     }
@@ -2075,7 +2075,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 asBoolean(context, op_cmp(otherStr) <= 0) : RubyComparable.op_le(context, this, other);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_lt19(ThreadContext context, IRubyObject other) {
         return op_lt(context, other);
     }
@@ -2090,7 +2090,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return sites(context).cmp.isBuiltin(this);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject str_eql_p19(ThreadContext context, IRubyObject other) {
         return str_eql_p(context, other);
     }
@@ -2345,7 +2345,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject dump() {
         return dump(getCurrentContext());
     }
@@ -2622,7 +2622,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         throw indexError(context, "index " + index + " out of string");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString inspect() {
         // The return type confuses existing extensions who expect this method on RubyString.
         return (RubyString) super.inspect();
@@ -2703,7 +2703,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString inspect(final Ruby runtime, ByteList byteList) {
         return inspect(runtime.getCurrentContext(), byteList);
     }
@@ -2817,7 +2817,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return asFixnum(context, value.getRealSize());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum bytesize() {
         return bytesize(getCurrentContext());
     }
@@ -2900,7 +2900,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return catWithCodeRange(other);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.4.0")
     public RubyString append19(IRubyObject other) {
         return append(other);
     }
@@ -3797,7 +3797,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return substr(getCurrentContext(), beg, len);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject substr(Ruby runtime, int beg, int len) {
         return substr(getCurrentContext(), beg, len);
     }
@@ -3862,12 +3862,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return obj;
     }
 
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject substr19(Ruby runtime, int beg, int len) {
         return substrEnc(getCurrentContext(), beg, len);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject substrEnc(Ruby runtime, int beg, int len) {
         return substrEnc(getCurrentContext(), beg, len);
     }
@@ -3979,7 +3979,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return this;
     }
 
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     private void replaceInternal19(Ruby runtime, int beg, int len, RubyString repl) {
         strUpdate(getCurrentContext(), beg, len, this, repl);
     }
@@ -4375,7 +4375,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 Create.newEmptyString(context, value.getEncoding());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject succ_bang() {
         return succ_bang(getCurrentContext());
     }
@@ -4586,7 +4586,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return val;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_i() {
         return to_i(getCurrentContext());
     }
@@ -4597,7 +4597,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return stringToInum(10);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_i(IRubyObject arg0) {
         return to_i(getCurrentContext(), arg0);
     }
@@ -4644,7 +4644,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return stringToInum(16, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_f() {
         return to_f(getCurrentContext());
     }
@@ -4715,12 +4715,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      * @param delimiter
      * @return splited entries
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray split(RubyRegexp delimiter) {
         return splitCommon(getCurrentContext(), delimiter, 0);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray split(RubyRegexp delimiter, int limit) {
         return split(getCurrentContext(), delimiter, limit);
     }
@@ -4737,12 +4737,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return splitCommon(context, delimiter, limit);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray split(RubyString delimiter) {
         return splitCommon(getCurrentContext(), delimiter, 0);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray split(RubyString delimiter, int limit) {
         return split(getCurrentContext(), delimiter, limit);
     }
@@ -5550,7 +5550,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject ljust(IRubyObject arg0) {
         return ljust(getCurrentContext(), arg0);
     }
@@ -5563,7 +5563,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return justify(context, arg0, 'l');
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject ljust(IRubyObject arg0, IRubyObject arg1) {
         return ljust(getCurrentContext(), arg0, arg1);
     }
@@ -5573,7 +5573,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return justify(context, arg0, arg1, 'l');
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rjust(IRubyObject arg0) {
         return rjust(getCurrentContext(), arg0);
     }
@@ -5586,7 +5586,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return justify(context, arg0, 'r');
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject rjust(IRubyObject arg0, IRubyObject arg1) {
         return rjust(getCurrentContext(), arg0, arg1);
     }
@@ -5596,7 +5596,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return justify(context, arg0, arg1, 'r');
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject center(IRubyObject arg0) {
         return center(getCurrentContext(), arg0);
     }
@@ -5610,7 +5610,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject center(IRubyObject arg0, IRubyObject arg1) {
         return center(getCurrentContext(), arg0, arg1);
     }
@@ -5748,22 +5748,22 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyString chomp19(ThreadContext context) {
         return chomp(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyString chomp19(ThreadContext context, IRubyObject arg0) {
         return chomp(context, arg0);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject chomp_bang19(ThreadContext context) {
         return chomp_bang(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject chomp_bang19(ThreadContext context, IRubyObject arg0) {
         return chomp_bang(context, arg0);
     }
@@ -6248,12 +6248,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject tr19(ThreadContext context, IRubyObject src, IRubyObject repl) {
         return tr(context, src, repl);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject tr_bang19(ThreadContext context, IRubyObject src, IRubyObject repl) {
         return tr_bang(context, src, repl);
     }
@@ -6293,12 +6293,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject tr_s19(ThreadContext context, IRubyObject src, IRubyObject repl) {
         return tr_s(context, src, repl);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject tr_s_bang19(ThreadContext context, IRubyObject src, IRubyObject repl) {
         return tr_s_bang(context, src, repl);
     }
@@ -6643,7 +6643,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return enumerateGraphemeClusters(context, "each_grapheme_cluster", block, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubySymbol intern() {
         return intern(getCurrentContext());
     }
@@ -6733,7 +6733,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 first : RubyRational.newRationalNoReduce(context, asFixnum(context, 0), asFixnum(context, 1));
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubyString unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         return newString(input.getRuntime(), input.unmarshalString());
@@ -6930,7 +6930,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void setValue(CharSequence value) {
         view(ByteList.plain(value), false);
     }
@@ -7364,7 +7364,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public boolean isBare(Ruby runtime) {
         return isBare(getCurrentContext());
     }
@@ -7380,7 +7380,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return context.sites.String;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public final RubyString strDup() {
         return strDup(getRuntime(), getMetaClass().getRealClass());
     }
@@ -7390,7 +7390,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return Pack.unpack(getRuntime(), this.value, stringValue(obj).value);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject encode_bang(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 2);
 

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -225,7 +225,7 @@ public class RubyStruct extends RubyObject {
 
     // Struct methods
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass newInstance(IRubyObject recv, IRubyObject[] args, Block block) {
         return newInstance(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }
@@ -329,7 +329,7 @@ public class RubyStruct extends RubyObject {
 
     // For binding purposes on the newly created struct types
     public static class StructMethods {
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject[] args, Block block) {
             return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args, block);
         }
@@ -339,7 +339,7 @@ public class RubyStruct extends RubyObject {
             return Create.newStruct(context, (RubyClass) recv, args, block);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject newStruct(IRubyObject recv, Block block) {
             return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, block);
         }
@@ -349,7 +349,7 @@ public class RubyStruct extends RubyObject {
             return Create.newStruct(context, (RubyClass) recv, block);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, Block block) {
             return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, block);
         }
@@ -359,7 +359,7 @@ public class RubyStruct extends RubyObject {
             return Create.newStruct(context, (RubyClass) recv, arg0, block);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
             return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, block);
         }
@@ -369,7 +369,7 @@ public class RubyStruct extends RubyObject {
             return Create.newStruct(context, (RubyClass) recv, arg0, arg1, block);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
             return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, arg2, block);
         }
@@ -379,7 +379,7 @@ public class RubyStruct extends RubyObject {
             return Create.newStruct(context, (RubyClass) recv, arg0, arg1, arg2, block);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject members(IRubyObject recv, Block block) {
             return members(((RubyBasicObject) recv).getCurrentContext(), recv);
         }
@@ -389,7 +389,7 @@ public class RubyStruct extends RubyObject {
             return RubyStruct.members(context, (RubyClass) recv);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject inspect(IRubyObject recv) {
             return inspect(((RubyBasicObject) recv).getCurrentContext(), recv);
         }
@@ -402,7 +402,7 @@ public class RubyStruct extends RubyObject {
             return inspected.convertToString().catString("(keyword_init: true)");
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject keyword_init_p(IRubyObject self) {
             return keyword_init_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -420,7 +420,7 @@ public class RubyStruct extends RubyObject {
      *
      * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject[], Block)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject[] args, Block block) {
         return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args, block);
     }
@@ -431,7 +431,7 @@ public class RubyStruct extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, Block)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyStruct newStruct(IRubyObject recv, Block block) {
         return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, block);
     }
@@ -443,7 +443,7 @@ public class RubyStruct extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject, Block)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, Block block) {
         return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, block);
     }
@@ -456,7 +456,7 @@ public class RubyStruct extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject, IRubyObject, Block)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
         return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, block);
     }
@@ -470,7 +470,7 @@ public class RubyStruct extends RubyObject {
      * @return
      * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject, IRubyObject, IRubyObject, Block)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, arg2, block);
     }
@@ -604,7 +604,7 @@ public class RubyStruct extends RubyObject {
         return __member__(context, classOf());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray members() {
         return members(getCurrentContext());
     }
@@ -638,7 +638,7 @@ public class RubyStruct extends RubyObject {
         return recv.size(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set(IRubyObject value, int index) {
         return set(getCurrentContext(), value, index);
     }
@@ -761,7 +761,7 @@ public class RubyStruct extends RubyObject {
         return newArray(context, values);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyHash to_h(ThreadContext context) {
         return to_h(context, Block.NULL_BLOCK);
     }
@@ -797,7 +797,7 @@ public class RubyStruct extends RubyObject {
         return asFixnum(context, values.length);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum size() {
         return size(getCurrentContext());
     }
@@ -830,7 +830,7 @@ public class RubyStruct extends RubyObject {
         return block.isGiven() ? each_pairInternal(context, block) : enumeratorizeWithSize(context, this, "each_pair", RubyStruct::size);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aref(IRubyObject key) {
         return aref(getCurrentContext(), key);
     }
@@ -853,7 +853,7 @@ public class RubyStruct extends RubyObject {
         return aref(context, toInt(context, key));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     final IRubyObject aref(int idx) {
         return aref(getCurrentContext(), idx);
     }
@@ -871,7 +871,7 @@ public class RubyStruct extends RubyObject {
         return values[index];
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aset(IRubyObject key, IRubyObject value) {
         return aset(getCurrentContext(), key, value);
     }
@@ -897,7 +897,7 @@ public class RubyStruct extends RubyObject {
         return values[index] = value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject values_at(IRubyObject[] args) {
         return values_at(getCurrentContext(), args);
     }
@@ -962,7 +962,7 @@ public class RubyStruct extends RubyObject {
         return argc == 1 ? val : RubyObject.dig(context, val, args, 1);
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static void marshalTo(RubyStruct struct, org.jruby.runtime.marshal.MarshalStream output) throws java.io.IOException {
         var context = struct.getRuntime().getCurrentContext();
@@ -993,7 +993,7 @@ public class RubyStruct extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static IRubyObject unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input) throws java.io.IOException {
         final Ruby runtime = input.getRuntime();

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -101,7 +101,7 @@ import static org.jruby.util.StringSupport.codeRangeScan;
  */
 @JRubyClass(name = "Symbol", include = "Enumerable")
 public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingCapable, Constantizable, Appendable {
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static final long symbolHashSeedK0 = 5238926673095087190l;
 
     private final String symbol;
@@ -331,7 +331,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     /* Symbol class methods.
      *
      */
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public static RubySymbol newSymbol(Ruby runtime, IRubyObject name) {
         if (name instanceof RubySymbol) {
             return runtime.getSymbolTable().getSymbol(((RubySymbol) name).getBytes(), false);
@@ -418,7 +418,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         return newHardSymbol(runtime, bytes, handler);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubySymbol newConstantSymbol(Ruby runtime, IRubyObject fqn, ByteList bytes) {
         return newConstantSymbol(runtime.getCurrentContext(), fqn, bytes);
     }
@@ -478,7 +478,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
                 constant;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     final RubyString inspect(final Ruby runtime) {
         return (RubyString) inspect(runtime.getCurrentContext());
     }
@@ -687,7 +687,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
      * @return ""
      * @deprecated Use {@link RubySymbol#length(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject length() {
         return length(getCurrentContext());
     }
@@ -959,13 +959,13 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     public static IRubyObject all_symbols(ThreadContext context, IRubyObject recv) {
         return context.runtime.getSymbolTable().all_symbols(context);
     }
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static IRubyObject all_symbols(IRubyObject recv) {
         var runtime = recv.getRuntime();
         return runtime.getSymbolTable().all_symbols(runtime.getCurrentContext());
     }
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     public static RubySymbol unmarshalFrom(org.jruby.runtime.marshal.UnmarshalStream input, org.jruby.runtime.marshal.UnmarshalStream.MarshalState state) throws java.io.IOException {
         ByteList byteList = input.unmarshalString();
@@ -1423,7 +1423,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
             return null;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public RubyArray all_symbols() {
             return all_symbols(runtime.getCurrentContext());
         }
@@ -1505,7 +1505,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         }
 
         // backwards-compatibility, but threadsafe now
-        @Deprecated
+        @Deprecated(since = "9.0.0.0")
         public RubySymbol lookup(String name) {
             int hash = name.hashCode();
             SymbolEntry[] table = symbolTable;
@@ -1525,7 +1525,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
         // not so backwards-compatible here, but no one should have been
         // calling this anyway.
-        @Deprecated
+        @Deprecated(since = "9.0.0.0")
         public void store(RubySymbol symbol) {
             throw new UnsupportedOperationException();
         }
@@ -1586,7 +1586,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         return object.convertToString().getByteList().toString();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.10.0")
     public static String checkID(IRubyObject object) {
         return idStringFromObject(object.getRuntime().getCurrentContext(), object);
     }
@@ -1716,7 +1716,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         return context.sites.Symbol;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     public IRubyObject taint(ThreadContext context) {
         return this;

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -143,7 +143,7 @@ public class RubySystemCallError extends RubyStandardError {
 
     private static final ObjectMarshal SYSTEM_CALL_ERROR_MARSHAL = new ObjectMarshal() {
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type,
                               org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
@@ -172,7 +172,7 @@ public class RubySystemCallError extends RubyStandardError {
         }
 
         @Override
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream input) throws IOException {
             var context = runtime.getCurrentContext();
@@ -207,7 +207,7 @@ public class RubySystemCallError extends RubyStandardError {
                 defineMethods(context, RubySystemCallError.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block unused) {
         return initialize(getRuntime().getCurrentContext(), args);

--- a/core/src/main/java/org/jruby/RubySystemExit.java
+++ b/core/src/main/java/org/jruby/RubySystemExit.java
@@ -56,7 +56,7 @@ public class RubySystemExit extends RubyException {
                 defineMethods(context, RubySystemExit.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubySystemExit newInstance(Ruby runtime, int status, String message) {
         return newInstance(runtime.getCurrentContext(), status, message);
     }
@@ -78,7 +78,7 @@ public class RubySystemExit extends RubyException {
         return new SystemExit(message, this);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block block) {
         return initialize(getRuntime().getCurrentContext(), args, block);

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -602,7 +602,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return startThread(recv, args, true, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyThread start(IRubyObject recv, IRubyObject[] args, Block block) {
         return start(recv.getRuntime().getCurrentContext(), recv, args, block);
     }
@@ -928,7 +928,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return false;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setName(IRubyObject name) {
         return setName(getCurrentContext(), name);
     }
@@ -948,7 +948,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return name;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getName() {
         return getName(getCurrentContext());
     }
@@ -1396,7 +1396,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return asBoolean(context, getStatus() == Status.SLEEP || getStatus() == Status.DEAD);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean stop_p() {
         return stop_p(getRuntime().getCurrentContext());
     }
@@ -1413,7 +1413,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum priority() {
         return priority(getCurrentContext());
     }
@@ -1423,7 +1423,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return asFixnum(context, javaPriorityToRubyPriority(threadImpl.getPriority()));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject priority_set(IRubyObject priority) {
         return priority_set(getCurrentContext(), priority);
     }
@@ -1671,7 +1671,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return exitingException;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public interface BlockingTask {
         public void run() throws InterruptedException;
         public void wakeup();
@@ -1747,7 +1747,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public void executeBlockingTask(BlockingTask task) throws InterruptedException {
         try {
             this.currentBlockingTask = task;
@@ -2400,7 +2400,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         enterSleep();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public void beforeBlockingCall() {
         beforeBlockingCall(metaClass.runtime.getCurrentContext());
     }
@@ -2608,7 +2608,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                 f);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject setFiberScheduler(IRubyObject scheduler) {
         return setFiberScheduler(getCurrentContext(), scheduler);
     }
@@ -2656,7 +2656,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return blockingCount > 0;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject pending_interrupt_p(ThreadContext context, IRubyObject[] args) {
         return switch (args.length) {
             case 0 -> pending_interrupt_p(context);
@@ -2665,22 +2665,22 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject pending_interrupt_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         return context.getThread().pending_interrupt_p(context, args);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public RubyBoolean alive_p() {
         return isAlive() ? getRuntime().getTrue() : getRuntime().getFalse();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject value() {
         return value(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject join(ThreadContext context, IRubyObject[] args) {
         return switch (args.length) {
             case 0 -> join(context);
@@ -2689,7 +2689,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.10.0")
     public IRubyObject op_aset(IRubyObject key, IRubyObject value) {
         return op_aset(getRuntime().getCurrentContext(), key, value);
     }

--- a/core/src/main/java/org/jruby/RubyThreadGroup.java
+++ b/core/src/main/java/org/jruby/RubyThreadGroup.java
@@ -127,12 +127,12 @@ public class RubyThreadGroup extends RubyObject {
         return asBoolean(context, enclosed);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject enclosed_p(Block block) {
         return enclosed_p(getRuntime().getCurrentContext(), block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject list(Block block) {
         return list(getCurrentContext(), block);
     }
@@ -162,7 +162,7 @@ public class RubyThreadGroup extends RubyObject {
         super(runtime, type);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject add(IRubyObject rubyThread, Block block) {
         if (!(rubyThread instanceof RubyThread)) throw typeError(getRuntime().getCurrentContext(), rubyThread, "Thread");
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -149,7 +149,7 @@ public class RubyTime extends RubyObject {
         return ClassIndex.TIME;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static String getEnvTimeZone(Ruby runtime) {
         return getEnvTimeZone(runtime.getCurrentContext());
     }
@@ -170,7 +170,7 @@ public class RubyTime extends RubyObject {
         return (entry.value instanceof RubyString) ? entry.value.asJavaString() : null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static DateTimeZone getLocalTimeZone(Ruby runtime) {
         return getLocalTimeZone(runtime.getCurrentContext());
     }
@@ -180,7 +180,7 @@ public class RubyTime extends RubyObject {
         return tz == null ? DateTimeZone.getDefault() : getTimeZoneFromTZString(context, tz);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static DateTimeZone getTimeZoneFromTZString(Ruby runtime, String zone) {
         return getTimeZoneFromTZString(runtime.getCurrentContext(), zone);
     }
@@ -234,7 +234,7 @@ public class RubyTime extends RubyObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static DateTimeZone getTimeZoneFromString(Ruby runtime, String zone) {
         DateTimeZone cachedZone = runtime.getTimezoneCache().get(zone);
         if (cachedZone != null) return cachedZone;
@@ -354,7 +354,7 @@ public class RubyTime extends RubyObject {
      * @return ""
      * @deprecated Use {@link RubyTime#invalidUTCOffset(ThreadContext)} instead
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RaiseException invalidUTCOffset(Ruby runtime) {
         return invalidUTCOffset(runtime.getCurrentContext());
     }
@@ -368,7 +368,7 @@ public class RubyTime extends RubyObject {
      * @return ""
      * @deprecated Use {@link RubyTime#invalidUTCOffset(ThreadContext)} instead
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RaiseException invalidUTCOffset(Ruby runtime, IRubyObject value) {
         return invalidUTCOffset(runtime.getCurrentContext(), value);
     }
@@ -436,7 +436,7 @@ public class RubyTime extends RubyObject {
         return timeZoneWithOffset(name, offset);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static DateTimeZone getTimeZone(Ruby runtime, long seconds) {
         return getTimeZone(runtime.getCurrentContext(), seconds);
     }
@@ -447,7 +447,7 @@ public class RubyTime extends RubyObject {
         return getTimeZoneWithOffset(context, "", (int) (seconds * 1000));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static DateTimeZone getTimeZoneWithOffset(Ruby runtime, String zoneName, int offset) {
         return getTimeZoneWithOffset(runtime.getCurrentContext(), zoneName, offset);
     }
@@ -549,7 +549,7 @@ public class RubyTime extends RubyObject {
     /**
      * Use {@link #setDateTime(DateTime)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public void updateCal(DateTime dt) {
         this.dt = dt;
     }
@@ -558,7 +558,7 @@ public class RubyTime extends RubyObject {
         return newTime(runtime, new DateTime(milliseconds));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyTime newTimeFromNanoseconds(Ruby runtime, long nanoseconds) {
         return newTimeFromNanoseconds(runtime.getCurrentContext(), nanoseconds);
     }
@@ -607,7 +607,7 @@ public class RubyTime extends RubyObject {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyTime gmtime() {
         return gmtime(getCurrentContext());
     }
@@ -652,7 +652,7 @@ public class RubyTime extends RubyObject {
         return asBoolean(context, isUTC());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean gmt() {
         return gmt(getRuntime().getCurrentContext());
     }
@@ -699,7 +699,7 @@ public class RubyTime extends RubyObject {
         return ((RubyTime) dup()).adjustTimeZone(context, dtz, false);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RubyString strftime(IRubyObject format) {
         return strftime(getRuntime().getCurrentContext(), format);
     }
@@ -1090,7 +1090,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getMillisOfSecond() * 1000 + getUSec());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger usec() {
         return usec(getCurrentContext());
     }
@@ -1163,7 +1163,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getSecondOfMinute());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger sec() {
         return sec(getCurrentContext());
     }
@@ -1173,7 +1173,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getMinuteOfHour());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger min() {
         return min(getCurrentContext());
     }
@@ -1183,7 +1183,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getHourOfDay());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger hour() {
         return hour(getCurrentContext());
     }
@@ -1193,7 +1193,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getDayOfMonth());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger mday() {
         return mday(getCurrentContext());
     }
@@ -1203,7 +1203,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getMonthOfYear());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger month() {
         return month(getCurrentContext());
     }
@@ -1213,7 +1213,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getYear());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger year() {
         return year(getCurrentContext());
     }
@@ -1223,7 +1223,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, (dt.getDayOfWeek() % 7));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger wday() {
         return wday(getCurrentContext());
     }
@@ -1233,7 +1233,7 @@ public class RubyTime extends RubyObject {
         return asFixnum(context, dt.getDayOfYear());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger yday() {
         return yday(getCurrentContext());
     }
@@ -1273,7 +1273,7 @@ public class RubyTime extends RubyObject {
         return asBoolean(context, (dt.getDayOfWeek() % 7) == 6);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject subsec() {
         return subsec(getRuntime().getCurrentContext());
     }
@@ -1303,7 +1303,7 @@ public class RubyTime extends RubyObject {
         return asBoolean(context, !dt.getZone().isStandardOffset(dt.getMillis()));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyBoolean isdst() {
         return isdst(getRuntime().getCurrentContext());
     }
@@ -1312,7 +1312,7 @@ public class RubyTime extends RubyObject {
      * @return ""
      * @deprecated Use {@link RubyTime#zone(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject zone() {
         return zone(getCurrentContext());
     }
@@ -1331,7 +1331,7 @@ public class RubyTime extends RubyObject {
         return zone;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public String getZoneName() {
         return getRubyTimeZoneName(getCurrentContext(), dt);
     }
@@ -1342,7 +1342,7 @@ public class RubyTime extends RubyObject {
      * @return ""
      * @deprecated Use {@link RubyTime#getRubyTimeZoneName(ThreadContext, DateTime)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static String getRubyTimeZoneName(Ruby runtime, DateTime dt) {
         return getRubyTimeZoneName(runtime.getCurrentContext(), dt);
     }
@@ -1415,14 +1415,14 @@ public class RubyTime extends RubyObject {
         return dump(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RubyString dump(IRubyObject[] args, Block unusedBlock) {
         RubyString str = (RubyString) mdump();
         str.syncVariables(this);
         return str;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RubyObject mdump() {
         return mdump(getCurrentContext());
     }
@@ -1548,7 +1548,7 @@ public class RubyTime extends RubyObject {
     /**
      * @deprecated Use {@link #newInstance(ThreadContext, IRubyObject, IRubyObject[])}
      */
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static IRubyObject s_new(IRubyObject recv, IRubyObject[] args, Block block) {
         Ruby runtime = recv.getRuntime();
         RubyTime time = new RubyTime(runtime, (RubyClass) recv, new DateTime(getLocalTimeZone(runtime.getCurrentContext())));
@@ -1559,7 +1559,7 @@ public class RubyTime extends RubyObject {
     /**
      * @deprecated Use {@link #newInstance(ThreadContext, IRubyObject, IRubyObject[])}
      */
-    @Deprecated
+    @Deprecated(since = "1.1.3")
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         return newInstance(context, recv, args);
     }
@@ -1996,7 +1996,7 @@ public class RubyTime extends RubyObject {
         return (RubyTime) recv.allocate(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static RubyTime load(IRubyObject recv, IRubyObject from, Block block) {
         var context = recv.getRuntime().getCurrentContext();
         return s_mload(context, allocateInstance(context, (RubyClass) recv), from);

--- a/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
+++ b/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
@@ -56,7 +56,7 @@ public class RubyUncaughtThrowError extends RubyArgumentError {
                 defineMethods(context, RubyUncaughtThrowError.class);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected RubyUncaughtThrowError(Ruby runtime, RubyClass exceptionClass) {
         this(runtime.getCurrentContext(), exceptionClass);
     }
@@ -66,7 +66,7 @@ public class RubyUncaughtThrowError extends RubyArgumentError {
         this.message = context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyUncaughtThrowError newUncaughtThrowError(final Ruby runtime,
                                                                IRubyObject tag, IRubyObject value, RubyString message) {
         return newUncaughtThrowError(runtime.getCurrentContext(), tag, value, message);
@@ -86,7 +86,7 @@ public class RubyUncaughtThrowError extends RubyArgumentError {
         return new UncaughtThrowError(message, this);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block block) {
         return initialize(getRuntime().getCurrentContext(), args, block);

--- a/core/src/main/java/org/jruby/TopSelfFactory.java
+++ b/core/src/main/java/org/jruby/TopSelfFactory.java
@@ -50,7 +50,7 @@ public final class TopSelfFactory {
         super();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject createTopSelf(final Ruby runtime) {
         var Object = objectClass(runtime.getCurrentContext());
         var topSelf = new RubyObject(runtime, Object);

--- a/core/src/main/java/org/jruby/anno/JRubyMethod.java
+++ b/core/src/main/java/org/jruby/anno/JRubyMethod.java
@@ -119,9 +119,9 @@ public @interface JRubyMethod {
      */
     Class[] implementers() default {};
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     boolean scope() default false;
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     boolean backtrace() default false;
 }

--- a/core/src/main/java/org/jruby/anno/TypePopulator.java
+++ b/core/src/main/java/org/jruby/anno/TypePopulator.java
@@ -69,7 +69,7 @@ public abstract class TypePopulator {
     }
 
     // Still needed for older generated populators.
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static DynamicMethod populateModuleMethod(RubyModule cls, DynamicMethod javaMethod) {
         return populateModuleMethod(cls, cls.singletonClass(cls.getCurrentContext()), javaMethod);
     }
@@ -113,7 +113,7 @@ public abstract class TypePopulator {
                     .ifPresent(classAnno -> AnnotationHelper.addSubclassNames(classAndSubs, classAnno));
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public void populate(RubyModule target, Class clazz) {
             populate(target.getCurrentContext(), target, clazz);
         }

--- a/core/src/main/java/org/jruby/api/Warn.java
+++ b/core/src/main/java/org/jruby/api/Warn.java
@@ -23,7 +23,7 @@ public class Warn {
      * @param message to be displayed as a warning
      * @param version the version at which this deprecated feature will be removed
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void warnDeprecatedForRemoval(ThreadContext context, String message, String version) {
         context.runtime.getWarnings().warnDeprecatedForRemoval(message, version);
     }

--- a/core/src/main/java/org/jruby/ast/ClassVarDeclNode.java
+++ b/core/src/main/java/org/jruby/ast/ClassVarDeclNode.java
@@ -42,7 +42,7 @@ import org.jruby.ast.visitor.NodeVisitor;
 /**
  * Class variable declaration.
  */
-@Deprecated
+@Deprecated(since = "9.2.0.0")
 public class ClassVarDeclNode extends AssignableNode implements INameNode {
     private final RubySymbol name;
 

--- a/core/src/main/java/org/jruby/ast/HashNode.java
+++ b/core/src/main/java/org/jruby/ast/HashNode.java
@@ -182,7 +182,7 @@ public class HashNode extends Node implements ILiteralNode {
         return hasOnlySymbolKeys;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public boolean isMaybeKwargs() {
         return !isLiteral;
     }

--- a/core/src/main/java/org/jruby/ast/ListNode.java
+++ b/core/src/main/java/org/jruby/ast/ListNode.java
@@ -228,7 +228,7 @@ public class ListNode extends Node implements Iterable<Node> {
         return properList;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public List<Node> childNodes() {
         Node single = this.single;
 

--- a/core/src/main/java/org/jruby/ast/NewlineNode.java
+++ b/core/src/main/java/org/jruby/ast/NewlineNode.java
@@ -52,7 +52,7 @@ import org.jruby.ast.visitor.NodeVisitor;
 public class NewlineNode extends Node {
     private final Node nextNode;
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public NewlineNode(int line, Node nextNode) {
         super(line, nextNode.containsVariableAssignment());
 

--- a/core/src/main/java/org/jruby/ast/executable/AbstractScript.java
+++ b/core/src/main/java/org/jruby/ast/executable/AbstractScript.java
@@ -44,7 +44,7 @@ public abstract class AbstractScript implements Script {
         return __file__(context, self, new IRubyObject[] {arg1, arg2, arg3}, block);
     }
     
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject load(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
         return load(context, self, false);
     }

--- a/core/src/main/java/org/jruby/ast/executable/RuntimeCache.java
+++ b/core/src/main/java/org/jruby/ast/executable/RuntimeCache.java
@@ -117,7 +117,7 @@ public class RuntimeCache {
         return regexps[index];
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RubyRegexp cacheRegexp(int index, RubyString pattern, int options) {
         RubyRegexp regexp = regexps[index];
         Ruby runtime = pattern.getCurrentContext().runtime;
@@ -128,7 +128,7 @@ public class RuntimeCache {
         return regexp;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RubyRegexp cacheRegexp(int index, RubyRegexp regexp) {
         regexps[index] = regexp;
         return regexp;

--- a/core/src/main/java/org/jruby/ast/executable/Script.java
+++ b/core/src/main/java/org/jruby/ast/executable/Script.java
@@ -13,7 +13,7 @@ public interface Script {
     public IRubyObject __file__(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block);
     
     public IRubyObject run(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block);
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject load(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block);
     public IRubyObject load(ThreadContext context, IRubyObject self, boolean wrap);
     public void setFilename(String filename);

--- a/core/src/main/java/org/jruby/ast/util/ArgsUtil.java
+++ b/core/src/main/java/org/jruby/ast/util/ArgsUtil.java
@@ -104,7 +104,7 @@ public final class ArgsUtil {
         return runtime.getNil();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject getOptionsArg(Ruby runtime, IRubyObject arg) {
         return getOptionsArg(runtime, arg, true);
     }
@@ -171,7 +171,7 @@ public final class ArgsUtil {
     }
 
     // not used
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject[] extractKeywordArgs(ThreadContext context, IRubyObject[] args, String... validKeys) {
         return extractKeywordArgs(context, ArgsUtil.getOptionsArg(context.runtime, args), validKeys);
     }

--- a/core/src/main/java/org/jruby/ast/visitor/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/jruby/ast/visitor/AbstractNodeVisitor.java
@@ -632,7 +632,7 @@ public abstract class AbstractNodeVisitor<T> implements NodeVisitor<T> {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public T visitClassVarDeclNode(ClassVarDeclNode node) {
         return defaultVisit(node);
     }

--- a/core/src/main/java/org/jruby/ast/visitor/NodeVisitor.java
+++ b/core/src/main/java/org/jruby/ast/visitor/NodeVisitor.java
@@ -158,6 +158,6 @@ public interface NodeVisitor<T> {
     T visitZSuperNode(ZSuperNode iVisited);
     T visitOther(Node iVisited);
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     default T visitClassVarDeclNode(ClassVarDeclNode iVisited) { return null; }
 }

--- a/core/src/main/java/org/jruby/common/NullWarnings.java
+++ b/core/src/main/java/org/jruby/common/NullWarnings.java
@@ -54,12 +54,12 @@ public class NullWarnings implements IRubyWarnings {
     public void warning(ID id, String message) {}
     public void warning(ID id, String fileName, int lineNumber, String message) {}
     
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public void warn(ID id, String message, Object... data) {}
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public void warning(ID id, String message, Object... data) {}
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public void warn(ID id, String fileName, int lineNumber, String message, Object... data) {}
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public void warning(ID id, String fileName, int lineNumber, String message, Object...data) {}
 }

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -205,12 +205,12 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         doWarn(filename, LINE_NUMBER_NON_WARNING, message, null);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public void warnExperimental(String filename, int line, String message) {
         warnWithCategory(filename, line, message, Category.EXPERIMENTAL);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void warnDeprecated(ID id, String message) {
         warnWithCategory(message, Category.DEPRECATED);
     }
@@ -235,12 +235,12 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         if (runtime.getWarningCategories().contains(category)) warn(filename, line, message, category);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void warnDeprecatedAlternate(String name, String alternate) {
         if (hasDeprecationWarningEnabled()) warn(ID.DEPRECATED_METHOD, name + " is deprecated; use " + alternate + " instead");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void warnDeprecatedForRemoval(String name, String version) {
         if (hasDeprecationWarningEnabled()) warn(ID.MISCELLANEOUS, name + " is deprecated and will be removed in Ruby " + version);
     }
@@ -386,7 +386,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
      * Prints a warning, unless $VERBOSE is nil.
      */
     @Override
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public void warn(ID id, String fileName, String message) {
         if (!runtime.warningsEnabled()) return;
 
@@ -394,7 +394,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         warn(context, newString(context, fileName + " warning: " + message + '\n'));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject warn(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return switch (args.length) {
             case 1 -> warn(context, recv, args[0]);

--- a/core/src/main/java/org/jruby/compiler/Compilable.java
+++ b/core/src/main/java/org/jruby/compiler/Compilable.java
@@ -16,7 +16,7 @@ import static org.jruby.api.Access.classClass;
  */
 public interface Compilable<T> {
     void setCallCount(int count);
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     default void completeBuild(T buildResult) {
         completeBuild(getImplementationClass().getCurrentContext(), buildResult);
     }
@@ -54,7 +54,7 @@ public interface Compilable<T> {
      * Return the owning module/class name.
      * @return method/block owner's name
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     default String getOwnerName() {
         return getOwnerName(getImplementationClass().getCurrentContext());
     }
@@ -81,7 +81,7 @@ public interface Compilable<T> {
 
     public RubyModule getImplementationClass();
 
-    @Deprecated
+    @Deprecated(since = "9.2.9.0")
     default String getClassName(ThreadContext context) {
         return getOwnerName(context);
     }

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -273,7 +273,7 @@ public class JITCompiler implements JITCompilerMBean {
         return new OneShotClassLoader(runtime.getJRubyClassLoader());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static void log(Compilable<?> target, String name, String message, Object... reason) {
         log(target.getImplementationClass().getRuntime().getCurrentContext(), target, name, message, reason);
     }

--- a/core/src/main/java/org/jruby/compiler/impl/SkinnyMethodAdapter.java
+++ b/core/src/main/java/org/jruby/compiler/impl/SkinnyMethodAdapter.java
@@ -969,13 +969,13 @@ public final class SkinnyMethodAdapter extends MethodVisitor {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public void visitMethodInsn(int arg0, String arg1, String arg2, String arg3) {
         getMethodVisitor().visitMethodInsn(arg0, arg1, arg2, arg3);
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public void visitMethodInsn(int arg0, String arg1, String arg2, String arg3, boolean arg4) {
         getMethodVisitor().visitMethodInsn(arg0, arg1, arg2, arg3, arg4);
     }

--- a/core/src/main/java/org/jruby/embed/EmbedEvalUnit.java
+++ b/core/src/main/java/org/jruby/embed/EmbedEvalUnit.java
@@ -57,7 +57,7 @@ public interface EmbedEvalUnit extends JavaEmbedUtils.EvalUnit {
      */
     DynamicScope getLocalVarScope();
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     default ManyVarsDynamicScope getScope() {
         return (ManyVarsDynamicScope) getLocalVarScope();
     }

--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -724,7 +724,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      *
      * @param mode a new profiling mode to be set.
      */
-    @Deprecated
+    @Deprecated(since = "1.7.17")
     public void setProfile(ProfilingMode mode) {
         provider.getRubyInstanceConfig().setProfilingMode(mode);
     }
@@ -1048,7 +1048,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      *
      * @return Ruby runtime of a specified local context
      */
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public Ruby getRuntime() {
         return provider.getRuntime();
     }
@@ -1698,7 +1698,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      *
      * @return an input stream that Ruby runtime has.
      */
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public InputStream getIn() {
         return getInput();
     }
@@ -1761,7 +1761,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      *
      * @return an output stream that Ruby runtime has
      */
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public PrintStream getOut() {
         return getOutput();
     }
@@ -1824,7 +1824,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      *
      * @return an error output stream that Ruby runtime has
      */
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public PrintStream getErr() {
         return getError();
     }
@@ -1901,12 +1901,12 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * add the given classloader to the LOAD_PATH
      * @param classloader
      */
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void addLoadPath(ClassLoader classloader) {
         addLoadPath(createUri(classloader, "/.jrubydir"));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     protected void addLoadPath(String uri) {
         runScriptlet( "$LOAD_PATH << '" + uri + "' unless $LOAD_PATH.member?( '" + uri + "' )" );
     }
@@ -1915,7 +1915,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * add the given classloader to the GEM_PATH
      * @param classloader
      */
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void addGemPath(ClassLoader classloader) {
         addGemPath(createUri(classloader, "/specifications/.jrubydir"));
     }

--- a/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
+++ b/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
@@ -246,7 +246,7 @@ public class BiVariableMap implements Map<String, Object> {
      * @return the BiVariable type object to which the specified key is mapped, or
      *         {@code null} if this map contains no mapping for the key
      */
-    //@Deprecated
+    //@Deprecated(since = "1.7.20")
     public BiVariable getVariable(final String name) {
         return getVariable(getTopSelf(), name);
     }

--- a/core/src/main/java/org/jruby/embed/internal/EmbedEvalUnitImpl.java
+++ b/core/src/main/java/org/jruby/embed/internal/EmbedEvalUnitImpl.java
@@ -77,7 +77,7 @@ public class EmbedEvalUnitImpl implements EmbedEvalUnit {
      *
      * @return a root node of parsed Ruby script
      */
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node getNode() {
         return (Node) parseResult.getAST();
     }

--- a/core/src/main/java/org/jruby/embed/internal/LocalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/LocalContext.java
@@ -62,7 +62,7 @@ public class LocalContext {
 
     // This method is used only from ThreadLocalContextProvider.
     // Other providers should instantialte runtime in their own way.
-    @Deprecated
+    @Deprecated(since = "1.7.20")
     public Ruby getThreadSafeRuntime() {
         return getRuntime();
     }

--- a/core/src/main/java/org/jruby/embed/osgi/OSGiIsolatedScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/osgi/OSGiIsolatedScriptingContainer.java
@@ -66,7 +66,7 @@ public class OSGiIsolatedScriptingContainer extends IsolatedScriptingContainer {
         return bundle;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     private String createUri(Bundle cl, String ref) {
         URL url = cl.getResource(ref);
         if ( url == null && ref.startsWith( "/" ) ) {
@@ -81,7 +81,7 @@ public class OSGiIsolatedScriptingContainer extends IsolatedScriptingContainer {
      * add the classloader from the given bundle to the LOAD_PATH
      * @param bundle
      */
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void addBundleToLoadPath(Bundle bundle) {
         addLoadPath(createUri(bundle, "/.jrubydir"));
     }
@@ -92,7 +92,7 @@ public class OSGiIsolatedScriptingContainer extends IsolatedScriptingContainer {
      * 
      * @param symbolicName
      */
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void addBundleToLoadPath(String symbolicName) {
         addBundleToLoadPath(toBundle(symbolicName));
     }
@@ -118,7 +118,7 @@ public class OSGiIsolatedScriptingContainer extends IsolatedScriptingContainer {
      * add the classloader from the given bundle to the GEM_PATH
      * @param bundle
      */
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void addBundleToGemPath(Bundle bundle) {
         addGemPath(createUri(bundle, "/specifications/.jrubydir"));
     }
@@ -129,7 +129,7 @@ public class OSGiIsolatedScriptingContainer extends IsolatedScriptingContainer {
      * 
      * @param symbolicName
      */
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void addBundleToGemPath(String symbolicName) {
         addBundleToGemPath(toBundle(symbolicName));
     }

--- a/core/src/main/java/org/jruby/embed/util/SystemPropertyCatcher.java
+++ b/core/src/main/java/org/jruby/embed/util/SystemPropertyCatcher.java
@@ -164,7 +164,7 @@ public class SystemPropertyCatcher {
      *
      * @param container ScriptingContainer to be set jruby home.
      */
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public static void setJRubyHome(ScriptingContainer container) {
         String jrubyhome = findJRubyHome(container);
         if (jrubyhome != null) {
@@ -180,7 +180,7 @@ public class SystemPropertyCatcher {
      * @param instance any instance to get a resource
      * @return JRuby home path if exists, null when failed to find it.
      */
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static String findJRubyHome(Object instance) {
         String jrubyhome;
         if ((jrubyhome = SafePropertyAccessor.getenv("JRUBY_HOME")) != null) {
@@ -192,7 +192,7 @@ public class SystemPropertyCatcher {
         return "uri:classloader://META-INF/jruby.home";
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static String findFromJar(Object instance) {
         URL resource = instance.getClass().getResource("/META-INF/jruby.home");
         if (resource == null) {
@@ -231,7 +231,7 @@ public class SystemPropertyCatcher {
      *
      * @return a list of load paths.
      */
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static List<String> findLoadPaths() {
         String paths = SafePropertyAccessor.getProperty(PropertyName.CLASSPATH.toString());
         List<String> loadPaths = new ArrayList<String>();

--- a/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
@@ -195,7 +195,7 @@ public class GlobalVariable extends AbstractVariable {
         // do nothing
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.20")
     public void tryEagerInjection(Ruby runtime, IRubyObject receiver) {
         tryEagerInjection(receiver);
     }

--- a/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
+++ b/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
@@ -111,7 +111,7 @@ public class VariableInterceptor {
      * @param runtime Ruby runtime
      * @param scope scope to inject local variable values
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static void inject(BiVariableMap map, Ruby runtime, ManyVarsDynamicScope scope) {
         // lvar might not be given while parsing but be given when evaluating.
         // to avoid ArrayIndexOutOfBoundsException, checks the length of scope.getValues()

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -296,12 +296,12 @@ public class RaiseException extends JumpException {
     public static RaiseException createNativeRaiseException(Ruby runtime, Throwable cause) {
         return createNativeRaiseException(runtime, cause, null);
     }
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public static RaiseException createNativeRaiseException(Ruby runtime, Throwable cause, Member target) {
         org.jruby.NativeException nativeException = new org.jruby.NativeException(runtime, runtime.getNativeException(), cause);
         return new RaiseException(cause, nativeException);
     }
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public RaiseException(Throwable cause, org.jruby.NativeException nativeException) {
         super(nativeException.getMessageAsJavaString(), cause);
         providedMessage = super.getMessage(); // cause.getClass().getId() + ": " + message
@@ -310,17 +310,17 @@ public class RaiseException extends JumpException {
         setStackTraceFromException();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RaiseException(RubyException exception) {
         this(exception.getMessageAsJavaString(), exception);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RaiseException(RubyException exception, boolean unused) {
         this(exception.getMessageAsJavaString(), exception);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RaiseException(RubyException exception, IRubyObject backtrace) {
         // this(exception.getMessageAsJavaString(), exception) would preRaise twice!
         super(exception.getMessageAsJavaString());
@@ -328,17 +328,17 @@ public class RaiseException extends JumpException {
         preRaise(exception.getRuntime().getCurrentContext(), backtrace, true);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RaiseException(Ruby runtime, RubyClass exceptionClass, String msg) {
         this(runtime, exceptionClass, msg, null);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RaiseException(Ruby runtime, RubyClass exceptionClass, String msg, boolean unused) {
         this(runtime, exceptionClass, msg, null);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RaiseException(Ruby runtime, RubyClass exceptionClass, String msg, IRubyObject backtrace) {
         super(msg == null ? msg = "No message available" : msg);
         final ThreadContext context = runtime.getCurrentContext();
@@ -349,17 +349,17 @@ public class RaiseException extends JumpException {
         preRaise(context, backtrace, true);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public RaiseException(Ruby runtime, RubyClass exceptionClass, String msg, IRubyObject backtrace, boolean unused) {
         this(runtime, exceptionClass, msg, backtrace);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     protected final void setException(RubyException newException, boolean unused) {
         this.exception = newException;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     private void preRaise(ThreadContext context, StackTraceElement[] javaTrace) {
         preRaise(context, null, false);
 
@@ -371,7 +371,7 @@ public class RaiseException extends JumpException {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static RaiseException from(RubyException exception, IRubyObject backtrace) {
         return new RaiseException(exception, backtrace);
     }

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -776,13 +776,13 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     // Left for arjdbc (being phased out from 61.3 forward and newer points of newer arjdbc versions)
-    @Deprecated
+    @Deprecated(since = "9.4.7.0")
     public static RubyBigDecimal newInstance(ThreadContext context, IRubyObject recv, IRubyObject arg) {
         return (RubyBigDecimal) newInstance(context, recv, arg, true, true);
     }
 
     // Left for arjdbc (being phased out from 61.3 forward and newer points of newer arjdbc versions)
-    @Deprecated
+    @Deprecated(since = "9.4.7.0")
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject arg, boolean strict, boolean exception) {
         switch (((RubyBasicObject) arg).getNativeClassIndex()) {
             case RATIONAL:
@@ -1633,7 +1633,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return cmp(context, arg, 'G');
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject abs() {
         return abs(getCurrentContext());
     }
@@ -1748,7 +1748,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return newArray(context, new RubyBigDecimal(runtime, div), new RubyBigDecimal(runtime, mod));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject exponent() {
         return exponent(getCurrentContext());
     }
@@ -1763,7 +1763,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return asBoolean(context, !isNaN() && !isInfinity());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject finite_p() {
         return finite_p(getCurrentContext());
     }
@@ -1821,7 +1821,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return isZero(context) ? context.nil : this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject nonzero_p() {
         return nonzero_p(getCurrentContext());
     }
@@ -1895,7 +1895,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return (value.unscaledValue().toString().length() + 8) / BASE_FIG;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     @JRubyMethod
     public IRubyObject precs(ThreadContext context) {
         warnDeprecated(context, "BigDecimal#precs is deprecated and will be removed in the future; use BigDecimal#precision instead.");
@@ -2034,7 +2034,7 @@ public class RubyBigDecimal extends RubyNumeric {
      * @return
      * @deprecated Use {@link org.jruby.ext.bigdecimal.RubyBigDecimal#sign(ThreadContext)} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject sign() {
         return sign(getCurrentContext());
     }
@@ -2086,7 +2086,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return val.precision() - val.scale();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject sqrt(IRubyObject arg) {
         return sqrt(getCurrentContext(), arg);
     }
@@ -2111,7 +2111,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return n;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_f() {
         return toFloat(getCurrentContext(), true);
     }
@@ -2148,7 +2148,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return toFloat(getRuntime().getCurrentContext(), false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final IRubyObject to_int() {
         return to_int(getCurrentContext());
     }
@@ -2164,13 +2164,13 @@ public class RubyBigDecimal extends RubyNumeric {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     final RubyInteger to_int(Ruby runtime) {
         return (RubyInteger) to_int(getCurrentContext());
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public RubyInteger convertToInteger() {
         return (RubyInteger) to_int(getCurrentContext());
     }
@@ -2355,13 +2355,13 @@ public class RubyBigDecimal extends RubyNumeric {
         return engineeringValue(context, null).toString();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject to_s(IRubyObject[] args) {
         return toStringImpl(getCurrentContext(), args.length == 0 ? null : (args[0].isNil() ? null : args[0].toString()));
     }
 
     // Note: #fix has only no-arg form, but truncate allows optional parameter.
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject fix() {
         return fix(getCurrentContext());
     }
@@ -2398,7 +2398,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return asBoolean(context, isZero(context));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public IRubyObject zero_p() {
         return zero_p(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -129,7 +129,7 @@ public class RubyDate extends RubyObject {
     // Julian Day Number day 0 ... `def self.civil(y=-4712, m=1, d=1, sg=ITALY)`
     static final DateTime defaultDateTime = new DateTime(-4712 - 1, 1, 1, 0, 0, CHRONO_ITALY_UTC);
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static RubyClass getDate(final Ruby runtime) {
         return getDate(runtime.getCurrentContext());
     }
@@ -138,7 +138,7 @@ public class RubyDate extends RubyObject {
         return (RubyClass) objectClass(context).getConstantAt(context, "Date");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static RubyClass getDateTime(final Ruby runtime) {
         return getDateTime(runtime.getCurrentContext());
     }
@@ -147,7 +147,7 @@ public class RubyDate extends RubyObject {
         return (RubyClass) objectClass(context).getConstantAt(context, "DateTime");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static boolean isDateTime(final Ruby runtime, final IRubyObject type) {
         return isDateTime(runtime.getCurrentContext(), type);
     }
@@ -166,7 +166,7 @@ public class RubyDate extends RubyObject {
         this.dt = dt; // assuming of = 0 (UTC)
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyDate(Ruby runtime, DateTime dt) {
         this(runtime, getDate(runtime.getCurrentContext()), dt);
     }
@@ -186,7 +186,7 @@ public class RubyDate extends RubyObject {
         this.subMillisNum = subMillisNum; this.subMillisDen = subMillisDen;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyDate(Ruby runtime, long millis, Chronology chronology) {
         this(runtime.getCurrentContext(), millis, chronology);
     }
@@ -491,7 +491,7 @@ public class RubyDate extends RubyObject {
         return dt;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static int getYear(IRubyObject year) {
         return getYear(((RubyBasicObject) year).getCurrentContext(), year);
     }
@@ -502,7 +502,7 @@ public class RubyDate extends RubyObject {
         return (y <= 0) ? --y : y; // due julian date calc -> see adjustJodaYear
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static int getMonth(IRubyObject month) {
         return getYear(((RubyBasicObject) month).getCurrentContext(), month);
     }
@@ -1545,7 +1545,7 @@ public class RubyDate extends RubyObject {
         return getValidStart(context, sg.convertToFloat().asDouble(context), ITALY);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static long valid_sg(ThreadContext context, IRubyObject sg) {
         return getValidStart(context, sg.convertToFloat().asDouble(context), 0);
     }
@@ -1687,7 +1687,7 @@ public class RubyDate extends RubyObject {
         return new RubyDateParser().parse(context, format, (RubyString) string);
     }
 
-    // @Deprecated
+    // @Deprecated(since = "9.2.0.0")
     public static IRubyObject _strptime(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         return switch (args.length) {
             case 1 -> _strptime(context, self, args[0]);

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -95,7 +95,7 @@ public class RubyDateTime extends RubyDate {
         this.off = dt.getZone().getOffset(dt.getMillis()) / 1000;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyDateTime(Ruby runtime, DateTime dt) {
         this(runtime, getDateTime(runtime.getCurrentContext()), dt);
     }

--- a/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
+++ b/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
@@ -161,7 +161,7 @@ public class RubyDigest {
         return RubyString.newStringNoCopy(context.runtime, new ByteList(ByteList.plain(toHex(val)), USASCIIEncoding.INSTANCE));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString hexencode(IRubyObject self, IRubyObject arg) {
         return hexencode(((RubyBasicObject) self).getCurrentContext(), self, arg);
     }
@@ -171,7 +171,7 @@ public class RubyDigest {
         return toHexString(context, arg.convertToString().getBytes());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString bubblebabble(IRubyObject recv, IRubyObject arg) {
         return bubblebabble(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
@@ -375,7 +375,7 @@ public class RubyDigest {
             return sites(context).digest_length.call(context, self, self);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         public static IRubyObject digest(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             return switch (args.length) {
                 case 0 -> digest(context, self);
@@ -384,12 +384,12 @@ public class RubyDigest {
             };
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         public static IRubyObject hexdigest(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             return toHexString(context, digest(context, self, args).convertToString().getBytes());
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         public static IRubyObject bubblebabble(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
             return switch (args.length) {
                 case 1 -> bubblebabble(context, recv, args[0]);
@@ -474,12 +474,12 @@ public class RubyDigest {
             return newString(context, BubbleBabble.bubblebabble(digest, 0, digest.length));
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         public static RubyString bubblebabble(IRubyObject recv, IRubyObject arg) {
             return bubblebabble(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         public static IRubyObject s_hexdigest(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
             return s_hexdigest(context, recv, args);
         }
@@ -547,7 +547,7 @@ public class RubyDigest {
             return this;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject finish() {
             return finish(getCurrentContext());
         }
@@ -559,7 +559,7 @@ public class RubyDigest {
             return digest;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject digest_length() {
             return digest_length(getCurrentContext());
         }
@@ -569,7 +569,7 @@ public class RubyDigest {
             return asFixnum(context, algo.getDigestLength());
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject block_length() {
             return block_length(getCurrentContext());
         }

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -218,7 +218,7 @@ public class RubyEtc {
         return newString(context, new ByteList(buf.array(), 0, n - 1));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject getpwuid(IRubyObject recv, IRubyObject[] args) {
         return getpwuid(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -251,7 +251,7 @@ public class RubyEtc {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject getpwnam(IRubyObject recv, IRubyObject name) {
         return getpwnam(((RubyBasicObject) recv).getCurrentContext(), recv, name);
     }
@@ -277,7 +277,7 @@ public class RubyEtc {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject passwd(IRubyObject recv, Block block) {
         return passwd(((RubyBasicObject) recv).getCurrentContext(), recv, block);
     }
@@ -312,7 +312,7 @@ public class RubyEtc {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject getlogin(IRubyObject recv) {
         return getlogin(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -333,7 +333,7 @@ public class RubyEtc {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject endpwent(IRubyObject recv) {
         return endpwent(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -350,7 +350,7 @@ public class RubyEtc {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject setpwent(IRubyObject recv) {
         return setpwent(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -367,7 +367,7 @@ public class RubyEtc {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject getpwent(IRubyObject recv) {
         return getpwent(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -386,7 +386,7 @@ public class RubyEtc {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject getgrnam(IRubyObject recv, IRubyObject name) {
         return getgrnam(((RubyBasicObject) recv).getCurrentContext(), recv, name);
     }
@@ -411,7 +411,7 @@ public class RubyEtc {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject getgrgid(IRubyObject recv, IRubyObject[] args) {
         return getgrgid(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -439,7 +439,7 @@ public class RubyEtc {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject endgrent(IRubyObject recv) {
         return endgrent(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -456,7 +456,7 @@ public class RubyEtc {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject setgrent(IRubyObject recv) {
         return setgrent(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -473,7 +473,7 @@ public class RubyEtc {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject group(IRubyObject recv, Block block) {
         return group(((RubyBasicObject) recv).getCurrentContext(), recv, block);
     }
@@ -515,7 +515,7 @@ public class RubyEtc {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static synchronized IRubyObject getgrent(IRubyObject recv) {
         return getgrent(((RubyBasicObject) recv).getCurrentContext(), recv);
     }

--- a/core/src/main/java/org/jruby/ext/ffi/CallbackManager.java
+++ b/core/src/main/java/org/jruby/ext/ffi/CallbackManager.java
@@ -5,7 +5,7 @@ import org.jruby.Ruby;
 import org.jruby.runtime.ThreadContext;
 
 public abstract class CallbackManager {
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public Pointer getCallback(Ruby runtime, CallbackInfo cbInfo, Object proc) {
         return getCallback(runtime.getCurrentContext(), cbInfo, proc);
     }

--- a/core/src/main/java/org/jruby/ext/ffi/MemoryUtil.java
+++ b/core/src/main/java/org/jruby/ext/ffi/MemoryUtil.java
@@ -228,7 +228,7 @@ public final class MemoryUtil {
         return Create.newArrayNoCopy(context, objArray);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void putArrayOfFloat32(MemoryIO io, long offset, RubyArray ary) {
         putArrayOfFloat32(((RubyBasicObject) ary).getCurrentContext(), io, offset, ary);
     }
@@ -258,7 +258,7 @@ public final class MemoryUtil {
         return Create.newArrayNoCopy(context, objArray);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void putArrayOfFloat64(MemoryIO io, long offset, RubyArray ary) {
         putArrayOfFloat64(ary.getCurrentContext(), io, offset, ary);
     }

--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -275,7 +275,7 @@ public class Platform {
         return CPU;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public final int getJavaMajorVersion() {
         return org.jruby.platform.Platform.JAVA_VERSION;
     }

--- a/core/src/main/java/org/jruby/ext/ffi/StructByValue.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructByValue.java
@@ -44,7 +44,7 @@ public final class StructByValue extends Type {
         this.structLayout = structLayout;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     StructByValue(Ruby runtime, RubyClass structClass, StructLayout structLayout) {
         super(runtime, Access.getClass(runtime.getCurrentContext(), "FFI", "Type", "Struct"),
                 NativeType.STRUCT, structLayout.size, structLayout.alignment);

--- a/core/src/main/java/org/jruby/ext/ffi/Util.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Util.java
@@ -78,7 +78,7 @@ public final class Util {
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static final float floatValue(IRubyObject parameter) {
         return floatValue(((RubyBasicObject) parameter).getCurrentContext(), parameter);
     }
@@ -87,7 +87,7 @@ public final class Util {
         return (float) toDouble(context, parameter);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static final double doubleValue(IRubyObject parameter) {
         return doubleValue(((RubyBasicObject) parameter).getCurrentContext(), parameter);
     }
@@ -106,7 +106,7 @@ public final class Util {
         return RubyNumeric.num2long(parameter);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int intValue(IRubyObject obj, RubyHash enums) {
         var context = ((RubyBasicObject) obj).getCurrentContext();
         if (obj instanceof RubyInteger obji) return obji.asInt(context);
@@ -159,7 +159,7 @@ public final class Util {
                     : RubyFixnum.newFixnum(runtime, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final <T> T convertParameter(IRubyObject parameter, Class<T> paramClass) {
         return paramClass.cast(parameter.toJava(paramClass));
     }

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/DataConverters.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/DataConverters.java
@@ -21,7 +21,7 @@ public class DataConverters {
     @SuppressWarnings("unchecked")
     private static final Map<IRubyObject, NativeDataConverter> enumConverters = Collections.synchronizedMap(new WeakIdentityHashMap());
 
-    @Deprecated
+    @Deprecated(since = "1.7.17")
     static boolean isEnumConversionRequired(Type type, RubyHash enums) {
         if (type instanceof Type.Builtin && enums != null && !enums.isEmpty()) {
             switch (type.getNativeType()) {
@@ -94,7 +94,7 @@ public class DataConverters {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.17")
     static NativeDataConverter getParameterConverter(Type type, RubyHash enums) {
         if (isEnumConversionRequired(type, enums)) {
             NativeDataConverter converter = enumConverters.get(enums);

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/DefaultMethod.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/DefaultMethod.java
@@ -59,7 +59,7 @@ public class DefaultMethod extends DynamicMethod implements CacheableMethod {
         return function.getFunctionAddress();
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     protected final NativeInvoker getNativeInvoker() {
         return getNativeInvoker(getImplementationClass().getRuntime().getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JFFIInvoker.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JFFIInvoker.java
@@ -33,7 +33,7 @@ public class JFFIInvoker extends org.jruby.ext.ffi.AbstractInvoker {
                 defineConstants(context, JFFIInvoker.class);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     JFFIInvoker(Ruby runtime, long address, Type returnType, Type[] parameterTypes, CallingConvention convention) {
         this(runtime, Access.getClass(runtime.getCurrentContext(), "FFI", "Invoker"),
                 new CodeMemoryIO(runtime, address),

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
@@ -183,7 +183,7 @@ public final class JITRuntime {
         return asFixnum(context, (byte) value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newSigned8(Ruby runtime, int value) {
         return newSigned8(runtime.getCurrentContext(), value);
     }
@@ -192,7 +192,7 @@ public final class JITRuntime {
         return asFixnum(context, (byte) value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newSigned8(Ruby runtime, long value) {
         return newSigned8(runtime.getCurrentContext(), value);
     }
@@ -202,7 +202,7 @@ public final class JITRuntime {
         return asFixnum(context, n < 0 ? ((n & 0x7F) + 0x80) : n);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newUnsigned8(Ruby runtime, int value) {
         return newUnsigned8(runtime.getCurrentContext(), value);
     }
@@ -212,7 +212,7 @@ public final class JITRuntime {
         return asFixnum(context, n < 0 ? ((n & 0x7F) + 0x80) : n);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newUnsigned8(Ruby runtime, long value) {
         return newUnsigned8(runtime.getCurrentContext(), value);
     }
@@ -221,7 +221,7 @@ public final class JITRuntime {
         return asFixnum(context, (short) value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newSigned16(Ruby runtime, int value) {
         return newSigned16(runtime.getCurrentContext(), value);
     }
@@ -230,7 +230,7 @@ public final class JITRuntime {
         return asFixnum(context, (short) value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newSigned16(Ruby runtime, long value) {
         return newSigned16(runtime.getCurrentContext(), value);
     }
@@ -240,7 +240,7 @@ public final class JITRuntime {
         return asFixnum(context, n < 0 ? ((n & 0x7FFF) + 0x8000) : n);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newUnsigned16(Ruby runtime, int value) {
         return newUnsigned16(runtime.getCurrentContext(), value);
     }
@@ -250,7 +250,7 @@ public final class JITRuntime {
         return asFixnum(context, n < 0 ? ((n & 0x7FFF) + 0x8000) : n);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newUnsigned16(Ruby runtime, long value) {
         return newUnsigned16(runtime.getCurrentContext(), value);
     }
@@ -259,7 +259,7 @@ public final class JITRuntime {
         return asFixnum(context, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newSigned32(Ruby runtime, int value) {
         return newSigned32(runtime.getCurrentContext(), value);
     }
@@ -268,7 +268,7 @@ public final class JITRuntime {
         return asFixnum(context, (int) value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newSigned32(Ruby runtime, long value) {
         return newSigned32(runtime.getCurrentContext(), value);
     }
@@ -287,7 +287,7 @@ public final class JITRuntime {
         return asFixnum(context, n < 0 ? ((n & 0x7FFFFFFFL) + 0x80000000L) : n);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newUnsigned32(Ruby runtime, long value) {
         return newUnsigned32(runtime.getCurrentContext(), value);
     }
@@ -296,7 +296,7 @@ public final class JITRuntime {
         return asFixnum(context, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newSigned64(Ruby runtime, long value) {
         return newSigned64(runtime.getCurrentContext(), value);
     }
@@ -308,7 +308,7 @@ public final class JITRuntime {
                 asFixnum(context, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newUnsigned64(Ruby runtime, long value) {
         return newUnsigned64(runtime.getCurrentContext(), value);
     }
@@ -317,7 +317,7 @@ public final class JITRuntime {
         return context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newNil(Ruby runtime, int ignored) {
         return newNil(runtime.getCurrentContext(), ignored);
     }
@@ -326,7 +326,7 @@ public final class JITRuntime {
         return context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newNil(Ruby runtime, long ignored) {
         return newNil(runtime.getCurrentContext(), ignored);
     }
@@ -398,7 +398,7 @@ public final class JITRuntime {
         return asFloat(context, Float.intBitsToFloat(value));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newFloat32(Ruby runtime, int value) {
         return newFloat32(runtime.getCurrentContext(), value);
     }
@@ -407,7 +407,7 @@ public final class JITRuntime {
         return asFloat(context, Float.intBitsToFloat((int) value));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newFloat32(Ruby runtime, long value) {
         return newFloat32(runtime.getCurrentContext(), value);
     }
@@ -416,7 +416,7 @@ public final class JITRuntime {
         return asFloat(context, Double.longBitsToDouble(value));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newFloat64(Ruby runtime, long value) {
         return newFloat64(runtime.getCurrentContext(), value);
     }

--- a/core/src/main/java/org/jruby/ext/jruby/CoreExt.java
+++ b/core/src/main/java/org/jruby/ext/jruby/CoreExt.java
@@ -47,7 +47,7 @@ import static org.jruby.api.Convert.toInt;
  * @author kares
  */
 public abstract class CoreExt {
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void loadStringExtensions(Ruby runtime) {
         loadStringExtensions(runtime.getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyExecutionContextLocal.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyExecutionContextLocal.java
@@ -75,7 +75,7 @@ public abstract class JRubyExecutionContextLocal extends RubyObject {
         return default_value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getDefaultProc() {
         return getDefaultProc(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -182,7 +182,7 @@ public class JRubyLibrary implements Library {
         return asBoolean(context, Ruby.isSecurityRestricted());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubyBoolean is_security_restricted(IRubyObject recv) {
         return is_security_restricted(((RubyBasicObject) recv).getCurrentContext(), recv);
     }

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyObjectInputStream.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyObjectInputStream.java
@@ -28,7 +28,7 @@ public class JRubyObjectInputStream extends RubyObject {
                 defineMethods(context, JRubyObjectInputStream.class);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject newInstance(IRubyObject recv, IRubyObject[] args, Block block) {
         return newInstance(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }
@@ -45,7 +45,7 @@ public class JRubyObjectInputStream extends RubyObject {
 	    super(runtime,rubyClass);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize(IRubyObject wrappedStream) {
         return initialize(getCurrentContext(), wrappedStream);
     }
@@ -61,7 +61,7 @@ public class JRubyObjectInputStream extends RubyObject {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject readObject() {
         return readObject(getCurrentContext());
     }
@@ -77,7 +77,7 @@ public class JRubyObjectInputStream extends RubyObject {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject close() {
         return close(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -92,7 +92,7 @@ public class JRubyUtilLibrary implements Library {
         return getObjectSpaceEnabled(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject setObjectSpaceEnabled(IRubyObject recv, IRubyObject arg) {
         return setObjectSpaceEnabled(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
@@ -112,7 +112,7 @@ public class JRubyUtilLibrary implements Library {
         return asBoolean(context, context.runtime.getPosix().isNative());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static IRubyObject getClassLoaderResources(IRubyObject recv, IRubyObject name) {
         return class_loader_resources(((RubyBasicObject) recv).getCurrentContext(), recv, name);
     }

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -411,21 +411,21 @@ public class RubyPathname extends RubyObject {
         return context.sites.Pathname;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     @JRubyMethod
     public IRubyObject taint(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     @JRubyMethod
     public IRubyObject untaint(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject fnmatch(ThreadContext context, IRubyObject[] args) {
         return switch (args.length) {
             case 1 -> fnmatch_p(context, args[0]);

--- a/core/src/main/java/org/jruby/ext/ripper/Warnings.java
+++ b/core/src/main/java/org/jruby/ext/ripper/Warnings.java
@@ -111,16 +111,16 @@ public interface Warnings {
     public abstract void warning(ID id, Position position, String message);
     public abstract void warning(ID id, String fileName, int lineNumber, String message);
     
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public abstract void warn(ID id, String message, Object... data);
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public abstract void warning(ID id, String message, Object... data);
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public abstract void warn(ID id, Position position, String message, Object... data);
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public abstract void warn(ID id, String fileName, int lineNumber, String message, Object... data);
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public abstract void warning(ID id, Position position, String message, Object... data);
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public abstract void warning(ID id, String fileName, int lineNumber, String message, Object...data);
 }

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -92,7 +92,7 @@ public class RubySet extends RubyObject implements Set {
             this.defaultMarshal = defaultMarshal;
         }
 
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
             defaultMarshal.marshalTo(runtime, obj, type, marshalStream);
@@ -102,7 +102,7 @@ public class RubySet extends RubyObject implements Set {
             defaultMarshal.marshalTo(context, out, obj, type, marshalStream);
         }
 
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
             Object result = defaultMarshal.unmarshalFrom(runtime, type, unmarshalStream);
@@ -367,7 +367,7 @@ public class RubySet extends RubyObject implements Set {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void clearImpl() {
         clearImpl(getCurrentContext());
     }
@@ -622,7 +622,7 @@ public class RubySet extends RubyObject implements Set {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void addImpl(final Ruby runtime, final IRubyObject obj) {
         addImpl(runtime.getCurrentContext(), obj);
     }
@@ -1199,7 +1199,7 @@ public class RubySet extends RubyObject implements Set {
         return elements(); // potentially -> to be re-defined by SortedSet
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     protected final void modifyCheck(final Ruby runtime) {
         modifyCheck(runtime.getCurrentContext());
     }
@@ -1312,14 +1312,14 @@ public class RubySet extends RubyObject implements Set {
         return JavaUtil.convertJavaToUsableRubyObject(getRuntime(), obj);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     @JRubyMethod
     public IRubyObject taint(ThreadContext context) {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @Override
     @JRubyMethod
     public IRubyObject untaint(ThreadContext context) {

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -775,7 +775,7 @@ public class RubyBasicSocket extends RubyIO {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected InetSocketAddress getInetRemoteSocket() {
         return getInetRemoteSocket(getCurrentContext());
     }
@@ -791,7 +791,7 @@ public class RubyBasicSocket extends RubyIO {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected UnixSocketAddress getUnixRemoteSocket() {
         return getUnixRemoteSocket(getCurrentContext());
     }
@@ -807,7 +807,7 @@ public class RubyBasicSocket extends RubyIO {
         return SocketType.forChannel(channel).getLocalSocketAddress(channel);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected SocketAddress getRemoteSocket() {
         return getRemoteSocket(getCurrentContext());
     }
@@ -966,7 +966,7 @@ public class RubyBasicSocket extends RubyIO {
         return newArray(context, ret0, ret1, ret2, ret3);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected static String bindContextMessage(IRubyObject host, int port) {
         return bindContextMessage(((RubyBasicObject) host).getCurrentContext(), host, port);
     }
@@ -975,42 +975,42 @@ public class RubyBasicSocket extends RubyIO {
         return "bind(2) for " + host.inspect(context) + " port " + port;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject recv(IRubyObject[] args) {
         return recv(getCurrentContext(), args);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject getsockopt(IRubyObject lev, IRubyObject optname) {
         return getsockopt(getCurrentContext(), lev, optname);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject setsockopt(IRubyObject lev, IRubyObject optname, IRubyObject val) {
         return setsockopt(getCurrentContext(), lev, optname, val);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject getsockname() {
         return getsockname(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject getpeername() {
         return getpeername(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static IRubyObject do_not_reverse_lookup(IRubyObject recv) {
         return do_not_reverse_lookup(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static IRubyObject set_do_not_reverse_lookup(IRubyObject recv, IRubyObject flag) {
         return set_do_not_reverse_lookup(((RubyBasicObject) recv).getCurrentContext(), recv, flag);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     @Override
     public IRubyObject read_nonblock(ThreadContext context, IRubyObject[] args) {
         return switch (args.length) {

--- a/core/src/main/java/org/jruby/ext/socket/RubyIPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyIPSocket.java
@@ -182,22 +182,22 @@ public class RubyIPSocket extends RubyBasicSocket {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject addr() {
         return addr(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject peeraddr() {
         return peeraddr(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static IRubyObject getaddress(IRubyObject recv, IRubyObject hostname) {
         return getaddress(((RubyBasicObject) recv).getCurrentContext(), recv, hostname);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject recvfrom(ThreadContext context, IRubyObject[] args) {
         switch (args.length) {
             case 1:

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -713,7 +713,7 @@ public class RubySocket extends RubyBasicSocket {
         return SocketType.forChannel(channel).getLocalSocketAddress(channel);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static RuntimeException sockerr(Ruby runtime, String msg) {
         return SocketUtils.sockerr(runtime, msg);
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
@@ -304,17 +304,17 @@ public class RubyTCPServer extends RubyTCPSocket {
         throw context.runtime.newErrnoENOTCONNError();
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject accept() {
         return accept(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject listen(IRubyObject backlog) {
         return listen(((RubyBasicObject) backlog).getCurrentContext(), backlog);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static IRubyObject open(IRubyObject recv, IRubyObject[] args, Block block) {
         return open(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
@@ -237,12 +237,12 @@ public class RubyTCPSocket extends RubyIPSocket {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static IRubyObject open(IRubyObject recv, IRubyObject[] args, Block block) {
         return open(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static IRubyObject gethostbyname(IRubyObject recv, IRubyObject hostname) {
         return gethostbyname(((RubyBasicObject) recv).getCurrentContext(), recv, hostname);
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -664,27 +664,27 @@ public class RubyUDPSocket extends RubyIPSocket {
     private volatile Class<? extends InetAddress> explicitFamily;
     private volatile ProtocolFamily family;
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject bind(IRubyObject host, IRubyObject port) {
         return bind(getCurrentContext(), host, port);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject connect(IRubyObject host, IRubyObject port) {
         return connect(getCurrentContext(), host, port);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject recvfrom(IRubyObject[] args) {
         return recvfrom(getCurrentContext(), args);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject send(IRubyObject[] args) {
         return send(getCurrentContext(), args);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public static IRubyObject open(IRubyObject recv, IRubyObject[] args, Block block) {
         return open(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -132,17 +132,17 @@ public class SocketUtils {
         return asFixnum(context, port);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public static IRubyObject pack_sockaddr_in(ThreadContext context, IRubyObject port, IRubyObject host) {
         return Sockaddr.pack_sockaddr_in(context, port, host);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public static RubyArray unpack_sockaddr_in(ThreadContext context, IRubyObject addr) {
         return Sockaddr.unpack_sockaddr_in(context, addr);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public static IRubyObject pack_sockaddr_un(ThreadContext context, IRubyObject filename) {
         String path = filename.convertToString().asJavaString();
         return Sockaddr.pack_sockaddr_un(context, path);
@@ -405,7 +405,7 @@ public class SocketUtils {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.10.0")
     public static InetAddress[] getRubyInetAddresses(ByteList address) throws UnknownHostException {
         // switched to String because the ByteLists were not comparing properly in 1.9 mode (encoding?
         // FIXME: Need to properly decode this string (see Helpers.decodeByteList)
@@ -664,7 +664,7 @@ public class SocketUtils {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int portToInt(IRubyObject port) {
         return portToInt(((RubyBasicObject) port).getCurrentContext(), port);
     }

--- a/core/src/main/java/org/jruby/ext/thread/ConditionVariable.java
+++ b/core/src/main/java/org/jruby/ext/thread/ConditionVariable.java
@@ -117,7 +117,7 @@ public class ConditionVariable extends RubyObject {
         return context.sites.ConditionVariable;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.8.0")
     public IRubyObject wait_ruby(ThreadContext context, IRubyObject[] args) {
         switch (args.length) {
             case 1:

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -245,7 +245,7 @@ public class Queue extends RubyObject implements DataType {
         putLock.unlock();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void initializedCheck() {
         initializedCheck(getCurrentContext());
     }
@@ -593,7 +593,7 @@ public class Queue extends RubyObject implements DataType {
         return closed;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public synchronized void checkShutdown() {
         if (isShutdown()) {
             Ruby runtime = getCurrentContext().runtime;

--- a/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
+++ b/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
@@ -297,7 +297,7 @@ public class SizedQueue extends Queue {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject push(ThreadContext context, final IRubyObject[] argv) {
         return switch (argv.length) {
             case 1 -> push(context, argv[0]);

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
@@ -59,7 +59,7 @@ public class JZlibDeflate extends ZStream {
     private com.jcraft.jzlib.Deflater flater = null;
     private int flush = JZlib.Z_NO_FLUSH;
 
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject s_deflate(IRubyObject recv, IRubyObject[] args) {
         return s_deflate(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -87,7 +87,7 @@ public class JZlibDeflate extends ZStream {
         super(runtime, type);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject _initialize(IRubyObject[] args) {
         return _initialize(getCurrentContext(), args);
     }
@@ -140,7 +140,7 @@ public class JZlibDeflate extends ZStream {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject append(IRubyObject arg) {
         return append(getCurrentContext(), arg);
     }
@@ -190,7 +190,7 @@ public class JZlibDeflate extends ZStream {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject flush(IRubyObject[] args) {
         return flush(getCurrentContext(), args);
     }
@@ -204,7 +204,7 @@ public class JZlibDeflate extends ZStream {
         return flush(context, flush);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject deflate(IRubyObject[] args) {
         return deflate(getCurrentContext(), args);
     }

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
@@ -71,7 +71,7 @@ public class JZlibInflate extends ZStream {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject _initialize(IRubyObject[] args) {
          return _initialize(getCurrentContext(), args);
     }
@@ -127,7 +127,7 @@ public class JZlibInflate extends ZStream {
         return this;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
      public void append(ByteList obj) {
         append(getCurrentContext(), obj);
      }
@@ -141,7 +141,7 @@ public class JZlibInflate extends ZStream {
         run(context, false);
     }
 
-     @Deprecated(since = "10.0")
+     @Deprecated(since = "10.0.0.0")
      public IRubyObject sync_point_p() {
          return sync_point_p(getCurrentContext());
      }
@@ -151,7 +151,7 @@ public class JZlibInflate extends ZStream {
          return sync_point(context);
      }
 
-     @Deprecated(since = "10.0")
+     @Deprecated(since = "10.0.0.0")
      public IRubyObject sync_point() {
          return sync_point(getCurrentContext());
      }

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -83,7 +83,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return RubyGzipFile.wrapBlock(context, result, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static JZlibRubyGzipReader newInstance(IRubyObject recv, IRubyObject[] args) {
         return newInstance(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args);
     }
@@ -189,7 +189,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return asFixnum(context, line);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject lineno() {
         return lineno(getCurrentContext());
     }
@@ -346,7 +346,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject readpartial(IRubyObject[] args) {
         return readpartial(getCurrentContext(), args);
     }
@@ -431,7 +431,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return new ByteList(buffer, 0, length - toRead, false);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_lineno(IRubyObject lineArg) {
         return set_lineno(getCurrentContext(), lineArg);
     }
@@ -443,7 +443,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return lineArg;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject pos() {
         return pos(getCurrentContext());
     }
@@ -453,7 +453,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return asFixnum(context, position);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject readchar() {
         return readchar(getCurrentContext());
     }
@@ -472,7 +472,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getc() {
         return getbyte(getCurrentContext());
     }
@@ -491,12 +491,12 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getbyte() {
         return getbyte(getCurrentContext());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject readbyte() {
         return readbyte(getCurrentContext());
     }
@@ -571,7 +571,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return realIo;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject eof() {
         return eof(getCurrentContext());
     }
@@ -585,7 +585,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject eof_p() {
         return eof_p(getCurrentContext());
     }
@@ -595,7 +595,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return eof(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject unused() {
         return unused(getCurrentContext());
     }
@@ -699,7 +699,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject ungetbyte(IRubyObject b) {
         return ungetbyte(getCurrentContext(), b);
     }

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -73,7 +73,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return RubyGzipFile.wrapBlock(context, result, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static JZlibRubyGzipWriter newInstance(IRubyObject recv, IRubyObject[] args) {
         return newInstance(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args);
     }
@@ -100,7 +100,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         super(runtime, type);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject initialize(IRubyObject[] args) {
         return initialize(getCurrentContext(), args, Block.NULL_BLOCK);
     }
@@ -219,7 +219,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
      * @return
      * @deprecated Use {@link JZlibRubyGzipWriter#print(ThreadContext, IRubyObject[])} instead.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject print(IRubyObject[] args) {
         return print(getCurrentContext(), args);
     }
@@ -238,7 +238,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject pos() {
         return pos(getCurrentContext());
     }
@@ -248,7 +248,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return asFixnum(context, io.getTotalIn());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_orig_name(IRubyObject obj) {
         return set_orig_name(getCurrentContext(), obj);
     }
@@ -266,7 +266,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return obj;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_comment(IRubyObject obj) {
         return set_comment(getCurrentContext(), obj);
     }
@@ -295,7 +295,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return obj;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject putc(IRubyObject p1) {
         return putc(getCurrentContext(), p1);
     }
@@ -331,7 +331,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return realIo;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject flush(IRubyObject[] args) {
         return flush(getCurrentContext(), args);
     }
@@ -358,7 +358,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_mtime(IRubyObject arg) {
         return set_mtime(getCurrentContext(), arg);
     }
@@ -393,7 +393,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return asFixnum(context, crc);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject write(IRubyObject p1) {
         return write(getCurrentContext(), p1);
     }

--- a/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
@@ -79,12 +79,12 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return instance;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject wrap(ThreadContext context, IRubyObject recv, IRubyObject io, Block block) {
         return wrap(context, recv, new IRubyObject[]{io}, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject wrap19(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         return wrap(context, recv, args, block);
     }
@@ -98,7 +98,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return wrapBlock(context, instance, block);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyGzipFile newInstance(IRubyObject recv, Block block) {
         return newInstance(((RubyBasicObject) recv).getCurrentContext(), recv, block);
     }
@@ -159,7 +159,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public Encoding getReadEncoding() {
         return getReadEncoding(getCurrentContext());
     }
@@ -180,7 +180,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return enc2;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected RubyString newStr(Ruby runtime, ByteList value) {
         return newStr(runtime.getCurrentContext(), value);
     }
@@ -194,7 +194,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
                 EncodingUtils.strConvEncOpts(context, newString(context, value), enc2, enc, ecflags, ecopts);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject os_code() {
         return os_code(getCurrentContext());
     }
@@ -204,7 +204,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return asFixnum(context, osCode & 0xff);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject closed_p() {
         return closed_p(getCurrentContext());
     }
@@ -218,7 +218,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return closed;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject orig_name() {
         return orig_name(getCurrentContext());
     }
@@ -230,7 +230,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return nullFreeOrigName == null ? context.nil : nullFreeOrigName;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject to_io() {
         return to_io(getCurrentContext());
     }
@@ -240,7 +240,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return realIo;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject comment() {
         return comment(getCurrentContext());
     }
@@ -252,7 +252,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return nullFreeComment == null ? context.nil : nullFreeComment;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject crc() {
         return crc(getCurrentContext());
     }
@@ -267,7 +267,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return mtime;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject sync() {
         return sync(getCurrentContext());
     }
@@ -277,7 +277,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return sync ? context.tru : context.fals;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject finish() {
         return finish(getCurrentContext());
     }
@@ -291,7 +291,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return realIo;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject close() {
         return close(getCurrentContext());
     }
@@ -301,7 +301,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return realIo;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject level() {
         return level(getCurrentContext());
     }
@@ -311,7 +311,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return asFixnum(context, level);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_sync(IRubyObject arg) {
         return set_sync(getCurrentContext(), arg);
     }

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -187,7 +187,7 @@ public class RubyZlib {
     @JRubyClass(name="Zlib::DataError", parent="Zlib::Error")
     public static class DataError extends Error {}
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject zlib_version(IRubyObject recv) {
         return zlib_version(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -218,7 +218,7 @@ public class RubyZlib {
         return asFixnum(context, result);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject crc32(IRubyObject recv, IRubyObject[] args) {
         return crc32(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -238,7 +238,7 @@ public class RubyZlib {
         return asFixnum(context, result);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject adler32(IRubyObject recv, IRubyObject[] args) {
         return adler32(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -248,7 +248,7 @@ public class RubyZlib {
         return JZlibInflate.s_inflate(context, recv, string);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject deflate(IRubyObject recv, IRubyObject[] args) {
         return deflate(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -266,7 +266,7 @@ public class RubyZlib {
         return result;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject crc_table(IRubyObject recv) {
         return crc_table(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
@@ -281,7 +281,7 @@ public class RubyZlib {
         return asFixnum(context, com.jcraft.jzlib.JZlib.crc32_combine(crc1, crc2, len2));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject crc32_combine(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return crc32_combine(((RubyBasicObject) recv).getCurrentContext(), recv, arg0, arg1, arg2);
     }
@@ -296,7 +296,7 @@ public class RubyZlib {
         return asFixnum(context, com.jcraft.jzlib.JZlib.adler32_combine(adler1, adler2, len2));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject adler32_combine(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return adler32_combine(((RubyBasicObject) recv).getCurrentContext(), recv, arg0, arg1, arg2);
     }

--- a/core/src/main/java/org/jruby/ext/zlib/ZStream.java
+++ b/core/src/main/java/org/jruby/ext/zlib/ZStream.java
@@ -55,7 +55,7 @@ public abstract class ZStream extends RubyObject {
 
     protected abstract boolean internalStreamEndP();
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected void internalReset() {
         internalReset(getCurrentContext());
     }
@@ -68,7 +68,7 @@ public abstract class ZStream extends RubyObject {
 
     protected abstract long internalAdler();
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected IRubyObject internalFinish(Block block) {
         return internalFinish(getCurrentContext(), block);
     }
@@ -94,7 +94,7 @@ public abstract class ZStream extends RubyObject {
         return RubyString.newEmptyBinaryString(context.getRuntime());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject total_out() {
         return total_out(getCurrentContext());
     }
@@ -105,7 +105,7 @@ public abstract class ZStream extends RubyObject {
         return asFixnum(context, internalTotalOut());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject stream_end_p() {
         return stream_end_p(getCurrentContext());
     }
@@ -115,7 +115,7 @@ public abstract class ZStream extends RubyObject {
         return internalStreamEndP() ? context.tru : context.fals;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject data_type() {
         return data_type(getCurrentContext());
     }
@@ -126,7 +126,7 @@ public abstract class ZStream extends RubyObject {
         return getModule(context, "Zlib").getConstant(context, "UNKNOWN");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject closed_p() {
         return closed_p(getCurrentContext());
     }
@@ -136,7 +136,7 @@ public abstract class ZStream extends RubyObject {
         return closed ? context.tru : context.fals;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject reset() {
         return reset(getCurrentContext());
     }
@@ -149,7 +149,7 @@ public abstract class ZStream extends RubyObject {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject avail_out() {
         return avail_out(getCurrentContext());
     }
@@ -159,7 +159,7 @@ public abstract class ZStream extends RubyObject {
         return asFixnum(context, 0);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject set_avail_out(IRubyObject p1) {
         return set_avail_out(getCurrentContext(), p1);
     }
@@ -178,7 +178,7 @@ public abstract class ZStream extends RubyObject {
         return asFixnum(context, internalAdler());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject adler() {
         return adler(getCurrentContext());
     }
@@ -192,7 +192,7 @@ public abstract class ZStream extends RubyObject {
         return result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject avail_in() {
         return avail_in(getCurrentContext());
     }
@@ -207,7 +207,7 @@ public abstract class ZStream extends RubyObject {
         return RubyString.newEmptyBinaryString(context.getRuntime());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject total_in() {
         return total_in(getCurrentContext());
     }
@@ -224,7 +224,7 @@ public abstract class ZStream extends RubyObject {
         return asBoolean(context, internalFinished());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject close() {
         return close(getCurrentContext());
     }
@@ -237,7 +237,7 @@ public abstract class ZStream extends RubyObject {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     void checkClosed() {
         checkClosed(getCurrentContext());
     }
@@ -280,7 +280,7 @@ public abstract class ZStream extends RubyObject {
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static void checkStrategy(Ruby runtime, int strategy) {
         checkStrategy(runtime.getCurrentContext(), strategy);
     }

--- a/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
@@ -120,7 +120,7 @@ public class AdoptedNativeThread implements ThreadLike {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public String getRubyName() {
         Thread thread = getThread();
         if (thread != null) return thread.getName();

--- a/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
@@ -101,7 +101,7 @@ public class RubyNativeThread implements ThreadLike {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public String getRubyName() {
         return rubyName;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
@@ -73,7 +73,7 @@ public class RubyRunnable implements ThreadedRunnable {
         this.creatorContext = creatorContext;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.5")
     public RubyThread getRubyThread() {
         return rubyThread;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -302,41 +302,41 @@ public class ThreadService extends ThreadLocal<SoftReference<ThreadContext>> {
         return threadCount.incrementAndGet();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.15.0")
     public Map<Object, RubyThread> getRubyThreadMap() {
         return (Map<Object, RubyThread>) (Map) rubyThreadMap;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public void deliverEvent(RubyThread sender, RubyThread target, Event event) {
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.15.0")
     public ThreadGroup getRubyThreadGroup() {
         return rubyThreadGroup;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.15.0")
     public ThreadContext getThreadContextForThread(RubyThread thread) {
         return thread.getContext();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.15.0")
     public synchronized void dissociateThread(Object thread) {
         rubyThreadMap.remove(thread);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.15.0")
     public final void setCurrentContext(ThreadContext context) {
         set(new SoftReference<ThreadContext>(context));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.15.0")
     public boolean getPolling() {
         return rubyThreadMap.size() > 1;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static class Event {
         public enum Type { KILL, RAISE, WAKEUP }
         public final String description;
@@ -362,23 +362,23 @@ public class ThreadService extends ThreadLocal<SoftReference<ThreadContext>> {
             return ""; // not reached
         }
 
-        @Deprecated
+        @Deprecated(since = "9.0.0.0")
         public static Event kill(RubyThread sender, RubyThread target, Type type) {
             return new Event(sender.toString() + " sent KILL to " + target, type);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.0.0.0")
         public static Event raise(RubyThread sender, RubyThread target, Type type, IRubyObject exception) {
             return new Event(sender.toString() + " sent KILL to " + target, type, exception);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.0.0.0")
         public static Event wakeup(RubyThread sender, RubyThread target, Type type) {
             return new Event(sender.toString() + " sent KILL to " + target, type);
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public void setCritical(boolean critical) {
         if (critical && !criticalLock.isHeldByCurrentThread()) {
             acquireCritical();
@@ -387,17 +387,17 @@ public class ThreadService extends ThreadLocal<SoftReference<ThreadContext>> {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     private void acquireCritical() {
         criticalLock.lock();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     private void releaseCritical() {
         criticalLock.unlock();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public boolean getCritical() {
         return criticalLock.isHeldByCurrentThread();
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AttrReaderMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AttrReaderMethod.java
@@ -91,7 +91,7 @@ public class AttrReaderMethod extends JavaMethodZero {
     }
 
     // Used by racc extension, needed for backward-compat with 1.7.
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public AttrReaderMethod(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfiguration, String variableName) {
         this(implementationClass, visibility, variableName);
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AttrWriterMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AttrWriterMethod.java
@@ -87,7 +87,7 @@ public class AttrWriterMethod extends JavaMethodOne {
     }
 
     // Used by racc extension, needed for backward-compat with 1.7.
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public AttrWriterMethod(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfiguration, String variableName) {
         this(implementationClass, visibility, variableName);
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CallConfiguration.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CallConfiguration.java
@@ -89,23 +89,23 @@ public enum CallConfiguration {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration FRAME_AND_SCOPE = FrameFullScopeFull;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration FRAME_AND_DUMMY_SCOPE = FrameFullScopeDummy;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration FRAME_ONLY = FrameFullScopeNone;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration BACKTRACE_AND_SCOPE = FrameBacktraceScopeFull;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration BACKTRACE_DUMMY_SCOPE = FrameBacktraceScopeNone;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration BACKTRACE_ONLY = FrameBacktraceScopeNone;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration SCOPE_ONLY = FrameNoneScopeFull;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration NO_FRAME_DUMMY_SCOPE = FrameNoneScopeDummy;
-    @Deprecated
+    @Deprecated(since = "1.2")
     public static final CallConfiguration NO_FRAME_NO_SCOPE = FrameNoneScopeNone;
 
     /**
@@ -165,7 +165,7 @@ public enum CallConfiguration {
     abstract void post(ThreadContext context);
     boolean isNoop() { return framing == Framing.None && scoping == Scoping.None; }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static CallConfiguration getCallConfig(boolean frame, boolean scope, boolean backtrace) {
         return getCallConfig(frame, scope);
     }
@@ -175,7 +175,7 @@ public enum CallConfiguration {
      *
      * @see org.jruby.anno.AnnotationHelper#getCallConfigName(boolean, boolean)
      */
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public static CallConfiguration getCallConfig(boolean frame, boolean scope) {
         if (frame) {
             if (scope) {

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DescriptorInfo.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DescriptorInfo.java
@@ -135,7 +135,7 @@ public class DescriptorInfo {
         parameterDesc = descBuilder.toString();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.5.0")
     public boolean isBacktrace() {
         return false;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -429,7 +429,7 @@ public abstract class DynamicMethod {
      *
      * @return The arity of the method, as reported to Ruby consumers.
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public Arity getArity() {
         return Arity.optional();
     }
@@ -644,27 +644,27 @@ public abstract class DynamicMethod {
         return false;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     protected DynamicMethod(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
         this(implementationClass, visibility);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     protected DynamicMethod(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
         this(implementationClass, visibility, name);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     protected void init(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
         init(implementationClass, visibility);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public CallConfiguration getCallConfig() {
         return CallConfiguration.FrameNoneScopeNone;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void setCallConfig(CallConfiguration callConfig) {
     }
 
@@ -673,7 +673,7 @@ public abstract class DynamicMethod {
      * @param visibility of the method
      * @deprecated Use {@link DynamicMethod#DynamicMethod(RubyModule, Visibility, String)}
      */
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     protected DynamicMethod(RubyModule implementationClass, Visibility visibility) {
         this(implementationClass, visibility, "(anonymous)");
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -263,7 +263,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         tryJit(context, this, false);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public String getClassName(ThreadContext context) {
         return null;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
@@ -846,6 +846,6 @@ public class InvocationMethodFactory extends MethodFactory implements Opcodes {
         method.invokevirtual(p(JavaMethod.class), "returnTrace", sig(void.class, ThreadContext.class, boolean.class, String.class));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     private static final Class[] RubyModule_and_Visibility = new Class[]{ RubyModule.class, Visibility.class };
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/JavaMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/JavaMethod.java
@@ -111,19 +111,19 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
     }
 
     // Still used by exts like jruby-openssl. Regeneration should pick up new ones above.
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     protected final void preFrameAndScope(ThreadContext context, IRubyObject self, String name, Block block) {
         context.preMethodFrameAndScope(getImplementationClass(), name, self, block, staticScope);
     }
 
     // Still used by exts like jruby-openssl. Regeneration should pick up new ones above.
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     protected final void preFrameAndDummyScope(ThreadContext context, IRubyObject self, String name, Block block) {
         context.preMethodFrameAndDummyScope(getImplementationClass(), name, self, block, staticScope);
     }
 
     // Still used by exts like jruby-openssl. Regeneration should pick up new ones above.
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     protected final void preFrameOnly(ThreadContext context, IRubyObject self, String name, Block block) {
         context.preMethodFrameOnly(getImplementationClass(), name, self, block);
     }
@@ -196,7 +196,7 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         if (enabled) context.trace(RubyEvent.RETURN, Helpers.getSuperNameFromCompositeName(name), getImplementationClass());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public void setArity(Arity arity) {
         this.signature = Signature.from(arity);
     }
@@ -297,15 +297,15 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
             super(implementationClass, visibility, name);
         }
@@ -317,11 +317,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -339,11 +339,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -361,11 +361,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwoOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwoOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwoOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -383,11 +383,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -407,11 +407,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -429,11 +429,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwoOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwoOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwoOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -451,11 +451,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -475,11 +475,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodTwoOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodTwoOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwoOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -497,11 +497,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwoOrThreeOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -521,11 +521,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodThreeOrNBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodThreeOrNBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodThreeOrNBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -545,11 +545,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -564,11 +564,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -589,11 +589,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwoBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwoBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwoBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -616,11 +616,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -646,11 +646,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -674,11 +674,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwoBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwoBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwoBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -699,11 +699,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -728,11 +728,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodTwoBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodTwoBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwoBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -747,11 +747,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwoOrThreeBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -774,11 +774,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodThreeBlock(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodThreeBlock(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodThreeBlock(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -794,15 +794,15 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
             super(implementationClass, visibility, name);
         }
@@ -854,15 +854,15 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
             super(implementationClass, visibility, name);
         }
@@ -880,11 +880,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -902,11 +902,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwoOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwoOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwoOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -924,11 +924,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -948,15 +948,15 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
             super(implementationClass, visibility, name);
         }
@@ -974,11 +974,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwoOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwoOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwoOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -996,11 +996,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1020,11 +1020,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodTwoOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodTwoOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwoOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1042,11 +1042,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwoOrThreeOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1066,11 +1066,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodThreeOrN(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodThreeOrN(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodThreeOrN(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1090,15 +1090,15 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZero(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZero(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZero(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZero(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
             super(implementationClass, visibility, name);
         }
@@ -1121,11 +1121,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOne(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOne(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOne(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1147,11 +1147,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwo(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwo(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwo(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1175,11 +1175,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodZeroOrOneOrTwoOrThree(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodZeroOrOneOrTwoOrThree(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodZeroOrOneOrTwoOrThree(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1207,17 +1207,17 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
             super(implementationClass, visibility, name);
             setParameterList(ONE_REQ);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOne(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
             setParameterList(ONE_REQ);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOne(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
             setParameterList(ONE_REQ);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOne(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
             super(implementationClass, visibility, name);
             setParameterList(ONE_REQ);
@@ -1242,11 +1242,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwo(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwo(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwo(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1267,11 +1267,11 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodOneOrTwoOrThree(RubyModule implementationClass, Visibility visibility, String name) {
             super(implementationClass, visibility, name);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodOneOrTwoOrThree(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodOneOrTwoOrThree(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1297,12 +1297,12 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
             super(implementationClass, visibility, name);
             setParameterList(TWO_REQ);
         }
-        @Deprecated
+        @Deprecated(since = "9.1.16.0")
         public JavaMethodTwo(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
             setParameterList(TWO_REQ);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwo(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
             setParameterList(TWO_REQ);
@@ -1331,7 +1331,7 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         public JavaMethodTwoOrThree(RubyModule implementationClass, Visibility visibility) {
             super(implementationClass, visibility);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodTwoOrThree(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1359,7 +1359,7 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
             super(implementationClass, visibility);
             setParameterList(THREE_REQ);
         }
-        @Deprecated
+        @Deprecated(since = "9.0.1.0")
         public JavaMethodThree(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
             super(implementationClass, visibility);
         }
@@ -1379,32 +1379,32 @@ public abstract class JavaMethod extends DynamicMethod implements Cloneable, Met
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public JavaMethod(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig) {
         super(implementationClass, visibility);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public JavaMethod(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfig, String name) {
         super(implementationClass, visibility, name);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public CallConfiguration getCallerRequirement() {
         return CallConfiguration.FrameNoneScopeNone;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.1.0")
     public void setCallerRequirement(CallConfiguration callerRequirement) {
     }
 
     /**
      * Used for old-style nameless constructor to pass name in out-of-band.
      */
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     public static final ThreadLocal<String> NAME_PASSER = new ThreadLocal<>();
 
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     public JavaMethod(RubyModule implementationClass, Visibility visibility) {
         this(implementationClass, visibility, NAME_PASSER.get());
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/NullMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/NullMethod.java
@@ -108,7 +108,7 @@ public class NullMethod extends DynamicMethod {
      * @param callConfig Ignored
      */
     @Override
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public void setCallConfig(CallConfiguration callConfig) {
         throw new UnsupportedOperationException("BUG: NullMethod is immutable: setCallConfig called; report at http://bugs.jruby.org");
         // NullMethod should be immutable

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -194,7 +194,7 @@ public class IRMethod extends IRScope {
      * This method was renamed (due a typo).
      * @see #builtInterpreterContextForJavaConstructor()
      */
-    @Deprecated
+    @Deprecated(since = "9.3.11.0")
     public ExitableInterpreterContext builtInterperterContextForJavaConstructor() {
         return builtInterpreterContextForJavaConstructor();
     }

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -386,7 +386,7 @@ public abstract class IRScope implements ParseResult {
         throw new IllegalArgumentException("This is only here because prism requires this in ParseResult");
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public String getFileName() {
         return getFile();
     }
@@ -395,7 +395,7 @@ public abstract class IRScope implements ParseResult {
         return getRootLexicalScope().getFile();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public int getLineNumber() {
         return lineNumber;
     }

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -1280,7 +1280,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
     }
 
     // Pre-Ruby 3.4 path for JRuby 9.4.x.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     protected Operand buildDStr(Variable result, U[] nodePieces, Encoding encoding, boolean isFrozen, int line) {
         if (result == null) result = temp();
 
@@ -1924,7 +1924,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
 
     protected abstract Operand buildColon2ForConstAsgnDeclNode(U lhs, Variable valueResult, boolean constMissing);
 
-    @Deprecated
+    @Deprecated(since = "9.4.7.0")
     protected Operand buildOpAsgnConstDecl(Y left, U right, RubySymbol operator) {
         Operand lhs = build((U) left);
         Operand rhs = build(right);
@@ -1940,7 +1940,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         return copy(temp(), putConstant(parent, name, result));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     protected abstract Operand putConstant(Y constant, Operand value);
     protected abstract Operand putConstant(Y constant, CodeBlock value);
 

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -125,7 +125,7 @@ import static org.jruby.runtime.ThreadContext.*;
 // this is not a big deal.  Think this through!
 
 public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyNode, Colon3Node, HashNode> {
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static Node buildAST(boolean isCommandLineScript, String arg) {
         Ruby ruby = Ruby.getGlobalRuntime();
 
@@ -1351,7 +1351,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     protected Operand putConstant(Colon3Node colonNode, Operand value) {
         if (colonNode.getNodeType() == NodeType.COLON2NODE) {
             Colon2Node colon2Node = (Colon2Node) colonNode;

--- a/core/src/main/java/org/jruby/ir/instructions/CheckForLJEInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CheckForLJEInstr.java
@@ -27,7 +27,7 @@ public class CheckForLJEInstr extends NoOperandInstr {
         this.definedWithinMethod = notDefinedWithinMethod;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.9.0")
     public boolean maybeLambda() {
         return !definedWithinMethod;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/InheritanceSearchConstInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/InheritanceSearchConstInstr.java
@@ -50,7 +50,7 @@ public class InheritanceSearchConstInstr extends OneOperandResultBaseInstr imple
         return constName;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public boolean isNoPrivateConsts() {
         return false;
     }

--- a/core/src/main/java/org/jruby/ir/operands/UndefinedValue.java
+++ b/core/src/main/java/org/jruby/ir/operands/UndefinedValue.java
@@ -59,7 +59,7 @@ public class UndefinedValue extends Operand implements IRubyObject {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject callSuper(ThreadContext context, IRubyObject[] args, Block block) { throw undefinedOperation(); }
 
     @Override
@@ -71,9 +71,9 @@ public class UndefinedValue extends Operand implements IRubyObject {
     @Override
     public IRubyObject callMethod(ThreadContext context, String name, IRubyObject[] args, Block block) { throw undefinedOperation(); }
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject callMethod(ThreadContext context, int methodIndex, String name) { throw undefinedOperation(); }
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public IRubyObject callMethod(ThreadContext context, int methodIndex, String name, IRubyObject arg) { throw undefinedOperation(); }
 
     @Override
@@ -254,7 +254,7 @@ public class UndefinedValue extends Operand implements IRubyObject {
     public int getVariableCount() { throw undefinedOperation(); }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     public void syncVariables(List<Variable<Object>> variables) { throw undefinedOperation(); }
 
     @Override
@@ -299,26 +299,26 @@ public class UndefinedValue extends Operand implements IRubyObject {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public Object dataGetStructChecked() { throw undefinedOperation(); }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public boolean isTaint() { throw undefinedOperation(); }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public void setTaint(boolean b) { throw undefinedOperation(); }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject infectBy(IRubyObject obj) { throw undefinedOperation(); }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public boolean isUntrusted() { throw undefinedOperation(); }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public void setUntrusted(boolean b) { throw undefinedOperation(); }
 }

--- a/core/src/main/java/org/jruby/ir/runtime/IRBreakJump.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRBreakJump.java
@@ -15,7 +15,7 @@ public class IRBreakJump extends IRJump implements Unrescuable {
         this.breakInEval = breakInEval;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.9.0")
     public static IRBreakJump create(DynamicScope scopeToReturnTo, IRubyObject rv) {
         return new IRBreakJump(scopeToReturnTo, rv, false);
     }

--- a/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
@@ -65,7 +65,7 @@ public class KernelJavaAddons {
         return newArray;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject java_signature(IRubyObject recv, IRubyObject[] args) {
         return java_signature(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -75,7 +75,7 @@ public class KernelJavaAddons {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject java_name(IRubyObject recv, IRubyObject[] args) {
         return java_name(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -85,7 +85,7 @@ public class KernelJavaAddons {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject java_implements(IRubyObject recv, IRubyObject[] args) {
         return java_implements(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -95,7 +95,7 @@ public class KernelJavaAddons {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject java_annotation(IRubyObject recv, IRubyObject[] args) {
         return java_annotation(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -105,7 +105,7 @@ public class KernelJavaAddons {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject java_require(IRubyObject recv, IRubyObject[] args) {
         return java_require(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -115,7 +115,7 @@ public class KernelJavaAddons {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject java_package(IRubyObject recv, IRubyObject[] args) {
         return java_package(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
@@ -125,7 +125,7 @@ public class KernelJavaAddons {
         return context.nil;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject java_field(IRubyObject recv, IRubyObject[] args) {
         return java_field(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }

--- a/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
+++ b/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
@@ -793,13 +793,13 @@ public class CallableSelector {
      * @param <T> the callable type
      * @return cache usable with {@link CallableSelector}
      */
-    @Deprecated
+    @Deprecated(since = "9.0.4.0")
     public static <T extends ParameterTypes> IntHashMap<T> newCallableCache() {
         return new IntHashMap<T>(8);
     }
 
     @SuppressWarnings("unchecked")
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static ParameterTypes matchingCallableArityN(Ruby runtime, Map cache, ParameterTypes[] methods, IRubyObject[] args) {
         final int signatureCode = argsHashCode(args);
         ParameterTypes method = (ParameterTypes) cache.get(signatureCode);
@@ -814,7 +814,7 @@ public class CallableSelector {
     // when there's already a cached match. Do not condense them into a single
     // method.
     @SuppressWarnings("unchecked")
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static JavaCallable matchingCallableArityN(Ruby runtime, Map cache, JavaCallable[] methods, IRubyObject[] args) {
         final int signatureCode = argsHashCode(args);
         JavaCallable method = (JavaCallable) cache.get(signatureCode);
@@ -825,7 +825,7 @@ public class CallableSelector {
         return method;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static JavaCallable matchingCallableArityOne(Ruby runtime, Map cache, JavaCallable[] methods, IRubyObject arg0) {
         final int signatureCode = argsHashCode(arg0);
         JavaCallable method = (JavaCallable) cache.get(signatureCode);
@@ -836,7 +836,7 @@ public class CallableSelector {
         return method;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static JavaCallable matchingCallableArityTwo(Ruby runtime, Map cache, JavaCallable[] methods, IRubyObject arg0, IRubyObject arg1) {
         final int signatureCode = argsHashCode(arg0, arg1);
         JavaCallable method = (JavaCallable) cache.get(signatureCode);
@@ -847,7 +847,7 @@ public class CallableSelector {
         return method;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static JavaCallable matchingCallableArityThree(Ruby runtime, Map cache, JavaCallable[] methods, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         final int signatureCode = argsHashCode(arg0, arg1, arg2);
         JavaCallable method = (JavaCallable) cache.get(signatureCode);
@@ -858,7 +858,7 @@ public class CallableSelector {
         return method;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static JavaCallable matchingCallableArityFour(Ruby runtime, Map cache, JavaCallable[] methods, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
         final int signatureCode = argsHashCode(arg0, arg1, arg2, arg3);
         JavaCallable method = (JavaCallable) cache.get(signatureCode);

--- a/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
@@ -47,7 +47,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     protected boolean isMemberVarArgs(Member member) {
         return ((Constructor) member).isVarArgs();
     }

--- a/core/src/main/java/org/jruby/java/invokers/MethodInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/MethodInvoker.java
@@ -40,7 +40,7 @@ public abstract class MethodInvoker extends RubyToJavaInvoker {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     protected final boolean isMemberVarArgs(Member member) {
         return ((Method) member).isVarArgs();
     }

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -48,7 +48,7 @@ public final class ArrayJavaProxy extends JavaProxy {
                 tap(c -> c.singletonClass(context).addMethod(context, "new", new ArrayNewMethod(c.singletonClass(context), Visibility.PUBLIC)));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static ArrayJavaProxy newArray(final Ruby runtime, final Class<?> elementType, final int... dimensions) {
         return newArray(runtime.getCurrentContext(), elementType, dimensions);
     }
@@ -64,12 +64,12 @@ public final class ArrayJavaProxy extends JavaProxy {
     }
 
     @Override
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     protected org.jruby.javasupport.JavaArray asJavaObject(final Object array) {
         return new org.jruby.javasupport.JavaArray(getCurrentContext().runtime, array);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public final org.jruby.javasupport.JavaArray getJavaArray() {
         return asJavaObject(this.object);
     }

--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -426,7 +426,7 @@ public class ConcreteJavaProxy extends JavaProxy {
         if (getObject() == null) setObject(self);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected static void initialize(final RubyClass concreteJavaProxy) {
         initialize(concreteJavaProxy.getRuntime().getCurrentContext(), concreteJavaProxy);
     }

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -122,7 +122,7 @@ public class JavaProxy extends RubyObject {
         setJavaClass(target.getClassRuntime(), target, javaClass);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void setJavaClass(final IRubyObject target, final Class<?> javaClass) {
         setJavaClass(((RubyBasicObject) target).getCurrentContext(), target, javaClass);
     }
@@ -185,7 +185,7 @@ public class JavaProxy extends RubyObject {
         return Helpers.invokeSuper(context, recv, subclass, Block.NULL_BLOCK);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass singleton_class(final IRubyObject self) {
         return singleton_class(self.getRuntime().getCurrentContext(), self);
     }
@@ -458,7 +458,7 @@ public class JavaProxy extends RubyObject {
         return getRubyMethod(context, name, argTypesClasses);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject marshal_dump() {
         return marshal_dump(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -378,7 +378,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
             replaceExternally(context, otherHash);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         @Override
         public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
             return super.any_p(context, args, block);
@@ -709,7 +709,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return getOrCreateRubyHashMap(context.runtime).invert(context);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyHash merge_bang(final ThreadContext context, final IRubyObject other, final Block block) {
         return merge_bang(context, new IRubyObject[]{other}, block);
     }
@@ -722,7 +722,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return getOrCreateRubyHashMap(context.runtime).merge_bang(context, others, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyHash merge(ThreadContext context, IRubyObject other, Block block) {
         return merge(context, new IRubyObject[]{other}, block);
     }
@@ -859,12 +859,12 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return getOrCreateRubyHashMap(getRuntime());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public IRubyObject sort(ThreadContext context, Block block) {
         return getOrCreateRubyHashMap(context.runtime).sort(context, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
         return getOrCreateRubyHashMap(context.runtime).any_p(context, args, block);
     }

--- a/core/src/main/java/org/jruby/java/util/ArrayUtils.java
+++ b/core/src/main/java/org/jruby/java/util/ArrayUtils.java
@@ -45,7 +45,7 @@ public class ArrayUtils {
         return proxy;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static ArrayJavaProxy newProxiedArray(Ruby runtime, Class<?> componentType, int size) {
         return newProxiedArray(runtime.getCurrentContext(), componentType, size);
     }
@@ -54,7 +54,7 @@ public class ArrayUtils {
         return newProxiedArray(context, componentType, JavaUtil.getJavaConverter(componentType), size);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static ArrayJavaProxy newProxiedArray(Ruby runtime, Class<?> componentType, JavaUtil.JavaConverter converter, int size) {
         return newProxiedArray(runtime.getCurrentContext(), componentType, converter, size);
     }
@@ -134,7 +134,7 @@ public class ArrayUtils {
                 array.getClass().getComponentType().getName() + ')');
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.8.0")
     public static void copyDataToJavaArrayDirect(ThreadContext context,
         final RubyArray rubyArray, final Object javaArray) {
         copyDataToJavaArrayDirect(rubyArray, javaArray);

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -218,7 +218,7 @@ public class Java implements Library {
     }
 
     public static class OldStyleExtensionInherited {
-        @Deprecated
+        @Deprecated(since = "9.1.0.0")
         public static IRubyObject inherited(IRubyObject self, IRubyObject subclass) {
             return inherited(((RubyBasicObject) self).getCurrentContext(), self, subclass);
         }
@@ -230,7 +230,7 @@ public class Java implements Library {
     };
 
     public static class NewStyleExtensionInherited {
-        @Deprecated
+        @Deprecated(since = "9.1.0.0")
         public static IRubyObject inherited(IRubyObject self, IRubyObject subclass) {
             return inherited(((RubyBasicObject) self).getCurrentContext(), self, subclass);
         }
@@ -242,7 +242,7 @@ public class Java implements Library {
         }
     }
 
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject create_proxy_class(IRubyObject self, IRubyObject name, IRubyObject javaClass, IRubyObject mod) {
         var context = ((RubyBasicObject) self).getCurrentContext();
         RubyModule module = castAsModule(context, mod);
@@ -250,7 +250,7 @@ public class Java implements Library {
         return setProxyClass(context, module, name.asJavaString(), resolveJavaClassArgument(context, javaClass));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule setProxyClass(final Ruby runtime, final RubyModule target, final String constName,
                                            final Class<?> javaClass) throws NameError {
         return setProxyClass(runtime.getCurrentContext(), target, constName, javaClass);
@@ -320,7 +320,7 @@ public class Java implements Library {
         return getInterfaceModule(runtime.getCurrentContext(), javaClass.javaClass());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule getInterfaceModule(final Ruby runtime, final Class javaClass) {
         return getInterfaceModule(runtime.getCurrentContext(), javaClass);
     }
@@ -329,7 +329,7 @@ public class Java implements Library {
         return Java.getProxyClass(context, javaClass);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule get_interface_module(final Ruby runtime, final IRubyObject java_class) {
         return get_interface_module(runtime.getCurrentContext(), java_class);
     }
@@ -338,7 +338,7 @@ public class Java implements Library {
         return getInterfaceModule(context, resolveJavaClassArgument(context, java_class));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule get_proxy_class(final IRubyObject self, final IRubyObject java_class) {
         return get_proxy_class(((RubyBasicObject) self).getCurrentContext(), self, java_class);
     }
@@ -366,7 +366,7 @@ public class Java implements Library {
         return (Class) ((JavaProxy) self).getObject();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass getProxyClassForObject(Ruby runtime, Object object) {
         return getProxyClassForObject(runtime.getCurrentContext(), object);
     }
@@ -381,7 +381,7 @@ public class Java implements Library {
         return JavaUtil.getJavaClass(context, proxyClass);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule resolveType(final Ruby runtime, final IRubyObject type) {
         return resolveType(runtime.getCurrentContext(), type);
     }
@@ -453,12 +453,12 @@ public class Java implements Library {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public static RubyModule getProxyClass(Ruby runtime, JavaClass javaClass) {
         return getProxyClass(runtime.getCurrentContext(), javaClass.javaClass());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule getProxyClass(final Ruby runtime, final Class<?> clazz) {
         return getProxyClass(runtime.getCurrentContext(), clazz);
     }
@@ -610,7 +610,7 @@ public class Java implements Library {
 
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public static IRubyObject concrete_proxy_inherited(final IRubyObject clazz, final IRubyObject subclazz) {
         return invokeProxyClassInherited(((RubyBasicObject) clazz).getCurrentContext(), clazz, subclazz);
     }
@@ -895,7 +895,7 @@ public class Java implements Library {
         return getJavaPackageModule(runtime.getCurrentContext(), pkg == null ? "" : pkg.getName());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule getJavaPackageModule(final Ruby runtime, final String packageString) {
         return getJavaPackageModule(runtime.getCurrentContext(), packageString);
     }
@@ -956,7 +956,7 @@ public class Java implements Library {
         return createPackageModule(context, javaModule, name, packageName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule get_package_module(final IRubyObject self, final IRubyObject name) {
         return get_package_module(((RubyBasicObject) self).getCurrentContext(), self, name);
     }
@@ -1036,7 +1036,7 @@ public class Java implements Library {
         return JavaUtil.getPrimitiveClass(name) != null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static Class getJavaClass(final Ruby runtime, final String className) throws RaiseException {
         return getJavaClass(runtime.getCurrentContext(), className);
     }
@@ -1045,7 +1045,7 @@ public class Java implements Library {
         return getJavaClass(context, className, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static Class getJavaClass(final Ruby runtime, final String className, boolean initialize) throws RaiseException {
         return getJavaClass(runtime.getCurrentContext(), className, initialize);
     }
@@ -1058,7 +1058,7 @@ public class Java implements Library {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static Class loadJavaClass(final Ruby runtime, final String className) throws ClassNotFoundException, RaiseException {
         return loadJavaClass(runtime.getCurrentContext(), className);
     }
@@ -1368,7 +1368,7 @@ public class Java implements Library {
         return result != null ? result : context.nil;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public static IRubyObject wrap(Ruby runtime, IRubyObject java_object) {
         return getInstance(runtime, ((JavaObject) java_object).getValue());
     }
@@ -1376,7 +1376,7 @@ public class Java implements Library {
     /**
      * High-level object conversion utility function 'java_to_primitive' is the low-level version
      */
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject java_to_ruby(IRubyObject recv, IRubyObject object, Block unusedBlock) {
         var context = ((RubyBasicObject) recv).getCurrentContext();
@@ -1392,19 +1392,19 @@ public class Java implements Library {
     /**
      * High-level object conversion utility.
      */
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject ruby_to_java(final IRubyObject recv, IRubyObject object, Block unusedBlock) {
         return JavaUtil.ruby_to_java(recv, object, unusedBlock);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject java_to_primitive(IRubyObject recv, IRubyObject object, Block unusedBlock) {
         return JavaUtil.java_to_primitive(recv, object, unusedBlock);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject new_proxy_instance2(IRubyObject recv, final IRubyObject wrapper,
                                                   final IRubyObject interfaces, Block block) {
         return new_proxy_instance2(((RubyBasicObject) recv).getCurrentContext(), recv, wrapper, interfaces, block);
@@ -1429,7 +1429,7 @@ public class Java implements Library {
         return getInstance(context.runtime, newInterfaceImpl(context, wrapper, unwrapped));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static Object newInterfaceImpl(final IRubyObject wrapper, Class[] interfaces) {
         return newInterfaceImpl(((RubyBasicObject) wrapper).getCurrentContext(), wrapper, interfaces);
     }
@@ -1702,7 +1702,7 @@ public class Java implements Library {
         return proxy;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject wrapJavaObject(Ruby runtime, Object object) {
         return wrapJavaObject(runtime.getCurrentContext(), object);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaArray.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaArray.java
@@ -66,7 +66,7 @@ public class JavaArray extends JavaObject {
         return getValue().getClass().getComponentType();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum length() {
         return asFixnum(getCurrentContext(), getLength());
     }
@@ -85,12 +85,12 @@ public class JavaArray extends JavaObject {
         return 17 * getValue().hashCode();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject arefDirect(Ruby runtime, int intIndex) {
         return ArrayUtils.arefDirect(runtime, getValue(), javaConverter, intIndex);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aset(IRubyObject indexArg, IRubyObject value) {
         var context = getCurrentContext();
         var index = Convert.castAsInteger(context, indexArg).asInt(context);
@@ -105,12 +105,12 @@ public class JavaArray extends JavaObject {
         return ArrayUtils.asetDirect(runtime, getValue(), javaConverter, intIndex, value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void setWithExceptionHandling(ThreadContext context, int intIndex, Object javaObject) {
         ArrayUtils.setWithExceptionHandlingDirect(context.runtime, getValue(), intIndex, javaObject);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject afill(IRubyObject beginArg, IRubyObject endArg, IRubyObject value) {
         var context = ((RubyBasicObject) beginArg).getCurrentContext();
         var beginIndex = Convert.castAsInteger(context, beginArg).asInt(context);
@@ -122,7 +122,7 @@ public class JavaArray extends JavaObject {
         return value;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final void fillWithExceptionHandling(ThreadContext context, int start, int end, Object javaValue) {
         final Object array = getValue();
         for (int i = start; i < end; i++) {

--- a/core/src/main/java/org/jruby/javasupport/JavaArrayUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaArrayUtilities.java
@@ -75,7 +75,7 @@ public class JavaArrayUtilities {
         return string;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject ruby_string_to_bytes(IRubyObject recv, IRubyObject string) {
         return ruby_string_to_bytes(((RubyBasicObject) recv).getCurrentContext(), recv, string);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -65,7 +65,7 @@ import static org.jruby.api.Create.newString;
  * @deprecated since 9.3
  * @author  jpetersen
  */
-@Deprecated
+@Deprecated(since = "9.4.0.0")
 public class JavaClass extends JavaObject {
 
     public static final Class[] EMPTY_CLASS_ARRAY = ClassUtils.EMPTY_CLASS_ARRAY;
@@ -89,17 +89,17 @@ public class JavaClass extends JavaObject {
         return getValue().hashCode();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RubyModule getProxyModule() {
         return Java.getProxyClass(getRuntime().getCurrentContext(), javaClass());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RubyClass getProxyClass() {
         return (RubyClass) getProxyModule();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static JavaClass get(final Ruby runtime, final Class<?> klass) {
         return runtime.getJavaSupport().getJavaClassFromCache(klass);
     }
@@ -109,7 +109,7 @@ public class JavaClass extends JavaObject {
         return toRubyArray(runtime, classes);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static RubyArray toRubyArray(final Ruby runtime, final Class<?>[] classes) {
         IRubyObject[] javaClasses = new IRubyObject[classes.length];
         for ( int i = classes.length; --i >= 0; ) {
@@ -175,13 +175,13 @@ public class JavaClass extends JavaObject {
      * @param type
      * @return resolved type or null if resolution failed
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static JavaClass resolveType(final ThreadContext context, final IRubyObject type) {
         RubyModule proxyClass = Java.resolveType(context, type);
         return proxyClass == null ? null : get(context.runtime, JavaUtil.getJavaClass(proxyClass, null));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static JavaClass forNameVerbose(Ruby runtime, String className) {
         Class<?> klass = null;
         synchronized (JavaClass.class) {
@@ -200,18 +200,18 @@ public class JavaClass extends JavaObject {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     @JRubyMethod(name = "for_name", meta = true)
     public static JavaClass for_name(IRubyObject recv, IRubyObject name) {
         return forNameVerbose(((RubyBasicObject) recv).getCurrentContext().getRuntime(), name.asJavaString());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static JavaClass for_name(IRubyObject recv, String name) {
         return forNameVerbose(((RubyBasicObject) recv).getCurrentContext().getRuntime(), name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString inspect() {
         return inspect(getCurrentContext());
     }
@@ -252,7 +252,7 @@ public class JavaClass extends JavaObject {
      * @param additional
      * @return
      */
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject concatArrays(ThreadContext context, JavaArray original, JavaArray additional) {
         return ArrayUtils.concatArraysDirect(context, original.getValue(), additional.getValue());
     }
@@ -265,7 +265,7 @@ public class JavaClass extends JavaObject {
      * @param additional
      * @return
      */
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject concatArrays(ThreadContext context, JavaArray original, IRubyObject additional) {
         return ArrayUtils.concatArraysDirect(context, original.getValue(), additional);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
@@ -56,7 +56,7 @@ public class JavaConstructor extends JavaCallable {
         this.constructor = constructor;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public static JavaConstructor create(Ruby runtime, Constructor<?> constructor) {
         return new JavaConstructor(constructor);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaEmbedUtils.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaEmbedUtils.java
@@ -204,7 +204,7 @@ public class JavaEmbedUtils {
             this.result = result;
         }
 
-        @Deprecated
+        @Deprecated(since = "9.4.6.0")
         protected InterpretedEvalUnit(Ruby runtime, Node node) {
             this(runtime, (ParseResult) node);
         }
@@ -258,7 +258,7 @@ public class JavaEmbedUtils {
         return value.toJava(type);
     }
 
-    // @Deprecated
+    // @Deprecated(since = "9.4.1.0")
     public static <T> T rubyToJava(Ruby runtime, IRubyObject value, Class<T> type) {
         return value.toJava(type);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaField.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaField.java
@@ -50,7 +50,7 @@ import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.typeError;
 
-@Deprecated
+@Deprecated(since = "9.3.0.0")
 // @JRubyClass(name="Java::JavaField")
 public class JavaField {
 

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -493,7 +493,7 @@ public class JavaMethod extends JavaCallable {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RaiseException newMethodNotFoundError(Ruby runtime, Class target, String prettyName, String simpleName) {
         return newMethodNotFoundError(runtime.getCurrentContext(), target, prettyName, simpleName);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -168,12 +168,12 @@ public class JavaObject extends RubyObject {
         return JavaProxyMethods.to_s(context, dataGetStruct());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject to_s(Ruby runtime, Object dataStruct) {
         return JavaProxyMethods.to_s(runtime.getCurrentContext(), dataStruct);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject op_equal(final IRubyObject other) {
         return op_equal(getCurrentContext(), other);
     }
@@ -183,7 +183,7 @@ public class JavaObject extends RubyObject {
         return JavaProxyMethods.equals(context.runtime, getValue(), other);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyBoolean op_equal(JavaProxy self, IRubyObject other) {
         return JavaProxyMethods.equals(self.getCurrentContext().runtime, self.getObject(), other);
     }
@@ -199,12 +199,12 @@ public class JavaObject extends RubyObject {
         return asBoolean(context, thisValue == otherValue);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject same(final IRubyObject other) {
         return same(getCurrentContext(), other);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString java_type() {
         return java_type(getCurrentContext());
     }
@@ -219,7 +219,7 @@ public class JavaObject extends RubyObject {
         return JavaClass.get(getCurrentContext().runtime, getJavaClass());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject get_java_class() {
         return get_java_class(getCurrentContext());
     }
@@ -229,7 +229,7 @@ public class JavaObject extends RubyObject {
         return Java.getInstance(context.runtime, getJavaClass());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum length() {
         return length(getCurrentContext());
     }
@@ -239,7 +239,7 @@ public class JavaObject extends RubyObject {
         throw typeError(context, "not a java array");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject is_java_proxy() {
         return is_java_proxy(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -105,7 +105,7 @@ public class JavaPackage extends RubyModule {
 
     // NOTE: name is Ruby name not pkg.name ~ maybe it should be just like with JavaClass?
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString package_name() {
         return package_name(getCurrentContext());
     }
@@ -115,7 +115,7 @@ public class JavaPackage extends RubyModule {
         return newString(context, packageName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString to_s() {
         return (RubyString) to_s(getCurrentContext());
     }
@@ -182,7 +182,7 @@ public class JavaPackage extends RubyModule {
         return Java.getProxyOrPackageUnderPackage(context, this, name.toString(), cacheMethod);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     RubyModule relativeJavaProxyClass(final Ruby runtime, final IRubyObject name) {
         var context = runtime.getCurrentContext();
         final String fullName = packageRelativeName( name.toString() ).toString();

--- a/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
@@ -113,7 +113,7 @@ public class JavaProxyMethods {
         return stringValue == null ? context.nil : RubyString.newUnicodeString(context.runtime, stringValue);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     static IRubyObject to_s(Ruby runtime, Object javaObject) {
         return to_s(runtime.getCurrentContext(), javaObject);
     }
@@ -123,7 +123,7 @@ public class JavaProxyMethods {
      * @return
      * @deprecated Use {@link JavaProxyMethods#inspect(ThreadContext, IRubyObject)} instead
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject inspect(IRubyObject recv) {
         return inspect(((RubyBasicObject) recv).getCurrentContext(), recv);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -65,7 +65,7 @@ public abstract class JavaSupport {
 
     protected final Ruby runtime;
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     private final ClassValue<JavaClass> javaClassCache;
     private final ClassValue<RubyModule> proxyClassCache;
 
@@ -92,7 +92,7 @@ public abstract class JavaSupport {
     private RubyModule javaUtilitiesModule;
     private RubyModule javaArrayUtilitiesModule;
     private RubyClass javaObjectClass;
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     private Object objectJavaClass;
     private RubyClass javaClassClass;
     private RubyClass javaPackageClass;
@@ -131,7 +131,7 @@ public abstract class JavaSupport {
         return proxyKlass;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public Class loadJavaClassVerbose(String className) {
         var context = runtime.getCurrentContext();
         try {
@@ -148,7 +148,7 @@ public abstract class JavaSupport {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public Class loadJavaClassQuiet(String className) {
         try {
             return loadJavaClass(className);
@@ -187,7 +187,7 @@ public abstract class JavaSupport {
     // class/module, as happens-before is guaranteed by volatile write/read
     // of constants table.)
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule getJavaModule() {
         return getJavaModule(runtime.getCurrentContext());
     }
@@ -197,14 +197,14 @@ public abstract class JavaSupport {
         return module != null ? module : (javaModule = getModule(context, "Java"));
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule getJavaUtilitiesModule() {
         RubyModule module;
         if ((module = javaUtilitiesModule) != null) return module;
         return javaUtilitiesModule = getModule(runtime.getCurrentContext(), "JavaUtilities");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule getJavaArrayUtilitiesModule() {
         RubyModule module;
         if ((module = javaArrayUtilitiesModule) != null) return module;
@@ -237,12 +237,12 @@ public abstract class JavaSupport {
         return javaClass;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public void setObjectJavaClass(JavaClass objectJavaClass) {
         // noop
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public RubyClass getJavaArrayClass() {
         RubyClass clazz;
         if ((clazz = javaArrayClass) != null) return clazz;
@@ -251,7 +251,7 @@ public abstract class JavaSupport {
         return javaArrayClass = getJavaModule(context).getClass(context, "JavaArray");
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public RubyClass getJavaClassClass() {
         RubyClass clazz;
         if ((clazz = javaClassClass) != null) return clazz;
@@ -274,7 +274,7 @@ public abstract class JavaSupport {
         return javaInterfaceTemplate = getModule(runtime.getCurrentContext(), "JavaInterfaceTemplate");
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public RubyModule getPackageModuleTemplate() {
         return null; // no longer used + has been deprecated since ~ 9.1
     }
@@ -367,7 +367,7 @@ public abstract class JavaSupport {
 
     abstract ClassValue<Map<String, AssignedName>> getInstanceAssignedNames();
 
-    @Deprecated
+    @Deprecated(since = "9.4.3.0")
     public abstract Map<String, JavaClass> getNameClassMap();
 
     @Deprecated // internal API - no longer used

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -65,7 +65,7 @@ public class JavaSupportImpl extends JavaSupport {
         return new HashMap<>(8, 1);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public Map<String, JavaClass> getNameClassMap() {
         return Collections.emptyMap();
     }
@@ -78,7 +78,7 @@ public class JavaSupportImpl extends JavaSupport {
         return instanceAssignedNames;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public Map<Set<?>, JavaProxyClass> getJavaProxyClassCache() {
         Map<Set<?>, JavaProxyClass> javaProxyClassCache = new HashMap<>(javaProxyClasses.size());
         synchronized (javaProxyClasses) {
@@ -192,10 +192,10 @@ public class JavaSupportImpl extends JavaSupport {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     private volatile Map<Object, Object[]> javaObjectVariables;
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public Object getJavaObjectVariable(Object o, int i) {
         if (i == -1) return null;
 
@@ -209,7 +209,7 @@ public class JavaSupportImpl extends JavaSupport {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public void setJavaObjectVariable(Object o, int i, Object v) {
         if (i == -1) return;
 

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -638,7 +638,7 @@ public class JavaUtil {
     }
 
     public interface NumericConverter<T> {
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         default T coerce(RubyNumeric numeric, Class<T> target) {
             return coerce(numeric.getCurrentContext(), numeric, target);
         }
@@ -1098,12 +1098,12 @@ public class JavaUtil {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static Object convertRubyToJava(IRubyObject rubyObject) {
         return convertRubyToJava(rubyObject, Object.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static Object convertRubyToJava(IRubyObject rubyObject, Class javaClass) {
         if ( javaClass == void.class || rubyObject == null || rubyObject.isNil() ) {
             return null;
@@ -1189,64 +1189,64 @@ public class JavaUtil {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static byte convertRubyToJavaByte(IRubyObject rubyObject) {
         return (Byte) convertRubyToJava(rubyObject, byte.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static short convertRubyToJavaShort(IRubyObject rubyObject) {
         return (Short) convertRubyToJava(rubyObject, short.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static char convertRubyToJavaChar(IRubyObject rubyObject) {
         return (Character) convertRubyToJava(rubyObject, char.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static int convertRubyToJavaInt(IRubyObject rubyObject) {
         return (Integer) convertRubyToJava(rubyObject, int.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static long convertRubyToJavaLong(IRubyObject rubyObject) {
         return (Long) convertRubyToJava(rubyObject, long.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static float convertRubyToJavaFloat(IRubyObject rubyObject) {
         return (Float) convertRubyToJava(rubyObject, float.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static double convertRubyToJavaDouble(IRubyObject rubyObject) {
         return (Double) convertRubyToJava(rubyObject, double.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static boolean convertRubyToJavaBoolean(IRubyObject rubyObject) {
         return (Boolean) convertRubyToJava(rubyObject, boolean.class);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static Object convertArgumentToType(ThreadContext context, IRubyObject arg, Class target) {
         return arg.toJava(target);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static Object coerceNilToType(RubyNil nil, Class target) {
         return nil.toJava(target);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_BOOLEAN_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.isTrue();
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_BYTE_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
@@ -1256,7 +1256,7 @@ public class JavaUtil {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_SHORT_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
@@ -1266,7 +1266,7 @@ public class JavaUtil {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_CHAR_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
@@ -1276,7 +1276,7 @@ public class JavaUtil {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_INTEGER_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
@@ -1286,7 +1286,7 @@ public class JavaUtil {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_LONG_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
@@ -1296,7 +1296,7 @@ public class JavaUtil {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_FLOAT_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.respondsTo("to_f") ?
@@ -1305,7 +1305,7 @@ public class JavaUtil {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter RUBY_DOUBLE_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.respondsTo("to_f") ?
@@ -1314,7 +1314,7 @@ public class JavaUtil {
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final Map<Class, RubyConverter> RUBY_CONVERTERS = new HashMap<>(16, 1);
     static {
         RUBY_CONVERTERS.put(Boolean.class, RUBY_BOOLEAN_CONVERTER);
@@ -1333,7 +1333,7 @@ public class JavaUtil {
         RUBY_CONVERTERS.put(Double.TYPE, RUBY_DOUBLE_CONVERTER);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static IRubyObject convertJavaToRuby(Ruby runtime, JavaConverter converter, Object object) {
         if (converter == null || converter == JAVA_DEFAULT_CONVERTER) {
             return Java.getInstance(runtime, object);
@@ -1341,103 +1341,103 @@ public class JavaUtil {
         return converter.convert(runtime, object);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public interface RubyConverter {
         public Object convert(ThreadContext context, IRubyObject rubyObject);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_BOOLEAN_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Boolean.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_BYTE_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Byte.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_SHORT_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Short.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_CHAR_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Character.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_INT_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Integer.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_LONG_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Long.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_FLOAT_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Float.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_DOUBLE_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Double.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_OBJECT_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Object.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_CLASS_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(Class.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_STRING_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(String.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_BIGINTEGER_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(BigInteger.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final RubyConverter ARRAY_BIGDECIMAL_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             return rubyObject.toJava(BigDecimal.class);
         }
     };
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static final Map<Class, RubyConverter> ARRAY_CONVERTERS = new HashMap<>(24, 1);
     static {
         ARRAY_CONVERTERS.put(Boolean.class, ARRAY_BOOLEAN_CONVERTER);
@@ -1462,7 +1462,7 @@ public class JavaUtil {
         ARRAY_CONVERTERS.put(BigDecimal.class, ARRAY_BIGDECIMAL_CONVERTER);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static RubyConverter getArrayConverter(Class type) {
         RubyConverter converter = ARRAY_CONVERTERS.get(type);
         if (converter == null) {
@@ -1474,7 +1474,7 @@ public class JavaUtil {
     /**
      * High-level object conversion utility.
      */
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static IRubyObject ruby_to_java(final IRubyObject recv, IRubyObject object, Block unusedBlock) {
         var context = ((RubyObject) recv).getCurrentContext();
         if (object.respondsTo("to_java_object")) {
@@ -1491,14 +1491,14 @@ public class JavaUtil {
         return primitive_to_java(recv, object, unusedBlock);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static IRubyObject java_to_primitive(IRubyObject recv, IRubyObject object, Block unusedBlock) {
         return object instanceof JavaObject jo ?
                 JavaUtil.convertJavaToRuby(((RubyBasicObject) recv).getCurrentContext().runtime, jo.getValue()) :
                 object;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     @SuppressWarnings("deprecation")
     public static IRubyObject primitive_to_java(IRubyObject recv, IRubyObject object, Block unusedBlock) {
         if (object instanceof JavaObject) return object;
@@ -1541,7 +1541,7 @@ public class JavaUtil {
         return Java.getInstance(((RubyBasicObject) object).getCurrentContext().runtime, javaObject);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static Object convertArgument(Ruby runtime, Object argument, Class<?> parameterType) {
         if (argument == null) {
             if (parameterType.isPrimitive()) throw typeError(runtime.getCurrentContext(), "primitives do not accept null");
@@ -1590,7 +1590,7 @@ public class JavaUtil {
     /**
      * High-level object conversion utility function 'java_to_primitive' is the low-level version
      */
-    @Deprecated
+    @Deprecated(since = "1.4.0")
     public static IRubyObject java_to_ruby(Ruby runtime, IRubyObject object) {
         if (object instanceof JavaObject) {
             return JavaUtil.convertJavaToUsableRubyObject(runtime, ((JavaObject) object).getValue());
@@ -1599,7 +1599,7 @@ public class JavaUtil {
     }
 
     // FIXME: This doesn't actually support anything but String
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public static Object coerceStringToType(RubyString string, Class target) {
         try {
             ByteList bytes = string.getByteList();
@@ -1612,7 +1612,7 @@ public class JavaUtil {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public static Object coerceOtherToType(ThreadContext context, IRubyObject arg, Class target) {
         if (isDuckTypeConvertable(arg.getClass(), target)) {
             RubyObject rubyObject = (RubyObject) arg;
@@ -1626,7 +1626,7 @@ public class JavaUtil {
         return arg;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.5.0")
     public static Object coerceJavaObjectToType(ThreadContext context, Object javaObject, Class target) {
         if (javaObject != null && isDuckTypeConvertable(javaObject.getClass(), target)) {
             RubyObject rubyObject = (RubyObject) javaObject;
@@ -1641,7 +1641,7 @@ public class JavaUtil {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public static JavaObject unwrapJavaObject(Ruby runtime, IRubyObject convertee, String errorMessage) {
         IRubyObject obj = convertee;
         if(!(obj instanceof JavaObject)) {
@@ -1665,7 +1665,7 @@ public class JavaUtil {
         return defaultValue;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static <T> T unwrapJava(final IRubyObject wrapped) {
         return unwrapJava(((RubyBasicObject) wrapped).getCurrentContext(), wrapped);
     }
@@ -1678,7 +1678,7 @@ public class JavaUtil {
         return (T) unwrap;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static Class<?> getJavaClass(final RubyModule type) throws TypeError {
         return getJavaClass(type.getCurrentContext(), type);
     }
@@ -1712,6 +1712,6 @@ public class JavaUtil {
         return ifNone == null ? null : ifNone.get();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.9.0")
     public static final boolean CAN_SET_ACCESSIBLE = true;
 }

--- a/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
@@ -22,7 +22,7 @@ public class JavaUtilities {
         return java_object;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject get_interface_module(IRubyObject recv, IRubyObject arg0) {
         return get_interface_module(((RubyBasicObject) recv).getCurrentContext(), recv, arg0);
     }
@@ -32,7 +32,7 @@ public class JavaUtilities {
         return Java.get_interface_module(context, arg0);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject get_package_module(IRubyObject recv, IRubyObject arg0) {
         return get_package_module(((RubyBasicObject) recv).getCurrentContext(), recv, arg0);
     }
@@ -42,7 +42,7 @@ public class JavaUtilities {
         return Java.get_package_module(context, recv, arg0);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject get_package_module_dot_format(IRubyObject recv, IRubyObject arg0) {
         return get_package_module_dot_format(((RubyBasicObject) recv).getCurrentContext(), recv, arg0);
     }
@@ -52,7 +52,7 @@ public class JavaUtilities {
         return Java.get_package_module_dot_format(context, recv, arg0);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject get_proxy_class(IRubyObject recv, IRubyObject arg0) {
         return get_proxy_class(((RubyBasicObject) recv).getCurrentContext(), recv, arg0);
     }
@@ -73,7 +73,7 @@ public class JavaUtilities {
         return get_java_class(((RubyBasicObject) recv).getCurrentContext(), recv, arg0);
     }
 
-    @Deprecated(since = "10.0") // no longer used
+    @Deprecated(since = "10.0.0.0") // no longer used
     @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject get_java_class(ThreadContext context, IRubyObject recv, IRubyObject arg0) {
         Class<?> javaClass = Java.getJavaClass(context, arg0.asJavaString());

--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -33,7 +33,7 @@ public abstract class Initializer {
         this.javaClass = javaClass;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule setupProxyClass(Ruby runtime, final Class<?> javaClass, RubyClass proxy) {
         return setupProxyClass(runtime.getCurrentContext(), javaClass, proxy);
     }
@@ -61,7 +61,7 @@ public abstract class Initializer {
         flagAsJavaProxy(context, proxy); return proxy;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule setupProxyModule(Ruby runtime, final Class<?> javaClass, RubyModule proxy) {
         return setupProxyModule(runtime.getCurrentContext(), javaClass, proxy);
     }
@@ -87,7 +87,7 @@ public abstract class Initializer {
         proxy.dataWrapStruct(javaClass);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyModule initialize(RubyModule proxy) {
         return initialize(proxy.getCurrentContext(), proxy);
     }
@@ -95,7 +95,7 @@ public abstract class Initializer {
 
     public abstract RubyModule initialize(ThreadContext context, RubyModule proxy);
 
-    @Deprecated
+    @Deprecated(since = "9.2.9.0")
     public static final ClassValue<Method[]> DECLARED_METHODS = MethodGatherer.DECLARED_METHODS;
 
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodInstaller.java
@@ -138,12 +138,12 @@ public abstract class MethodInstaller extends NamedInstaller {
         aliases.remove(alias);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     final void defineMethods(RubyModule target, DynamicMethod invoker) {
         defineMethods(target.getCurrentContext(), target, invoker, true);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     protected final void defineMethods(RubyModule target, DynamicMethod invoker, boolean checkDups) {
         defineMethods(target.getCurrentContext(), target, invoker, checkDups);
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -235,7 +235,7 @@ public abstract class JavaLang {
             return RubyArray.newArrayMayCopy(runtime, backtrace);
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject set_backtrace(final IRubyObject self, final IRubyObject backtrace) {
             return set_backtrace(((RubyBasicObject) self).getCurrentContext(), self, backtrace);
         }
@@ -609,7 +609,7 @@ public abstract class JavaLang {
             return asBoolean(context, klass.isAnonymousClass());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject anonymous_p(final IRubyObject self) {
             return anonymous_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -620,7 +620,7 @@ public abstract class JavaLang {
             return JavaLangReflect.isAbstract(context, self, klass.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject abstract_p(final IRubyObject self) {
             return abstract_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -633,7 +633,7 @@ public abstract class JavaLang {
             return JavaLangReflect.isPublic(context, self, klass.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject public_p(final IRubyObject self) {
             return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -644,7 +644,7 @@ public abstract class JavaLang {
             return JavaLangReflect.isProtected(context, self, klass.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject protected_p(final IRubyObject self) {
             return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -655,7 +655,7 @@ public abstract class JavaLang {
             return JavaLangReflect.isPrivate(context, self, klass.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject private_p(final IRubyObject self) {
             return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -666,7 +666,7 @@ public abstract class JavaLang {
             return JavaLangReflect.isFinal(context, self, klass.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject final_p(final IRubyObject self) {
             return final_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -677,7 +677,7 @@ public abstract class JavaLang {
             return JavaLangReflect.isStatic(context, self, klass.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject static_p(final IRubyObject self) {
             return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
@@ -115,7 +115,7 @@ public abstract class JavaLangReflect {
             return isPublic(context, self, thiz.getModifiers());
         }
 
-        @Deprecated(since = "9.4")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject public_p(final IRubyObject self) {
             return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -126,7 +126,7 @@ public abstract class JavaLangReflect {
             return isProtected(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject protected_p(final IRubyObject self) {
             return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -137,7 +137,7 @@ public abstract class JavaLangReflect {
             return isPrivate(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject private_p(final IRubyObject self) {
             return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -148,7 +148,7 @@ public abstract class JavaLangReflect {
             return isFinal(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject final_p(final IRubyObject self) {
             return final_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -159,7 +159,7 @@ public abstract class JavaLangReflect {
             return isStatic(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject static_p(final IRubyObject self) {
             return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -223,7 +223,7 @@ public abstract class JavaLangReflect {
             return isAbstract(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject abstract_p(final IRubyObject self) {
             return abstract_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -236,7 +236,7 @@ public abstract class JavaLangReflect {
             return isPublic(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject public_p(final IRubyObject self) {
             return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -247,7 +247,7 @@ public abstract class JavaLangReflect {
             return isProtected(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject protected_p(final IRubyObject self) {
             return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -258,7 +258,7 @@ public abstract class JavaLangReflect {
             return isPrivate(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject private_p(final IRubyObject self) {
             return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -269,7 +269,7 @@ public abstract class JavaLangReflect {
             return isFinal(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject final_p(final IRubyObject self) {
             return final_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -280,7 +280,7 @@ public abstract class JavaLangReflect {
             return isStatic(context, self, thiz.getModifiers());
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject static_p(final IRubyObject self) {
             return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -356,7 +356,7 @@ public abstract class JavaLangReflect {
             return isPublic(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject public_p(final IRubyObject self) {
             return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -367,7 +367,7 @@ public abstract class JavaLangReflect {
             return isProtected(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject protected_p(final IRubyObject self) {
             return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -378,7 +378,7 @@ public abstract class JavaLangReflect {
             return isPrivate(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject private_p(final IRubyObject self) {
             return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
@@ -389,7 +389,7 @@ public abstract class JavaLangReflect {
             return isFinal(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject final_p(final IRubyObject self) {
 
             return final_p(((RubyBasicObject) self).getCurrentContext(), self);
@@ -401,7 +401,7 @@ public abstract class JavaLangReflect {
             return isStatic(context, self, thiz.getModifiers());
         }
 
-        @Deprecated
+        @Deprecated(since = "10.0.0.0")
         public static IRubyObject static_p(final IRubyObject self) {
             return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -133,7 +133,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
 
     private transient JavaProxyConstructor[] constructors;
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public JavaProxyConstructor[] getConstructors() {
         return getConstructors(getCurrentContext());
     }
@@ -151,7 +151,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         return this.constructors = constructors.toArray(new JavaProxyConstructor[constructors.size()]);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public JavaProxyConstructor getConstructor(final Class[] args)
         throws SecurityException, NoSuchMethodException {
 
@@ -283,7 +283,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             return method.toString();
         }
 
-        @Deprecated
+        @Deprecated(since = "9.1.6.0")
         public Object defaultResult() {
             final Class returnType = method.getReturnType();
 
@@ -307,7 +307,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             return method.getReturnType();
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public RubyObject name() {
             return newString(getCurrentContext(), getName());
         }
@@ -317,7 +317,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             return proxyClass;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public RubyArray argument_types() {
             return argument_types(getCurrentContext());
         }
@@ -327,7 +327,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             return toClassArray(context, getParameterTypes());
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject super_p() {
             return super_p(getCurrentContext());
         }
@@ -337,7 +337,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             return hasSuperImplementation() ? context.tru : context.fals;
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public RubyFixnum arity() {
             return arity(getCurrentContext());
         }
@@ -347,7 +347,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             return asFixnum(context, getArity());
         }
 
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public RubyString inspect() {
             return inspect(getCurrentContext());
         }
@@ -368,7 +368,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
          * @return
          * @deprecated Use {@link ProxyMethodImpl#do_invoke(ThreadContext, IRubyObject[])} instead.
          */
-        @Deprecated(since = "10.0")
+        @Deprecated(since = "10.0.0.0")
         public IRubyObject do_invoke(final IRubyObject[] args) {
             return do_invoke(getCurrentContext(), args);
         }
@@ -543,7 +543,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         EXCLUDE_MODULES.add("Enumerable");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyObject get_with_class(final IRubyObject self, IRubyObject obj) {
         return get_with_class(((RubyBasicObject) self).getCurrentContext(), self, obj);
     }
@@ -606,7 +606,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         return objects;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static JavaProxyClass getProxyClass(final Ruby runtime, final RubyClass clazz) {
         return getProxyClass(runtime.getCurrentContext(), clazz);
     }
@@ -616,7 +616,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
     	return (JavaProxyClass) clazz.getInstanceVariable("@java_proxy_class");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject superclass() {
         return superclass(getCurrentContext());
     }
@@ -626,7 +626,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         return Java.getInstance(context.runtime, getSuperclass());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray methods() {
         return methods(getCurrentContext());
     }
@@ -636,7 +636,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         return toRubyArray(context, getMethods());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray interfaces() {
         return interfaces(getCurrentContext());
     }
@@ -646,7 +646,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         return toClassArray(context, getInterfaces());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RubyArray constructors() {
         return constructors(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
@@ -141,7 +141,7 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
         return proxyConstructor.newInstance(argsPlus1);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum arity() {
         return arity(getCurrentContext());
     }
@@ -166,7 +166,7 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
         return proxyConstructor.hashCode();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString inspect() {
         return inspect(getCurrentContext());
     }
@@ -187,7 +187,7 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
         return buf.toString();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RubyArray argument_types() {
         return argument_types(getCurrentContext());
     }
@@ -259,7 +259,7 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
         return new RuntimeException("Dead code... If you see this, file a bug: JPCtIEC fail"); // greppable
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject new_instance(IRubyObject[] args, Block block) {
         return new_instance2(getCurrentContext(), args, block);
     }

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -56,7 +56,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         klass.getMetaClass().defineAlias(context, "__j_allocate", "allocate");
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.20")
     public IRubyObject op_equal(IRubyObject other) {
         return op_eqq(getCurrentContext(), other);
     }
@@ -74,7 +74,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         return asBoolean(context, this.equals(obj));
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.20")
     public IRubyObject same(IRubyObject other) {
         return op_equal(getCurrentContext(), other);
     }
@@ -120,7 +120,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         return getClass().getName();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyString java_type() {
         return java_type(getCurrentContext());
     }
@@ -130,7 +130,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         return newString(context, getJavaClass().getName());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject java_class() {
         return java_class(getCurrentContext());
     }
@@ -140,7 +140,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         return Java.getInstance(context.runtime, getJavaClass());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyFixnum length() {
         return length(getCurrentContext());
     }
@@ -150,7 +150,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         throw typeError(context, "not a java array");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aref(IRubyObject index) {
         return aref(getCurrentContext(), index);
     }
@@ -160,7 +160,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         throw typeError(context, "not a java array");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject aset(IRubyObject index, IRubyObject someValue) {
         return aset(getCurrentContext(), index, someValue);
     }
@@ -170,7 +170,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         throw typeError(context, "not a java array");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject is_java_proxy() {
         return is_java_proxy(getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/javasupport/util/RuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/javasupport/util/RuntimeHelpers.java
@@ -9,14 +9,14 @@ import org.jruby.runtime.builtin.IRubyObject;
 // Deprecated in 2012, but still in use in Nokogiri until Feb 2019
 // See https://github.com/sparklemotion/nokogiri/pull/1874
 // Relates to https://github.com/sparklemotion/nokogiri/pull/2027
-@Deprecated
+@Deprecated(since = "1.7.4")
 public class RuntimeHelpers extends Helpers {
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static RubyHash constructHash(Ruby runtime, IRubyObject key, IRubyObject value) {
         return CoreConstructors.createHash(runtime, key, value);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static RubyHash constructHash(Ruby runtime, IRubyObject key1, IRubyObject value1,
                                          IRubyObject key2, IRubyObject value2) {
         return CoreConstructors.createHash(runtime, key1, value1, key2, value2);

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -852,7 +852,7 @@ public abstract class LexingCommon {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public void validateFormalIdentifier(String identifier) {
         char first = identifier.charAt(0);
 

--- a/core/src/main/java/org/jruby/parser/Parser.java
+++ b/core/src/main/java/org/jruby/parser/Parser.java
@@ -139,7 +139,7 @@ public class Parser {
         return (ParseResult) result.getAST();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parse(String file, ByteList content, DynamicScope blockScope,
             ParserConfiguration configuration) {
         configuration.setDefaultEncoding(content.getEncoding());
@@ -148,7 +148,7 @@ public class Parser {
         return parse(file, lexerSource, blockScope, configuration);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parse(String file, byte[] content, DynamicScope blockScope,
             ParserConfiguration configuration) {
         var list = getLines(configuration.isEvalParse(), file, -1);
@@ -157,7 +157,7 @@ public class Parser {
         return parse(file, lexerSource, blockScope, configuration);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parse(String file, InputStream content, DynamicScope blockScope,
             ParserConfiguration configuration) {
         if (content instanceof LoadServiceResourceInputStream) {
@@ -187,7 +187,7 @@ public class Parser {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public Node parse(String file, LexerSource lexerSource, DynamicScope blockScope,
             ParserConfiguration configuration) {
         // We only need to pass in current scope if we are evaluating as a block (which

--- a/core/src/main/java/org/jruby/parser/ParserConfiguration.java
+++ b/core/src/main/java/org/jruby/parser/ParserConfiguration.java
@@ -63,7 +63,7 @@ public class ParserConfiguration {
         this.saveData = saveData;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public ParserConfiguration(Ruby runtime, int lineNumber,
             boolean inlineSource, boolean isFileParse, RubyInstanceConfig config) {
         this(runtime, lineNumber, inlineSource, isFileParse, false, config);

--- a/core/src/main/java/org/jruby/parser/ReOptions.java
+++ b/core/src/main/java/org/jruby/parser/ReOptions.java
@@ -46,8 +46,8 @@ public interface ReOptions {
                                       // and we won't escape regexp_options.
     int RE_DEFAULT = 512; // Only for RubyRegexp. for kcode default
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     int RE_OPTION_LONGEST      = 16;
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     int RE_MAY_IGNORECASE      = 32;
 }

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1693,7 +1693,7 @@ public abstract class RubyParserBase {
         return RubyLexer.isIdentifierChar(name.charAt(0));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public boolean is_local_id(String name) {
         return RubyLexer.isIdentifierChar(name.charAt(0));
     }
@@ -1978,7 +1978,7 @@ public abstract class RubyParserBase {
 
     public static final ByteList INTERNAL_ID = new ByteList(new byte[] {}, USASCIIEncoding.INSTANCE);
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public String internalId() {
         return INTERNAL_ID.toString();
     }

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -311,7 +311,7 @@ public class StaticScope implements Serializable, Cloneable {
         System.arraycopy(names, 0, variableNames, 0, names.length);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantDefined(String internedName) {
         return getConstantDefined(cref.getRuntime().getCurrentContext(), internedName);
     }
@@ -329,7 +329,7 @@ public class StaticScope implements Serializable, Cloneable {
         return previousCRefScope == null ? null : previousCRefScope.getConstantDefinedNoObject(context, internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantDefinedNoObject(String internedName) {
         return getConstantDefinedNoObject(cref.getRuntime().getCurrentContext(), internedName);
     }
@@ -338,7 +338,7 @@ public class StaticScope implements Serializable, Cloneable {
         return previousCRefScope == null ? null : getConstantDefined(context, internedName);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstant(String internedName) {
         return getConstant(cref.getRuntime().getCurrentContext(), internedName);
     }
@@ -350,7 +350,7 @@ public class StaticScope implements Serializable, Cloneable {
         return result == null ? cref.getConstantNoConstMissing(context, internedName) : result;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public IRubyObject getConstantInner(String internedName) {
         return getScopedConstant(cref.getRuntime().getCurrentContext(), internedName);
     }
@@ -510,7 +510,7 @@ public class StaticScope implements Serializable, Cloneable {
         return collection;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray getLocalVariables(Ruby runtime) {
         return getLocalVariables(runtime.getCurrentContext());
     }

--- a/core/src/main/java/org/jruby/parser/StaticScopeFactory.java
+++ b/core/src/main/java/org/jruby/parser/StaticScopeFactory.java
@@ -55,7 +55,7 @@ public class StaticScopeFactory {
         return scope;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static StaticScope newStaticScope(StaticScope parent, StaticScope.Type type, String[] names) {
         if(names == null) {
             return new StaticScope(type, parent);
@@ -64,7 +64,7 @@ public class StaticScopeFactory {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static StaticScope newStaticScope(StaticScope parent, StaticScope.Type type, String[] names, int keywordArgIndex) {
         if(names == null) {
             return new StaticScope(type, parent);

--- a/core/src/main/java/org/jruby/runtime/ArgumentDescriptor.java
+++ b/core/src/main/java/org/jruby/runtime/ArgumentDescriptor.java
@@ -40,7 +40,7 @@ public class ArgumentDescriptor {
         this(type, null);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public final RubyArray toArrayForm(Ruby runtime, boolean isLambda) {
         return toArrayForm(runtime.getCurrentContext(), isLambda);
     }

--- a/core/src/main/java/org/jruby/runtime/ArgumentType.java
+++ b/core/src/main/java/org/jruby/runtime/ArgumentType.java
@@ -68,7 +68,7 @@ public enum ArgumentType {
         };
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public RubyArray toArrayForm(Ruby runtime, RubySymbol name) {
         return toArrayForm(runtime.getCurrentContext(), name);
     }

--- a/core/src/main/java/org/jruby/runtime/Arity.java
+++ b/core/src/main/java/org/jruby/runtime/Arity.java
@@ -269,7 +269,7 @@ public final class Arity implements Serializable {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject[] scanArgs(Ruby runtime, IRubyObject[] args, int required, int optional) {
         return scanArgs(runtime.getCurrentContext(), args, required, optional);
     }
@@ -285,53 +285,53 @@ public final class Arity implements Serializable {
         return args;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int checkArgumentCount(Ruby runtime, IRubyObject[] args, int min, int max) {
         return checkArgumentCount(runtime.getCurrentContext(), args.length, min, max);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int checkArgumentCount(Ruby runtime, String name, IRubyObject[] args, int min, int max) {
         return checkArgumentCount(runtime.getCurrentContext(), name, args.length, min, max);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int checkArgumentCount(Ruby runtime, int length, int min, int max) {
         raiseArgumentError(runtime.getCurrentContext(), length, min, max);
 
         return length;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int checkArgumentCount(Ruby runtime, int length, int min, int max, boolean hasKwargs) {
         return checkArgumentCount(runtime.getCurrentContext(), length, min, max, hasKwargs);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int checkArgumentCount(Ruby runtime, String name, int length, int min, int max) {
         raiseArgumentError(runtime.getCurrentContext(), name, length, min, max);
 
         return length;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void raiseArgumentError(Ruby runtime, IRubyObject[] args, int min, int max) {
         raiseArgumentError(runtime.getCurrentContext(), args.length, min, max);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void raiseArgumentError(Ruby runtime, int length, int min, int max) {
         raiseArgumentError(runtime.getCurrentContext(), length, min, max);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void raiseArgumentError(Ruby runtime, int length, int min, int max, boolean hasKwargs) {
         ThreadContext context = runtime.getCurrentContext();
 
         raiseArgumentError(context, length, min, max, hasKwargs);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void raiseArgumentError(Ruby runtime, String name, int length, int min, int max) {
         raiseArgumentError(runtime.getCurrentContext(), name, length, min, max);
     }

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -281,7 +281,7 @@ public class Binding {
         return evalScopeBinding.evalScope;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public Binding(IRubyObject self, Frame frame,
                    Visibility visibility, DynamicScope dynamicScope, BacktraceElement backtrace) {
         this.self = self;
@@ -293,7 +293,7 @@ public class Binding {
         this.line = backtrace.line;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public Binding(Frame frame, DynamicScope dynamicScope, BacktraceElement backtrace) {
         this.self = frame.getSelf();
         this.frame = frame;
@@ -304,12 +304,12 @@ public class Binding {
         this.line = backtrace.line;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public BacktraceElement getBacktrace() {
         return new BacktraceElement(method, filename, line);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.8.0")
     public static final Binding DUMMY =
             new Binding(
                     RubyBasicObject.NEVER,

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -308,7 +308,7 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
      *
      * @return the arity
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public Arity arity() {
         return getSignature().arity();
     }

--- a/core/src/main/java/org/jruby/runtime/BlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/BlockBody.java
@@ -232,7 +232,7 @@ public abstract class BlockBody {
      *
      * @return the arity
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public Arity arity() {
         return signature.arity();
     }

--- a/core/src/main/java/org/jruby/runtime/CallBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock.java
@@ -53,7 +53,7 @@ public class CallBlock extends BlockBody {
     }
 
     // Put back because fishwife 1.10.1 still relies on this.
-    @Deprecated
+    @Deprecated(since = "9.3.3.0")
     public static Block newCallClosure(IRubyObject self, RubyModule imClass, Arity arity, BlockCallback callback, ThreadContext context) {
         return newCallClosure(self, imClass, Signature.from(arity), callback, context);
     }

--- a/core/src/main/java/org/jruby/runtime/CallBlock19.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock19.java
@@ -49,7 +49,7 @@ public class CallBlock19 extends BlockBody {
 
     // This is a stop-gap method where we try to construct an equivalent Signature from an Arity but beyond very simple Arity's it will strip
     // some info off.
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static Block newCallClosure(IRubyObject self, RubyModule imClass, Arity arity, BlockCallback callback, ThreadContext context) {
         Binding binding = context.currentBinding(self, Visibility.PUBLIC);
         BlockBody body = new CallBlock19(Signature.from(arity), callback, context);

--- a/core/src/main/java/org/jruby/runtime/DynamicScope.java
+++ b/core/src/main/java/org/jruby/runtime/DynamicScope.java
@@ -74,7 +74,7 @@ public abstract class DynamicScope implements Cloneable {
         return parent;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public DynamicScope getNextCapturedScope() {  // Used by ruby-debug-ide
         return getParentScope();
     }
@@ -591,7 +591,7 @@ public abstract class DynamicScope implements Cloneable {
                 scopeType.isBlock() && (staticScope.isArgumentScope() || lambda);  // Contained within define_method closure
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public DynamicScope cloneScope() {
         try {
             return (DynamicScope) clone();

--- a/core/src/main/java/org/jruby/runtime/Frame.java
+++ b/core/src/main/java/org/jruby/runtime/Frame.java
@@ -370,6 +370,6 @@ public final class Frame {
         return sb.toString();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.8.0")
     public static final Frame DUMMY = new Frame();
 }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -124,7 +124,7 @@ public class Helpers {
 
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyClass getSingletonClass(Ruby runtime, IRubyObject receiver) {
         // This is not all cases 
         if (receiver instanceof RubyFixnum || receiver instanceof RubySymbol) {
@@ -518,7 +518,7 @@ public class Helpers {
         return newLength;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int multiplyBufferLength(Ruby runtime, int base, int multiplier) {
         return multiplyBufferLength(runtime.getCurrentContext(), base, multiplier);
     }
@@ -545,7 +545,7 @@ public class Helpers {
         throw argumentError(context, "argument too big");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int addBufferLength(Ruby runtime, int base, int extra) {
         return addBufferLength(runtime.getCurrentContext(), base, extra);
     }
@@ -972,12 +972,12 @@ public class Helpers {
         return method.call(context, self, entry.sourceModule, name, arg0, arg1, arg2, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.5.0")
     public static RubyArray ensureRubyArray(IRubyObject value) {
         return ensureRubyArray(((RubyBasicObject) value).getCurrentContext(), value);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyArray ensureRubyArray(Ruby runtime, IRubyObject value) {
         return ensureRubyArray(runtime.getCurrentContext(), value);
     }
@@ -1028,7 +1028,7 @@ public class Helpers {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static String getLocalJumpTypeOrRethrow(RaiseException re) {
         RubyException exception = re.getException();
         Ruby runtime = exception.getCurrentContext().runtime;
@@ -1084,27 +1084,27 @@ public class Helpers {
         return block.getFrame().getBlock();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static Block getBlockFromBlockPassBody(IRubyObject proc, Block currentBlock) {
         return getBlockFromBlockPassBody(((RubyBasicObject) proc).getCurrentContext().runtime, proc, currentBlock);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject backrefLastMatch(ThreadContext context) {
         return RubyRegexp.last_match(context.getBackRef());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject backrefMatchPre(ThreadContext context) {
         return RubyRegexp.match_pre(context, context.getBackRef());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject backrefMatchPost(ThreadContext context) {
         return RubyRegexp.match_post(context.getBackRef());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject backrefMatchLast(ThreadContext context) {
         return RubyRegexp.match_last(context, context.getBackRef());
     }
@@ -1319,7 +1319,7 @@ public class Helpers {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static void storeExceptionInErrorInfo(Throwable currentThrowable, ThreadContext context) {
         IRubyObject exception;
         if (currentThrowable instanceof RaiseException) {
@@ -1918,7 +1918,7 @@ public class Helpers {
         return context.getLastLine();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyArray arrayValue(IRubyObject value) {
         return arrayValue(((RubyBasicObject) value).getCurrentContext(), value);
     }
@@ -1930,7 +1930,7 @@ public class Helpers {
      * @return ""
      * @deprecated Use {@link Helpers#arrayValue(ThreadContext, IRubyObject)}
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyArray arrayValue(ThreadContext context, Ruby runtime, IRubyObject value) {
         return arrayValue(context, value);
     }
@@ -1969,7 +1969,7 @@ public class Helpers {
     }
 
     // mri: rb_Array
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static RubyArray asArray(ThreadContext context, IRubyObject value) {
         return TypeConverter.rb_Array(context, value);
     }
@@ -2063,12 +2063,12 @@ public class Helpers {
         return args;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static RubySymbol addInstanceMethod(RubyModule containingClass, String name, DynamicMethod method, Visibility visibility, ThreadContext context, Ruby runtime) {
         return addInstanceMethod(containingClass, runtime.fastNewSymbol(name), method, visibility, context, runtime);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static RubySymbol addInstanceMethod(RubyModule containingClass, RubySymbol symbol, DynamicMethod method, Visibility visibility, ThreadContext context, Ruby runtime) {
         return addInstanceMethod(containingClass, symbol, method, visibility, context);
     }
@@ -2207,7 +2207,7 @@ public class Helpers {
         return scope;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static Visibility performNormalMethodChecksAndDetermineVisibility(Ruby runtime, RubyModule clazz,
                                                                              RubySymbol symbol, Visibility visibility) throws RaiseException {
         return performNormalMethodChecksAndDetermineVisibility(runtime.getCurrentContext(), clazz, symbol, visibility);
@@ -2331,7 +2331,7 @@ public class Helpers {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule checkIsModule(IRubyObject maybeModule) {
         if (maybeModule instanceof RubyModule mod) return mod;
 
@@ -2366,7 +2366,7 @@ public class Helpers {
         return RubyProc.newProc(context.runtime, block, Block.Type.LAMBDA);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void fillNil(final IRubyObject[] arr, int from, int to, Ruby runtime) {
         fillNil(runtime.getCurrentContext(), arr, from, to);
     }
@@ -2414,7 +2414,7 @@ public class Helpers {
         return arr;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void fillNil(IRubyObject[] arr, Ruby runtime) {
         fillNil(runtime.getCurrentContext(), arr);
     }
@@ -2505,7 +2505,7 @@ public class Helpers {
         throw argumentError(context, length, expected);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static boolean isModuleAndHasConstant(IRubyObject left, String name) {
         return isModuleAndHasConstant(((RubyBasicObject) left).getCurrentContext(), left, name);
     }
@@ -2514,7 +2514,7 @@ public class Helpers {
         return left instanceof RubyModule && ((RubyModule) left).publicConstDefinedFrom(context, name);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject getDefinedConstantOrBoundMethod(IRubyObject left, String name, IRubyObject definedConstantMessage, IRubyObject definedMethodMessage) {
         return getDefinedConstantOrBoundMethod(((RubyBasicObject) left).getCurrentContext(), left, name, definedConstantMessage, definedMethodMessage);
     }
@@ -2526,7 +2526,7 @@ public class Helpers {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyModule getSuperClassForDefined(Ruby runtime, RubyModule klazz) {
         RubyModule superklazz = klazz.getSuperClass();
 
@@ -2587,7 +2587,7 @@ public class Helpers {
         return scopeOffsets;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static RubyArray argsPush(ThreadContext context, RubyArray first, IRubyObject second) {
         return ((RubyArray)first.dup()).append(context, second);
     }
@@ -2611,7 +2611,7 @@ public class Helpers {
         return ((RubyArray) Helpers.ensureRubyArray(context, first).dup()).concat(secondArgs);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static RubyArray argsCat(IRubyObject first, IRubyObject second) {
         return argsCat(((RubyBasicObject) first).getCurrentContext(), first, second);
     }
@@ -2697,7 +2697,7 @@ public class Helpers {
         return descs.toArray(new ArgumentDescriptor[descs.size()]);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static ArgumentDescriptor[] parameterListToArgumentDescriptors(Ruby runtime, String[] parameterList, boolean isLambda) {
         return parameterListToArgumentDescriptors(runtime.getCurrentContext(), parameterList, isLambda);
     }
@@ -2730,7 +2730,7 @@ public class Helpers {
         return parms;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyArray argumentDescriptorsToParameters(Ruby runtime, ArgumentDescriptor[] argsDesc, boolean isLambda) {
         return argumentDescriptorsToParameters(runtime.getCurrentContext(), argsDesc, isLambda);
     }
@@ -2747,7 +2747,7 @@ public class Helpers {
         return Create.newArrayNoCopy(context, objArray);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static ArgumentDescriptor[] methodToArgumentDescriptors(DynamicMethod method) {
         return methodToArgumentDescriptors(method.getImplementationClass().getCurrentContext(), method);
     }
@@ -2764,7 +2764,7 @@ public class Helpers {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject methodToParameters(Ruby runtime, AbstractRubyMethod recv) {
         return methodToParameters(runtime.getCurrentContext(), recv);
     }
@@ -2855,12 +2855,12 @@ public class Helpers {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public static IRubyObject invokedynamic(ThreadContext context, IRubyObject self, int index) {
         return invokedynamic(context, self, MethodNames.values()[index]);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public static IRubyObject invokedynamic(ThreadContext context, IRubyObject self, int index, IRubyObject arg0) {
         return invokedynamic(context, self, MethodNames.values()[index], arg0);
     }
@@ -3084,7 +3084,7 @@ public class Helpers {
         return -1;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int memchr(boolean[] ary, int start, int len, boolean find) {
         return memchr(ary, start, find, len);
     }
@@ -3169,7 +3169,7 @@ public class Helpers {
         return context.sites.Helpers;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static String encodeParameterList(List<String[]> args) {
         if (args.size() == 0) return "NONE";
 
@@ -3254,34 +3254,34 @@ public class Helpers {
         return Helpers.invoke(context, self, name, IRubyObject.NULL_ARRAY, callType, Block.NULL_BLOCK);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public static IRubyObject invokeFrom(ThreadContext context, IRubyObject caller, IRubyObject self, String name, IRubyObject[] args, CallType callType, Block block) {
         return self.getMetaClass().invokeFrom(context, callType, caller, self, name, args, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public static IRubyObject invokeFrom(ThreadContext context, IRubyObject caller, IRubyObject self, String name, IRubyObject arg, CallType callType, Block block) {
         return self.getMetaClass().invokeFrom(context, callType, caller, self, name, arg, block);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public static IRubyObject invokeFrom(ThreadContext context, IRubyObject caller, IRubyObject self, String name, CallType callType) {
         return self.getMetaClass().invokeFrom(context, callType, caller, self, name, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject setBackref(Ruby runtime, ThreadContext context, IRubyObject value) {
         if (!value.isNil() && !(value instanceof RubyMatchData)) throw typeError(context, value, "MatchData");
 
         return context.setBackRef(value);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject getBackref(Ruby runtime, ThreadContext context) {
         return context.getBackRef();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static IRubyObject backref(ThreadContext context) {
         return context.getBackRef();
     }

--- a/core/src/main/java/org/jruby/runtime/MethodIndex.java
+++ b/core/src/main/java/org/jruby/runtime/MethodIndex.java
@@ -77,20 +77,20 @@ public class MethodIndex {
 
     private static final Logger LOG = LoggerFactory.getLogger(MethodIndex.class);
 
-    @Deprecated
+    @Deprecated(since = "1.7.1")
     public static final int NO_METHOD = MethodNames.DUMMY.ordinal();
-    @Deprecated
+    @Deprecated(since = "1.7.1")
     public static final int OP_EQUAL = MethodNames.OP_EQUAL.ordinal();
-    @Deprecated
+    @Deprecated(since = "1.7.1")
     public static final int EQL = MethodNames.EQL.ordinal();
-    @Deprecated
+    @Deprecated(since = "1.7.1")
     public static final int HASH = MethodNames.HASH.ordinal();
-    @Deprecated
+    @Deprecated(since = "1.7.1")
     public static final int OP_CMP = MethodNames.OP_CMP.ordinal();
-    @Deprecated
+    @Deprecated(since = "1.7.1")
     public static final int MAX_METHODS = MethodNames.values().length;
 
-    @Deprecated
+    @Deprecated(since = "1.7.1")
     public static final String[] METHOD_NAMES = {
         "",
         "==",
@@ -275,13 +275,13 @@ public class MethodIndex {
         addMethodWriteFieldsPacked(FrameField.pack(write), name);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static void addFrameAwareMethods(String... methods) {
         if (DEBUG) LOG.debug("Adding frame-aware method names: {}", Arrays.toString(methods));
         FRAME_AWARE_METHODS.addAll(Arrays.asList(methods));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static void addScopeAwareMethods(String... methods) {
         if (DEBUG) LOG.debug("Adding scope-aware method names: {}", Arrays.toString(methods));
         SCOPE_AWARE_METHODS.addAll(Arrays.asList(methods));

--- a/core/src/main/java/org/jruby/runtime/ObjectMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/ObjectMarshal.java
@@ -48,14 +48,14 @@ public interface ObjectMarshal<T> {
             throw typeError(context, "no marshal_load is defined for class " + type.getName(context));
         }
 
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) {
             var context = runtime.getCurrentContext();
             throw typeError(context, "no marshal_dump is defined for class " + type.getName(context));
         }
 
-        @Deprecated(since = "10.0", forRemoval = true)
+        @Deprecated(since = "10.0.0.0", forRemoval = true)
         @SuppressWarnings("removal")
         public Object unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) {
             var context = runtime.getCurrentContext();
@@ -66,12 +66,12 @@ public interface ObjectMarshal<T> {
     void marshalTo(ThreadContext context, RubyOutputStream out, T obj, RubyClass type, MarshalDumper dumper);
     T unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader loader);
 
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     default void marshalTo(Ruby runtime, T obj, RubyClass type, org.jruby.runtime.marshal.MarshalStream marshalStream) throws IOException {
         // no-op to allow implementing only the MarshalDumper version
     }
-    @Deprecated(since = "10.0", forRemoval = true)
+    @Deprecated(since = "10.0.0.0", forRemoval = true)
     @SuppressWarnings("removal")
     default T unmarshalFrom(Ruby runtime, RubyClass type, org.jruby.runtime.marshal.UnmarshalStream unmarshalStream) throws IOException {
         // no-op to allow implementing only the MarshalLoader version

--- a/core/src/main/java/org/jruby/runtime/ObjectSpace.java
+++ b/core/src/main/java/org/jruby/runtime/ObjectSpace.java
@@ -116,12 +116,12 @@ public class ObjectSpace {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public long idOf(IRubyObject rubyObject) {
         return createAndRegisterObjectId(rubyObject);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.10.0")
     public void addFinalizer(IRubyObject object, IRubyObject proc) {
         addFinalizer(((RubyBasicObject) object).getCurrentContext(), object, proc);
     }

--- a/core/src/main/java/org/jruby/runtime/RubyEvent.java
+++ b/core/src/main/java/org/jruby/runtime/RubyEvent.java
@@ -54,7 +54,7 @@ public enum RubyEvent {
         this.requiresDebug = requiresDebug;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.9.0")
     public int getLineNumberOffset(){
         return 0;
     }

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -142,7 +142,7 @@ public class Signature {
     public int required() { return pre + post; }
 
     // We calculate this every time but no one should be using this any more
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public Arity arity() {
         // NOTE: Some logic to *assign* variables still uses Arity, which treats Rest.ANON (the
         //       |a,| form) as a rest arg for destructuring purposes. However ANON does *not*
@@ -208,7 +208,7 @@ public class Signature {
     }
 
     // Lossy conversion to half-support older signatures which externally use Arity but needs to be converted.
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static Signature from(Arity arity) {
         switch(arity.required()) {
             case 0:
@@ -372,7 +372,7 @@ public class Signature {
         return "signature(pre=" + pre + ",opt=" + opt + ",post=" + post + ",rest=" + rest + ",kwargs=" + kwargs + ",kwreq=" + requiredKwargs + ",kwrest=" + keyRest + ")";
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void checkArity(Ruby runtime, IRubyObject[] args) {
         checkArity(runtime.getCurrentContext(), args);
     }

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -183,7 +183,7 @@ public final class ThreadContext {
      * This fields is no longer initialized, is null by default!
      * @deprecated Use {@link #getSecureRandom()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public transient SecureRandom secureRandom;
 
     private static boolean tryPreferredPRNG = true;
@@ -442,7 +442,7 @@ public final class ThreadContext {
         catchStack = newCatchStack;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.6.0")
     public void pushCatch(RubyContinuation.Continuation catchTarget) {
         pushCatch((CatchThrow) catchTarget);
     }
@@ -854,7 +854,7 @@ public final class ThreadContext {
     /**
      * Used by the evaluator and the compiler to look up a constant by name
      */
-    @Deprecated
+    @Deprecated(since = "1.7.2")
     public IRubyObject getConstant(String internedName) {
         return getCurrentStaticScope().getConstant(this, internedName);
     }
@@ -1549,7 +1549,7 @@ public final class ThreadContext {
      * @return the old call info
      * @deprecated use the trivially-inlinable static version
      */
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public int resetCallInfo() {
         return resetCallInfo(this);
     }
@@ -1571,7 +1571,7 @@ public final class ThreadContext {
      * Clear call info state (set to 0).
      * @deprecated use the trivially-inlinable static version
      */
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public void clearCallInfo() {
         clearCallInfo(this);
     }
@@ -1588,7 +1588,7 @@ public final class ThreadContext {
         return (callInfo & CALL_KEYWORD) != 0;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public IRubyObject setBackRef(IRubyObject match) {
         if (match.isNil()) return clearBackRef();
 

--- a/core/src/main/java/org/jruby/runtime/TraceEventManager.java
+++ b/core/src/main/java/org/jruby/runtime/TraceEventManager.java
@@ -67,7 +67,7 @@ public class TraceEventManager {
                     RubyEvent.RETURN
             );
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public synchronized void addEventHook(EventHook hook) {
         addEventHook(runtime.getCurrentContext(), hook);
     }

--- a/core/src/main/java/org/jruby/runtime/backtrace/RubyStackTraceElement.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/RubyStackTraceElement.java
@@ -79,7 +79,7 @@ public class RubyStackTraceElement implements java.io.Serializable {
         return element = new StackTraceElement(className, methodName, fileName, lineNumber);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.0.0")
     public StackTraceElement getElement() { return asStackTraceElement(); }
 
     public String toString() {
@@ -103,7 +103,7 @@ public class RubyStackTraceElement implements java.io.Serializable {
         return line;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public final CharSequence mriStyleString() {
         // return fileName + ':' + lineNumber + ":in '" + methodName + '\'';
         return new StringBuilder(fileName.length() + methodName.length() + 12).

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -814,7 +814,7 @@ public class TraceType {
         return TraceType.isInternalFile(filename) || TraceType.hasInternalMarker(filename);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public RubyStackTraceElement getBacktraceElement(ThreadContext context, int uplevel) {
         // NOTE: could be optimized not to walk the whole stack
         RubyStackTraceElement[] elements = getBacktrace(context).getBacktrace(context.runtime);

--- a/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
@@ -64,16 +64,16 @@ public interface IRubyObject {
 
     IRubyObject[] NULL_ARRAY = new IRubyObject[0];
 
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public IRubyObject callSuper(ThreadContext context, IRubyObject[] args, Block block);
 
     public IRubyObject callMethod(ThreadContext context, String name);
     public IRubyObject callMethod(ThreadContext context, String name, IRubyObject arg);
     public IRubyObject callMethod(ThreadContext context, String name, IRubyObject[] args);
     public IRubyObject callMethod(ThreadContext context, String name, IRubyObject[] args, Block block);
-    @Deprecated
+    @Deprecated(since = "1.1.5")
     public IRubyObject callMethod(ThreadContext context, int methodIndex, String name);
-    @Deprecated
+    @Deprecated(since = "1.1.6")
     public IRubyObject callMethod(ThreadContext context, int methodIndex, String name, IRubyObject arg);
 
     public IRubyObject checkCallMethod(ThreadContext context, String name);
@@ -346,7 +346,7 @@ public interface IRubyObject {
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other);
     public boolean eql(IRubyObject other);
 
-    @Deprecated
+    @Deprecated(since = "9.4.10.0")
     public void addFinalizer(IRubyObject finalizer);
 
     @SuppressWarnings("deprecation")
@@ -386,7 +386,7 @@ public interface IRubyObject {
      * 
      * @param variables the variables to be set for object 
      */
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     void syncVariables(List<Variable<Object>> variables);
 
     /**
@@ -444,7 +444,7 @@ public interface IRubyObject {
      * @deprecated Use {@link #checkStringType()} instead.
      * @return the string if so
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     default IRubyObject checkStringType19() {
         return checkStringType();
     }
@@ -456,17 +456,17 @@ public interface IRubyObject {
      * @see #convertToInteger(String)
      * @return integer
      */
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     default RubyInteger convertToInteger(int convertMethodIndex, String convertMethod) {
         return convertToInteger(convertMethod);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     boolean isTaint();
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     void setTaint(boolean taint);
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     IRubyObject infectBy(IRubyObject obj);
 }

--- a/core/src/main/java/org/jruby/runtime/builtin/InstanceVariables.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/InstanceVariables.java
@@ -28,7 +28,7 @@ public interface InstanceVariables {
      */
     boolean hasInstanceVariable(String name);
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     boolean fastHasInstanceVariable(String internedName);
     
     /**
@@ -39,7 +39,7 @@ public interface InstanceVariables {
      */
     IRubyObject getInstanceVariable(String name);
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     IRubyObject fastGetInstanceVariable(String internedName);
 
     /**
@@ -51,7 +51,7 @@ public interface InstanceVariables {
      */    
     IRubyObject setInstanceVariable(String name, IRubyObject value);
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     IRubyObject fastSetInstanceVariable(String internedName, IRubyObject value);
 
     /**

--- a/core/src/main/java/org/jruby/runtime/builtin/InternalVariables.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/InternalVariables.java
@@ -21,7 +21,7 @@ public interface InternalVariables {
      */
     boolean hasInternalVariable(String name);
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     boolean fastHasInternalVariable(String internedName);
     
     /**
@@ -33,7 +33,7 @@ public interface InternalVariables {
      */
     Object getInternalVariable(String name);
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     Object fastGetInternalVariable(String internedNaem);
     
     /**
@@ -45,7 +45,7 @@ public interface InternalVariables {
      */
     void setInternalVariable(String name, Object value);
 
-    @Deprecated
+    @Deprecated(since = "1.7.0")
     void fastSetInternalVariable(String internedName, Object value);
     
     /**

--- a/core/src/main/java/org/jruby/runtime/callback/Callback.java
+++ b/core/src/main/java/org/jruby/runtime/callback/Callback.java
@@ -35,7 +35,7 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.builtin.IRubyObject;
 
-@Deprecated
+@Deprecated(since = "1.7.4")
 public interface Callback {
     IRubyObject execute(IRubyObject recv, IRubyObject[] args, Block block);
     Arity getArity();

--- a/core/src/main/java/org/jruby/runtime/callsite/CachingCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/CachingCallSite.java
@@ -17,7 +17,7 @@ import static org.jruby.api.Convert.asFloat;
 public abstract class CachingCallSite extends CallSite {
 
     protected CacheEntry cache = CacheEntry.NULL_CACHE;
-    @Deprecated
+    @Deprecated(since = "9.2.17.0")
     protected CacheEntry builtinCache = CacheEntry.NULL_CACHE;
 
     public CachingCallSite(String methodName, CallType callType) {
@@ -400,7 +400,7 @@ public abstract class CachingCallSite extends CallSite {
         return cacheAndGet(selfType, methodName);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.8.0")
     public final CacheEntry retrieveCache(RubyClass selfType, String methodName) {
         // This must be retrieved *once* to avoid racing with other threads.
         CacheEntry cache = this.cache;
@@ -425,7 +425,7 @@ public abstract class CachingCallSite extends CallSite {
         return retrieveCache(selfType).method.isBuiltin();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.8.0")
     private CacheEntry cacheAndGet(RubyClass selfType, String methodName) {
         CacheEntry entry = selfType.searchWithCache(methodName);
         if (!entry.method.isUndefined()) {

--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -334,7 +334,7 @@ public final class EncodingService {
         return findEncodingCommon(((RubyString) arg).getByteList(), error);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     private Encoding getEncodingFromNKFName(final String name) {
         HashEntryIterator hei = encodings.entryIterator();
         while (hei.hasNext()) {
@@ -473,7 +473,7 @@ public final class EncodingService {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public Encoding getWindowsFilesystemEncoding(Ruby runtime) {
         return getWindowsFilesystemEncoding(runtime.getCurrentContext());
     }
@@ -562,7 +562,7 @@ public final class EncodingService {
         return findEncodingEntry(e.getName());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.1.0")
     public Encoding getFileSystemEncoding(Ruby runtime) {
         return getFileSystemEncoding();
     }

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -161,16 +161,16 @@ public class LoadService {
             return suffixes;
         }
 
-        @Deprecated
+        @Deprecated(since = "9.3.0.0")
         public String[] getSuffixes() {
             return suffixes.stream()
                     .map((suffix) -> suffix.name())
                     .toArray(String[]::new);
         }
 
-        @Deprecated
+        @Deprecated(since = "9.3.0.0")
         public static final String[] sourceSuffixes = LibrarySearcher.Suffix.SOURCES.stream().map((suffix) -> suffix.name()).toArray(String[]::new);
-        @Deprecated
+        @Deprecated(since = "9.3.0.0")
         public static final String[] extensionSuffixes = LibrarySearcher.Suffix.EXTENSIONS.stream().map((suffix) -> suffix.name()).toArray(String[]::new);
     }
 

--- a/core/src/main/java/org/jruby/runtime/marshal/CoreObjectType.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/CoreObjectType.java
@@ -38,7 +38,7 @@ public interface CoreObjectType {
      *
      * @return the ClassIndex of the native type this object was constructed from
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     int getNativeTypeIndex();
     
     /**

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
@@ -42,7 +42,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.collections.HashMapInt;
 
-@Deprecated(since = "10.0", forRemoval = true)
+@Deprecated(since = "10.0.0.0", forRemoval = true)
 @SuppressWarnings("removal")
 public class MarshalCache {
     private final HashMapInt linkCache = new HashMapInt<>(true);

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
@@ -79,7 +79,7 @@ import static org.jruby.util.RubyStringBuilder.types;
  *
  * @author Anders
  */
-@Deprecated(since = "10.0", forRemoval = true)
+@Deprecated(since = "10.0.0.0", forRemoval = true)
 @SuppressWarnings("removal")
 public class MarshalStream extends FilterOutputStream {
     private final Ruby runtime;
@@ -110,7 +110,7 @@ public class MarshalStream extends FilterOutputStream {
         if (depth == 0) out.flush(); // flush afer whole dump is complete
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void registerLinkTarget(IRubyObject newObject) {
         registerLinkTarget(((RubyBasicObject) newObject).getCurrentContext(), newObject);
     }
@@ -205,7 +205,7 @@ public class MarshalStream extends FilterOutputStream {
         return ((MarshalEncoding) value).shouldMarshalEncoding();
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void writeDirectly(IRubyObject value) throws IOException {
         writeDirectly(value.getRuntime().getCurrentContext(), value);
     }
@@ -339,7 +339,7 @@ public class MarshalStream extends FilterOutputStream {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void userNewMarshal(IRubyObject value, CacheEntry entry) throws IOException {
         userNewMarshal(((RubyBasicObject) value).getCurrentContext(), value, entry);
     }
@@ -348,7 +348,7 @@ public class MarshalStream extends FilterOutputStream {
         userNewCommon(context, value, entry);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void userNewMarshal(IRubyObject value) throws IOException {
         userNewMarshal(((RubyBasicObject) value).getCurrentContext(), value);
     }
@@ -375,7 +375,7 @@ public class MarshalStream extends FilterOutputStream {
         dumpObject(marshaled);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void userMarshal(IRubyObject value, CacheEntry entry) throws IOException {
         userMarshal(((RubyBasicObject) value).getCurrentContext(), value, entry);
     }
@@ -384,7 +384,7 @@ public class MarshalStream extends FilterOutputStream {
         userCommon(context, value, entry);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void userMarshal(IRubyObject value) throws IOException {
         userMarshal(((RubyBasicObject) value).getCurrentContext(), value);
     }
@@ -505,7 +505,7 @@ public class MarshalStream extends FilterOutputStream {
         return type;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void dumpDefaultObjectHeader(RubyClass type) throws IOException {
         dumpDefaultObjectHeader(runtime.getCurrentContext(), type);
     }
@@ -514,7 +514,7 @@ public class MarshalStream extends FilterOutputStream {
         dumpDefaultObjectHeader(context, 'o',type);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public void dumpDefaultObjectHeader(char tp, RubyClass type) throws IOException {
         dumpDefaultObjectHeader(type.getRuntime().getCurrentContext(), tp, type);
     }
@@ -572,12 +572,12 @@ public class MarshalStream extends FilterOutputStream {
         out.write(value);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public boolean isTainted() {
         return false;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public boolean isUntrusted() {
         return false;
     }

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalCache.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalCache.java
@@ -44,7 +44,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Error.typeError;
 
-@Deprecated(since = "10.0", forRemoval = true)
+@Deprecated(since = "10.0.0.0", forRemoval = true)
 @SuppressWarnings("removal")
 public class UnmarshalCache {
     private final Ruby runtime;
@@ -94,23 +94,23 @@ public class UnmarshalCache {
     }
 
     // Deprecated: Use readSymbolLink OR readDataLink directly
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject readLink(UnmarshalStream input, int type) throws IOException {
         return type == '@' ? readDataLink(input) : readSymbolLink(input);
     }
 
     // Deprecated: Use registerDataLink or registerSymbolLink directly.
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public void register(IRubyObject value) {
         selectCache(value).add(value);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public boolean isLinkType(int c) {
         return c == ';' || c == '@';
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     private List selectCache(IRubyObject value) {
         return (value instanceof RubySymbol) ? symbols : links;
     }

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
@@ -84,7 +84,7 @@ import static org.jruby.util.RubyStringBuilder.str;
  *
  * @author Anders
  */
-@Deprecated(since = "10.0", forRemoval = true)
+@Deprecated(since = "10.0.0.0", forRemoval = true)
 @SuppressWarnings("removal")
 public class UnmarshalStream extends InputStream {
 
@@ -759,13 +759,13 @@ public class UnmarshalStream extends InputStream {
         return inputStream.read();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public void defaultVariablesUnmarshal(MarshalState state, IRubyObject object) throws IOException {
         ivar(state, object, null);
     }
 
     // r_object
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public IRubyObject unmarshalObject(boolean _callProc) throws IOException { // <-- 100% false by all callers
         IRubyObject savedProc = this.proc;
         try {
@@ -776,12 +776,12 @@ public class UnmarshalStream extends InputStream {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public UnmarshalStream(Ruby runtime, InputStream in, IRubyObject proc, boolean taint, boolean untrust) throws IOException {
         this(runtime, in, proc);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public UnmarshalStream(Ruby runtime, InputStream in, IRubyObject proc, boolean taint) throws IOException {
         this(runtime, in, proc);
     }

--- a/core/src/main/java/org/jruby/runtime/opto/ObjectIdentityInvalidator.java
+++ b/core/src/main/java/org/jruby/runtime/opto/ObjectIdentityInvalidator.java
@@ -29,7 +29,7 @@ package org.jruby.runtime.opto;
 
 import java.util.List;
 
-@Deprecated(since = "10.0", forRemoval = true)
+@Deprecated(since = "10.0.0.0", forRemoval = true)
 public class ObjectIdentityInvalidator implements Invalidator {
     private volatile Object generation;
     

--- a/core/src/main/java/org/jruby/runtime/scope/ManyVarsDynamicScope.java
+++ b/core/src/main/java/org/jruby/runtime/scope/ManyVarsDynamicScope.java
@@ -298,7 +298,7 @@ public class ManyVarsDynamicScope extends DynamicScope {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.6.0")
     public DynamicScope cloneScope() {
         // we construct new rather than clone to avoid sharing variableValues
         return new ManyVarsDynamicScope(staticScope, parent);

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -214,7 +214,7 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
         return this;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     protected void storeInternal(final int index, final IRubyObject value) {
         storeInternal(getCurrentContext(), index, value);
     }

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -287,7 +287,7 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
         return !honorOverride || sites.op_cmp_fixnum.isBuiltin(runtime.getFixnum());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     protected void storeInternal(final int index, final IRubyObject value) {
         storeInternal(getCurrentContext(), index, value);
     }

--- a/core/src/main/java/org/jruby/util/ByteList.java
+++ b/core/src/main/java/org/jruby/util/ByteList.java
@@ -63,11 +63,11 @@ public class ByteList implements Comparable, CharSequence, Serializable {
 
     // NOTE: AR-JDBC (still) uses these fields directly in its ext .java parts  ,
     // until there's new releases we shall keep them public and maybe review other exts using BL's API
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public byte[] bytes;
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public int begin;
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public int realSize;
 
     private Encoding encoding = ASCIIEncoding.INSTANCE;

--- a/core/src/main/java/org/jruby/util/ClassProvider.java
+++ b/core/src/main/java/org/jruby/util/ClassProvider.java
@@ -33,7 +33,7 @@ import org.jruby.RubyModule;
 import org.jruby.runtime.ThreadContext;
 
 public interface ClassProvider {
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     default RubyClass defineClassUnder(RubyModule module, String name, RubyClass superClazz) {
         return defineClassUnder(module.getCurrentContext(), module, name, superClazz);
     }
@@ -42,7 +42,7 @@ public interface ClassProvider {
         throw new RuntimeException("Missing defineClassUnder implementation");
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     default RubyModule defineModuleUnder(RubyModule module, String name) {
         return defineModuleUnder(module.getCurrentContext(), module, name);
     }

--- a/core/src/main/java/org/jruby/util/ConvertBytes.java
+++ b/core/src/main/java/org/jruby/util/ConvertBytes.java
@@ -38,7 +38,7 @@ public class ConvertBytes {
         this.base = base;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public ConvertBytes(Ruby runtime, ByteList str, int base, boolean badcheck, boolean is19) {
         this(runtime, str, base, badcheck);
     }

--- a/core/src/main/java/org/jruby/util/Dir.java
+++ b/core/src/main/java/org/jruby/util/Dir.java
@@ -949,7 +949,7 @@ public class Dir {
     /**
      * @deprecated No replacement; not intended to be made public
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static int range(byte[] _pat, int pat, int pend, char test, int flags) {
         return new FilenameMatch(pat, 0, flags).helper(_pat, pend, new byte[] {(byte) test}, 1, ASCIIEncoding.INSTANCE);
     }

--- a/core/src/main/java/org/jruby/util/FileResource.java
+++ b/core/src/main/java/org/jruby/util/FileResource.java
@@ -62,7 +62,7 @@ public interface FileResource {
     // For transition to file resources only. Implementations should return
     // JRubyFile if this resource is backed by one, and NOT_FOUND JRubyFile
     // otherwise.
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     default JRubyFile hackyGetJRubyFile() {
         try {
             return unwrap(JRubyFile.class);

--- a/core/src/main/java/org/jruby/util/IdUtil.java
+++ b/core/src/main/java/org/jruby/util/IdUtil.java
@@ -74,7 +74,7 @@ public final class IdUtil {
     /**
      * rb_is_local_id and is_local_id
      */
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static boolean isLocal(String id) {
         return !isGlobal(id) && !isClassVariable(id) && !isInstanceVariable(id) && !isConstant(id) && !isPredicate(id) && !isSpecial(id);
     }

--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -229,7 +229,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
         });
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.22")
     public synchronized Runnable getJDBCDriverUnloader() {
         if (unloader == null) {
             try {

--- a/core/src/main/java/org/jruby/util/JavaNameMangler.java
+++ b/core/src/main/java/org/jruby/util/JavaNameMangler.java
@@ -360,7 +360,7 @@ public class JavaNameMangler {
 
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.7.0")
     public static boolean willMethodMangleOk(CharSequence name) {
         if (false && Platform.IS_IBM) {
             // IBM's JVM is much less forgiving, so we disallow anything with non-alphanumeric, _, and $

--- a/core/src/main/java/org/jruby/util/MRIRecursionGuard.java
+++ b/core/src/main/java/org/jruby/util/MRIRecursionGuard.java
@@ -25,18 +25,18 @@ public class MRIRecursionGuard {
     private final ThreadLocal<Map<String, RubyHash>> recursive = new ThreadLocal<Map<String, RubyHash>>();
     private final ThreadLocal<Boolean> inRecursiveListOperation = new ThreadLocal<>();
 
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     public MRIRecursionGuard(Ruby runtime) {
         this.runtime = runtime;
         this.recursiveKey = runtime.newSymbol("__recursive_key__");
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     public interface RecursiveFunction  {
         IRubyObject call(IRubyObject obj, boolean recur);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     public IRubyObject execRecursive(RecursiveFunction func, IRubyObject obj) {
         if (!inRecursiveListOperation.get()) {
             throw runtime.newThreadError("BUG: execRecursive called outside recursiveListOperation");
@@ -44,7 +44,7 @@ public class MRIRecursionGuard {
         return execRecursiveInternal(func, obj, null, false);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     public IRubyObject execRecursiveOuter(RecursiveFunction func, IRubyObject obj) {
         try {
             return execRecursiveInternal(func, obj, null, true);
@@ -53,7 +53,7 @@ public class MRIRecursionGuard {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     public <T extends IRubyObject> T recursiveListOperation(Callable<T> body) {
         try {
             inRecursiveListOperation.set(true);
@@ -68,7 +68,7 @@ public class MRIRecursionGuard {
     }
 
     // exec_recursive
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     private IRubyObject execRecursiveInternal(RecursiveFunction func, IRubyObject obj, IRubyObject pairid, boolean outer) {
         var context = runtime.getCurrentContext();
         ExecRecursiveParams p = new ExecRecursiveParams();

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -938,7 +938,7 @@ public class Numeric {
         return x.op_eqq(context, y).isTrue();
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void checkInteger(ThreadContext context, IRubyObject obj) {
         if (!(obj instanceof RubyInteger)) throw typeError(context, "not an integer");
     }

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -2671,30 +2671,30 @@ public class Pack {
         result.append((byte) ((s & 0xff00) >> 8)).append((byte) (s & 0xff));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static RubyArray unpack(Ruby runtime, ByteList encodedString, ByteList formatString) {
         return unpackWithBlock(runtime.getCurrentContext(), runtime, encodedString, formatString, Block.NULL_BLOCK);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static RubyString pack(Ruby runtime, RubyArray list, ByteList formatString) {
         RubyString buffer = runtime.newString();
         return packCommon(runtime.getCurrentContext(), list, formatString, executor(), buffer);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static RubyString pack(ThreadContext context, Ruby runtime, RubyArray list, RubyString formatString) {
         RubyString buffer = runtime.newString();
         return pack(context, list, formatString, buffer);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static void decode(ThreadContext context, Ruby runtime, ByteBuffer encode, int occurrences,
                               RubyArray result, Block block, Converter converter) {
         decode(context, encode, occurrences, result, block, converter, block.isGiven() ? UNPACK_BLOCK : UNPACK_ARRAY);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static RubyArray unpackWithBlock(ThreadContext context, Ruby runtime, ByteList encodedString, ByteList formatString, Block block) {
         return unpackWithBlock(context, RubyString.newStringLight(runtime, encodedString), formatString, block);
     }

--- a/core/src/main/java/org/jruby/util/RegexpSupport.java
+++ b/core/src/main/java/org/jruby/util/RegexpSupport.java
@@ -186,7 +186,7 @@ public class RegexpSupport {
         return 0;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void raiseRegexpError19(Ruby runtime, ByteList bytes, Encoding enc, RegexpOptions options, String err) {
         raiseRegexpError(runtime, bytes, enc, options, err);
     }
@@ -197,7 +197,7 @@ public class RegexpSupport {
         throw runtime.newRegexpError(err + ": " + regexpDescription(runtime, bytes, options, enc));
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static ByteList regexpDescription19(Ruby runtime, ByteList bytes, RegexpOptions options, Encoding enc) {
         return regexpDescription(runtime, bytes, options, enc);
     }
@@ -224,7 +224,7 @@ public class RegexpSupport {
         return description;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void appendRegexpString19(Ruby runtime, ByteList to, byte[] bytes, int start, int len, Encoding enc, Encoding resEnc) {
         appendRegexpString(runtime, to, bytes, start, len, enc, resEnc);
     }

--- a/core/src/main/java/org/jruby/util/ResourceException.java
+++ b/core/src/main/java/org/jruby/util/ResourceException.java
@@ -87,7 +87,7 @@ public abstract class ResourceException extends IOException {
         public TooManySymlinks(String path) { super("ELOOP", path); }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.1.0")
     public static class IOError extends ResourceException {
         private final IOException ioe;
 

--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -242,7 +242,7 @@ public class ShellLauncher {
         return getModifiedEnv(runtime, mergeEnv == null ? Collections.EMPTY_LIST : mergeEnv.entrySet(), false);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static String[] getModifiedEnv(Ruby runtime, Collection mergeEnv, boolean clearEnv) {
         return getModifiedEnv(runtime.getCurrentContext(), mergeEnv, clearEnv);
     }
@@ -432,7 +432,7 @@ public class ShellLauncher {
         return findPathExecutable(context, fname, pathObject);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static File findPathExecutable(Ruby runtime, String fname, IRubyObject pathObject) {
         return findPathExecutable(runtime.getCurrentContext(), fname, pathObject);
     }
@@ -842,22 +842,22 @@ public class ShellLauncher {
         return new POpenProcess(popenShared(runtime, new IRubyObject[] {string}, env, true), runtime, modes);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public static POpenProcess popen(Ruby runtime, IRubyObject string, IOOptions modes) throws IOException {
         return new POpenProcess(popenShared(runtime, new IRubyObject[] {string}, null, true), runtime, modes);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.7.4")
     public static POpenProcess popen(Ruby runtime, IRubyObject[] strings, Map env, IOOptions modes) throws IOException {
         return new POpenProcess(popenShared(runtime, strings, env), runtime, modes);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static POpenProcess popen3(Ruby runtime, IRubyObject[] strings) throws IOException {
         return new POpenProcess(popenShared(runtime, strings));
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static POpenProcess popen3(Ruby runtime, IRubyObject[] strings, boolean addShell) throws IOException {
         return new POpenProcess(popenShared(runtime, strings, null, addShell));
     }
@@ -924,7 +924,7 @@ public class ShellLauncher {
         private Pumper inputPumper;
         private Pumper inerrPumper;
 
-        @Deprecated
+        @Deprecated(since = "1.7.4")
         public POpenProcess(Process child, Ruby runtime, IOOptions modes) {
             this(child, runtime, modes.getModeFlags());
         }
@@ -1735,22 +1735,22 @@ public class ShellLauncher {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static OutputStream unwrapBufferedStream(OutputStream filteredStream) {
         return ChannelHelper.unwrapBufferedStream(filteredStream);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static InputStream unwrapBufferedStream(InputStream filteredStream) {
         return ChannelHelper.unwrapBufferedStream(filteredStream);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static OutputStream unwrapFilterOutputStream(OutputStream filteredStream) {
         return ChannelHelper.unwrapFilterOutputStream(filteredStream);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public static InputStream unwrapFilterInputStream(InputStream filteredStream) {
         return ChannelHelper.unwrapFilterInputStream(filteredStream);
     }

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -246,7 +246,7 @@ public class Sprintf {
             positionIndex = -2;
         }
 
-        @Deprecated
+        @Deprecated(since = "9.1.8.0")
         IRubyObject next(ByteList name) {
             // for 1.9 hash args
             if (name != null) {

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -578,7 +578,7 @@ public final class StringSupport {
         return enc.mbcToCode(bytes, p, end);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int codePoint(Ruby runtime, Encoding enc, byte[] bytes, int p, int end) {
         return codePoint(runtime.getCurrentContext(), enc, bytes, p, end);
     }
@@ -591,7 +591,7 @@ public final class StringSupport {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int codePoint(final Ruby runtime, final ByteList value) {
         return codePoint(runtime.getCurrentContext(), value);
     }
@@ -745,12 +745,12 @@ public final class StringSupport {
         return offset(str.getEncoding(), value.getUnsafeBytes(), value.getBegin(), value.getBegin() + value.getRealSize(), pos);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static int toLower(Encoding enc, int c) {
         return Encoding.isAscii(c) ? AsciiTables.ToLowerCaseTable[c] : c;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static int toUpper(Encoding enc, int c) {
         return Encoding.isAscii(c) ? AsciiTables.ToUpperCaseTable[c] : c;
     }
@@ -907,13 +907,13 @@ public final class StringSupport {
         return 0;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int memchr(byte[] ptr, int start, final int find, int len) {
         return Helpers.memchr(ptr, start, find, len);
     }
 
     // MRI: StringValueCStr, rb_string_value_cstr without trailing null addition
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString checkEmbeddedNulls(Ruby runtime, IRubyObject ptr) {
         return Check.checkEmbeddedNulls(runtime.getCurrentContext(), ptr);
     }
@@ -1161,7 +1161,7 @@ public final class StringSupport {
         return count;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int strCount(ByteList str, Ruby runtime, boolean[] table, TrTables tables, Encoding enc) {
         return strCount(runtime.getCurrentContext(), str, table, tables, enc);
     }
@@ -1407,7 +1407,7 @@ public final class StringSupport {
         return tables;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static TrTables trSetupTable(final ByteList str, final Ruby runtime,
                                         final boolean[] stable, TrTables tables, final boolean first, final Encoding enc) {
         return trSetupTable(runtime.getCurrentContext(), str, stable, tables, first, enc);
@@ -1574,7 +1574,7 @@ public final class StringSupport {
         return valueCopy;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static ByteList succCommon(Ruby runtime, ByteList original) {
         return succCommon(runtime.getCurrentContext(), original);
     }
@@ -1896,12 +1896,12 @@ public final class StringSupport {
         return source.getByteList();
     }
 
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     public static void replaceInternal19(int beg, int len, CodeRangeable source, CodeRangeable repl) {
         strUpdate(beg, len, source, repl);
     }
 
-    @Deprecated(since = "9.4")
+    @Deprecated(since = "10.0.0.0")
     public static void replaceInternal19(Ruby runtime, int beg, int len, RubyString source, RubyString repl) {
         strUpdate(runtime.getCurrentContext(), beg, len, source, repl);
     }
@@ -1930,7 +1930,7 @@ public final class StringSupport {
         if (cr != source.getCodeRange()) source.setCodeRange(cr);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void strUpdate(Ruby runtime, int beg, int len, RubyString source, RubyString repl) {
         strUpdate(runtime.getCurrentContext(), beg, len, source, repl);
     }
@@ -2004,7 +2004,7 @@ public final class StringSupport {
         return modify ? rubyString : null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static CodeRangeable strDeleteBang(CodeRangeable rubyString, Ruby runtime, boolean[] squeeze, TrTables tables, Encoding enc) {
         return strDeleteBang(runtime.getCurrentContext(), rubyString, squeeze, tables, enc);
     }
@@ -2572,7 +2572,7 @@ public final class StringSupport {
         return null;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static CodeRangeable trTransHelper(Ruby runtime, CodeRangeable self, CodeRangeable srcStr, CodeRangeable replStr, boolean sflag) {
         try {
             return trTransHelper(self, srcStr, replStr, sflag);
@@ -2694,7 +2694,7 @@ public final class StringSupport {
         return false;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static boolean multiByteSqueeze(Ruby runtime, ByteList value, boolean squeeze[], TrTables tables, Encoding enc, boolean isArg) {
         return multiByteSqueeze(runtime.getCurrentContext(), value, squeeze, tables, enc, isArg);
     }
@@ -2819,7 +2819,7 @@ public final class StringSupport {
         return -1;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int checkCaseMapOptions(Ruby runtime, IRubyObject arg0, IRubyObject arg1, int flags) {
         return checkCaseMapOptions(runtime.getCurrentContext(), arg0, arg1, flags);
     }
@@ -2848,7 +2848,7 @@ public final class StringSupport {
         return flags;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static int checkCaseMapOptions(Ruby runtime, IRubyObject arg0, int flags) {
         return checkCaseMapOptions(runtime.getCurrentContext(), arg0, arg0, flags);
     }
@@ -2888,7 +2888,7 @@ public final class StringSupport {
 
     private static final int CASE_MAPPING_ADDITIONAL_LENGTH = 20;
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static ByteList caseMap(Ruby runtime, ByteList src, IntHolder flags, Encoding enc) {
         return caseMap(runtime.getCurrentContext(), src, flags, enc);
     }
@@ -2930,7 +2930,7 @@ public final class StringSupport {
         return tgt;
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static void asciiOnlyCaseMap(Ruby runtime, ByteList value, IntHolder flags, Encoding enc) {
         asciiOnlyCaseMap(runtime.getCurrentContext(), value, flags);
     }
@@ -2960,7 +2960,7 @@ public final class StringSupport {
         return new String(bytes.unsafeBytes(), bytes.begin(), bytes.realSize());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.16.0")
     public static boolean isUnicode(Encoding enc) {
         return enc.isUnicode();
     }

--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -160,7 +160,7 @@ public class TypeConverter {
      * @param obj the object to check
      * @return the converted value
      */
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject checkData(IRubyObject obj) {
         if (obj instanceof org.jruby.runtime.marshal.DataType) return obj;
 
@@ -176,7 +176,7 @@ public class TypeConverter {
         return obj.getMetaClass().getRealClass().rubyName(context);
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubySymbol checkID(IRubyObject obj) {
         return Check.checkID(obj.getRuntime().getCurrentContext(), obj);
     }
@@ -189,7 +189,7 @@ public class TypeConverter {
      *
      * For 2.2 compatibility, we also force all incoming identifiers to get anchored as hard-referenced symbols.
      */
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubySymbol checkID(Ruby runtime, String name) {
         return RubySymbol.newHardSymbol(runtime, name.intern());
     }
@@ -490,14 +490,14 @@ public class TypeConverter {
         return context.sites.TypeConverter;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject convertToType(IRubyObject obj, RubyClass target, int convertMethodIndex, String convertMethod, boolean raise) {
         if (!obj.respondsTo(convertMethod)) return handleUncoercibleObject(raise, obj, target);
 
         return obj.callMethod(obj.getRuntime().getCurrentContext(), convertMethod);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject convertToType(IRubyObject obj, RubyClass target, int convertMethodIndex, String convertMethod) {
         if (target.isInstance(obj)) return obj;
         IRubyObject val = convertToType(obj, target, convertMethod, true);
@@ -509,7 +509,7 @@ public class TypeConverter {
         return val;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static IRubyObject convertToTypeWithCheck(IRubyObject obj, RubyClass target, int convertMethodIndex, String convertMethod) {
         if (target.isInstance(obj)) return obj;
         IRubyObject val = TypeConverter.convertToType(obj, target, convertMethod, false);
@@ -522,7 +522,7 @@ public class TypeConverter {
         return val;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.3.0")
     public static String convertToIdentifier(IRubyObject obj) {
         // Assume Symbol already returns ISO8859-1/raw bytes from asJavaString()
         // Assume all other objects cannot participate in providing raw bytes since we cannot

--- a/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
+++ b/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
@@ -807,7 +807,7 @@ public class ArgumentProcessor {
         return null;
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.3.0")
     public String resolveScriptUsingClassLoader(String scriptName) {
         if (RubyInstanceConfig.defaultClassLoader().getResourceAsStream("bin/" + scriptName) != null){
             return "classpath:/bin/" + scriptName;

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -366,112 +366,112 @@ public class Options {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> PARSER_WARN_GROUPED_EXPRESSIONS = bool(PARSER, "parser.warn.grouped_expressions", true, "Warn about interpreting (...) as a grouped expression.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> COMPILE_FASTOPS = bool(COMPILER, "compile.fastops", true, "Turn on fast operators for Fixnum and Float.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> COMPILE_THREADLESS = bool(COMPILER, "compile.threadless", false, "(EXPERIMENTAL) Turn on compilation without polling for \"unsafe\" thread events.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Integer> COMPILE_CHAINSIZE = integer(COMPILER, "compile.chainsize", Constants.CHAINED_COMPILE_LINE_COUNT_DEFAULT, "Set the number of lines at which compiled bodies are \"chained\".");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> COMPILE_PEEPHOLE = bool(COMPILER, "compile.peephole", true, "Enable or disable peephole optimizations.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> COMPILE_NOGUARDS = bool(COMPILER, "compile.noguards", false, "Compile calls without guards, for experimentation.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> COMPILE_FASTEST = bool(COMPILER, "compile.fastest", false, "Compile with all \"mostly harmless\" compiler optimizations.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> COMPILE_FASTSEND = bool(COMPILER, "compile.fastsend", false, "Compile obj.__send__(<literal>, ...) as obj.<literal>(...).");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> COMPILE_FASTMASGN = bool(COMPILER, "compile.fastMasgn", false, "Return true from multiple assignment instead of a new array.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Integer> COMPILE_OUTLINE_CASECOUNT = integer(COMPILER, "compile.outline.casecount", 50, "Outline when bodies when number of cases exceeds this value.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_SAFE = bool(INVOKEDYNAMIC, "invokedynamic.safe", false, "Enable all safe (but maybe not fast) uses of invokedynamic.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_INVOCATION = bool(INVOKEDYNAMIC, "invokedynamic.invocation", true, "Enable invokedynamic for method invocations.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_INVOCATION_INDIRECT = bool(INVOKEDYNAMIC, "invokedynamic.invocation.indirect", true, "Also bind indirect method invokers to invokedynamic.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_INVOCATION_JAVA = bool(INVOKEDYNAMIC, "invokedynamic.invocation.java", true, "Bind Ruby to Java invocations with invokedynamic.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_INVOCATION_ATTR = bool(INVOKEDYNAMIC, "invokedynamic.invocation.attr", true, "Bind Ruby attribute invocations directly to invokedynamic.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_INVOCATION_FFI = bool(INVOKEDYNAMIC, "invokedynamic.invocation.ffi", true, "Bind Ruby FFI invocations directly to invokedynamic.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_INVOCATION_FASTOPS = bool(INVOKEDYNAMIC, "invokedynamic.invocation.fastops", true, "Bind Fixnum and Float math using optimized logic.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_CACHE = bool(INVOKEDYNAMIC, "invokedynamic.cache", true, "Use invokedynamic to load cached values like literals and constants.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_CACHE_CONSTANTS = bool(INVOKEDYNAMIC, "invokedynamic.cache.constants", true, "Use invokedynamic to load constants.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_CACHE_LITERALS = bool(INVOKEDYNAMIC, "invokedynamic.cache.literals", true, "Use invokedynamic to load literals.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> INVOKEDYNAMIC_CACHE_IVARS = bool(INVOKEDYNAMIC, "invokedynamic.cache.ivars", true, "Use invokedynamic to get/set instance variables.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> JIT_CACHE = bool(JIT, "jit.cache", !COMPILE_INVOKEDYNAMIC.load(), "(DEPRECATED) Cache jitted method in-memory bodies across runtimes and loads.");    public static final Option<Boolean> INVOKEDYNAMIC_ALL = bool(INVOKEDYNAMIC, "invokedynamic.all", false, "Enable all possible uses of invokedynamic.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> JIT_DUMPING = bool(JIT, "jit.dumping", false, "Enable stdout dumping of JITed bytecode.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<String>  IR_INLINE_COMPILER_PASSES = string(IR, "ir.inline_passes", "Specify comma delimeted list of passes to run after inlining a method.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> FFI_COMPILE_INVOKEDYNAMIC = bool(NATIVE, "ffi.compile.invokedynamic", false, "Use invokedynamic to bind FFI invocations.");
 
     // internal IO mimics what this was doing, and this has been untested and unsupported for many years
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> NATIVE_NET_PROTOCOL = bool(MISCELLANEOUS, "native.net.protocol", false, "Use native impls for parts of net/protocol.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<String> THREAD_DUMP_SIGNAL = string(MISCELLANEOUS, "thread.dump.signal", new String[]{"USR1", "USR2", "etc"}, "USR2", "Set the signal used for dumping thread stacks.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> FIBER_COROUTINES = bool(MISCELLANEOUS, "fiber.coroutines", false, "Use JVM coroutines for Fiber.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> GLOBAL_REQUIRE_LOCK = bool(MISCELLANEOUS, "global.require.lock", false, "Use a single global lock for requires.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> REFLECTED_HANDLES = bool(MISCELLANEOUS, "reflected.handles", false, "Use reflection for binding methods, not generated bytecode.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> ENUMERATOR_LIGHTWEIGHT = bool(MISCELLANEOUS, "enumerator.lightweight", true, "Use lightweight Enumerator#next logic when possible.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> FCNTL_LOCKING = bool(MISCELLANEOUS, "file.flock.fcntl", true, "Use fcntl rather than flock for File#flock");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> RECORD_LEXICAL_HIERARCHY = bool(MISCELLANEOUS, "record.lexical.hierarchy", false, "Maintain children static scopes to support scope dumping.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> JI_LOGCANSETACCESSIBLE = bool(JAVA_INTEGRATION, "ji.logCanSetAccessible", false, "Log whether setAccessible is working.");
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public static final Option<Boolean> JAVA_HANDLES = bool(JAVA_INTEGRATION, "java.handles", false, "Use generated handles instead of reflection for calling Java.");
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static final Option<Boolean> NAME_ERROR_INSPECT_OBJECT = bool(MISCELLANEOUS, "nameError.inspect.object", true, "Inspect the target object for display in NameError messages.");
 }

--- a/core/src/main/java/org/jruby/util/collections/ClassValue.java
+++ b/core/src/main/java/org/jruby/util/collections/ClassValue.java
@@ -31,7 +31,7 @@ public abstract class ClassValue<T> {
          *
          * @see Java7ClassValue
          */
-        @Deprecated
+        @Deprecated(since = "9.4.13.0")
         HARD_VALUES(Java7ClassValue::new);
 
         Type(Function<ClassValueCalculator, ClassValue> function) {
@@ -54,7 +54,7 @@ public abstract class ClassValue<T> {
         return Options.JI_CLASS_VALUES.load().function.apply(calculator);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.13.0")
     private static <T> ClassValue<T> newJava7Instance(ClassValueCalculator<T> calculator) {
         return new Java7ClassValue<>(calculator);
     }

--- a/core/src/main/java/org/jruby/util/collections/Java7ClassValue.java
+++ b/core/src/main/java/org/jruby/util/collections/Java7ClassValue.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * A proxy cache that uses Java 7's ClassValue.
  */
-@Deprecated
+@Deprecated(since = "9.4.13.0")
 final class Java7ClassValue<T> extends ClassValue<T> {
 
     public Java7ClassValue(ClassValueCalculator<T> calculator) {

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -93,12 +93,12 @@ public class EncodingUtils {
         return idx;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject[] openArgsToArgs(Ruby runtime, IRubyObject firstElement, RubyHash options) {
         return openArgsToArgs(runtime.getCurrentContext(), firstElement, options);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject[] openArgsToArgs(ThreadContext context, IRubyObject firstElement, RubyHash options) {
         IRubyObject value = hashARef(context, options, "open_args");
 
@@ -117,7 +117,7 @@ public class EncodingUtils {
         return args;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void extractBinmode(Ruby runtime, IRubyObject optionsArg, int[] fmode_p) {
         extractBinmode(runtime.getCurrentContext(), optionsArg, fmode_p);
     }
@@ -162,27 +162,27 @@ public class EncodingUtils {
         return runtime.getEncodingService().getAscii8bitEncoding();
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static Object vmodeVperm(IRubyObject vmode, IRubyObject vperm) {
         return new API.ModeAndPermission(vmode, vperm);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject vmode(Object vmodeVperm) {
         return ((API.ModeAndPermission) vmodeVperm).mode;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void vmode(Object vmodeVperm, IRubyObject vmode) {
         ((API.ModeAndPermission) vmodeVperm).mode = vmode;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static IRubyObject vperm(Object vmodeVperm) {
         return ((API.ModeAndPermission) vmodeVperm).permission;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void vperm(Object vmodeVperm, IRubyObject vperm) {
         ((API.ModeAndPermission) vmodeVperm).permission = vperm;
     }
@@ -219,7 +219,7 @@ public class EncodingUtils {
         return ecflags;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static void extractModeEncoding(ThreadContext context,
                                            IOEncodable ioEncodable, Object vmodeAndVperm_p, IRubyObject options, int[] oflags_p, int[] fmode_p) {
         extractModeEncoding(context, ioEncodable, (API.ModeAndPermission) vmodeAndVperm_p, options, oflags_p, fmode_p);
@@ -1647,7 +1647,7 @@ public class EncodingUtils {
         }
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RaiseException makeEconvException(Ruby runtime, EConv ec) {
         return makeEconvException(runtime.getCurrentContext(), ec);
     }
@@ -2281,7 +2281,7 @@ public class EncodingUtils {
         return StringSupport.codePoint(enc, pBytes, p, e);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int encCodepointLength(Ruby runtime, byte[] pBytes, int p, int e, int[] len_p, Encoding enc) {
         return encCodepointLength(runtime.getCurrentContext(), pBytes, p, e, len_p, enc);
     }
@@ -2358,7 +2358,7 @@ public class EncodingUtils {
         return getEncoding(str.getByteList());
     }
 
-    @Deprecated(since = "10.0")
+    @Deprecated(since = "10.0.0.0")
     public static RubyString rbStrEscape(Ruby runtime, RubyString str) {
         return (RubyString) RubyString.rbStrEscape(runtime.getCurrentContext(), str);
     }
@@ -2443,12 +2443,12 @@ public class EncodingUtils {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.2.0.0")
     public static Encoding ioStripBOM(RubyIO io) {
         return ioStripBOM(io.getRuntime().getCurrentContext(), io);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static Encoding strTranscode0(ThreadContext context, int argc, IRubyObject[] args, IRubyObject[] self_p, int ecflags, IRubyObject ecopts) {
         Encoding[] enc_p = {null};
         TranscodeResult result = (ctx, str, enc, newStr) -> {enc_p[0] = enc; self_p[0] = newStr; return newStr;};
@@ -2469,7 +2469,7 @@ public class EncodingUtils {
         };
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static Encoding strTranscode(ThreadContext context, IRubyObject[] args, IRubyObject[] self_p) {
         Encoding[] enc_p = {null};
         TranscodeResult result = (ctx, str, enc, newStr) -> {enc_p[0] = enc; self_p[0] = newStr; return newStr;};
@@ -2479,22 +2479,22 @@ public class EncodingUtils {
         return enc_p[0];
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject strEncode(ThreadContext context, IRubyObject str, IRubyObject... args) {
         return strTranscode(context, args, (RubyString) str, EncodingUtils::encodedDup);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject encodedDup(ThreadContext context, IRubyObject newstr, IRubyObject str, Encoding encindex) {
         return encodedDup(context, (RubyString) newstr, encindex, (RubyString) str);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject strEncodeAssociate(ThreadContext context, IRubyObject str, Encoding encidx) {
         return strEncodeAssociate((RubyString) str, encidx);
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4.6.0")
     public static IRubyObject strTranscode(ThreadContext context, IRubyObject[] args, RubyString str, TranscodeResult result) {
         return switch (args.length) {
             case 0 -> strTranscode(context, str, result);

--- a/core/src/main/java/org/jruby/util/io/Getline.java
+++ b/core/src/main/java/org/jruby/util/io/Getline.java
@@ -29,7 +29,7 @@ public class Getline {
     }
 
     // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0) {
         boolean keywords = arg0 instanceof RubyHash;
@@ -41,7 +41,7 @@ public class Getline {
     }
 
     // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0, IRubyObject arg1) {
         boolean keywords = arg1 instanceof RubyHash;
@@ -54,7 +54,7 @@ public class Getline {
     }
 
     // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0,
                                                                         IRubyObject arg1, IRubyObject arg2) {
@@ -74,7 +74,7 @@ public class Getline {
     }
 
     // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0, Block block) {
         boolean keywords = arg0 instanceof RubyHash;
@@ -88,7 +88,7 @@ public class Getline {
     }
 
     // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0,
                                                                         IRubyObject arg1, Block block) {
@@ -103,7 +103,7 @@ public class Getline {
     }
 
     // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0,
                                                                         IRubyObject arg1, IRubyObject arg2, Block block) {
@@ -118,7 +118,7 @@ public class Getline {
         return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, block, keywords);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject... args) {
         return switch (args.length) {
@@ -144,7 +144,7 @@ public class Getline {
     // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
     // Note: some callers use this as the single entry point vs calling into the specific overload so we need to do extra null
     //   checking to figure out actual last valid passed argument.
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, int argc, IRubyObject arg0,
                                                                         IRubyObject arg1, IRubyObject arg2, Block block) {

--- a/core/src/main/java/org/jruby/util/io/ModeFlags.java
+++ b/core/src/main/java/org/jruby/util/io/ModeFlags.java
@@ -220,7 +220,7 @@ public class ModeFlags implements Cloneable {
      * @param channel the channel to examine for capabilities
      * @return the mode flags
      */
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static ModeFlags getModesFromChannel(Channel channel) {
         try {
             ModeFlags modes;

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -218,7 +218,7 @@ public class OpenFile implements Finalizable {
         return mode;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public String getModeAsString(Ruby runtime) {
         return getModeAsString(runtime.getCurrentContext());
     }
@@ -255,7 +255,7 @@ public class OpenFile implements Finalizable {
         return oflags;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static String ioOflagsModestr(Ruby runtime, int oflags) {
         return ioOflagsModestr(runtime.getCurrentContext(), oflags);
     }
@@ -286,7 +286,7 @@ public class OpenFile implements Finalizable {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int ioModestrOflags(Ruby runtime, String modestr) {
         return ioModestrOflags(runtime.getCurrentContext(), modestr);
     }
@@ -333,7 +333,7 @@ public class OpenFile implements Finalizable {
         return oflags;
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static int ioModestrFmode(Ruby runtime, String modestr) {
         return ioModestrFmode(runtime.getCurrentContext(), modestr);
     }
@@ -1884,7 +1884,7 @@ public class OpenFile implements Finalizable {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.1.8.0")
     public void incrementLineno(Ruby runtime) {
         boolean locked = lock();
         try {
@@ -2771,7 +2771,7 @@ public class OpenFile implements Finalizable {
         }
     }
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static int getFModeFromString(String modesString) throws InvalidValueException {
         int fmode = 0;
         int length = modesString.length();
@@ -3044,7 +3044,7 @@ public class OpenFile implements Finalizable {
         return lock.isHeldByCurrentThread();
     }
 
-    @Deprecated
+    @Deprecated(since = "9.3.0.0")
     public long binwrite(ThreadContext context, byte[] ptrBytes, int ptr, int len, boolean nosync) {
         return binwriteInt(context, ptrBytes, ptr, len, nosync);
     }

--- a/core/src/main/java/org/jruby/util/io/Sockaddr.java
+++ b/core/src/main/java/org/jruby/util/io/Sockaddr.java
@@ -327,7 +327,7 @@ public class Sockaddr {
         return AddressFamily.valueOf((high << 8) + low);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static AddressFamily getAddressFamilyFromSockaddr(Ruby runtime, ByteList val) {
         return getAddressFamilyFromSockaddr(runtime.getCurrentContext(), val);
     }
@@ -336,7 +336,7 @@ public class Sockaddr {
         return RaiseException.from(context.runtime, Access.getClass(context, "SocketError"), msg);
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0.0.0")
     public static SocketAddress sockaddrFromBytes(Ruby runtime, byte[] val) throws IOException {
         return sockaddrFromBytes(runtime.getCurrentContext(), val);
     }

--- a/core/src/main/resources/org/jruby/runtime/Constants.java
+++ b/core/src/main/resources/org/jruby/runtime/Constants.java
@@ -50,7 +50,7 @@ public final class Constants {
     public static final String JODA_TIME_VERSION = "@joda.time.version@";
     public static final String TZDATA_VERSION = "@tzdata.version@";
 
-    @Deprecated
+    @Deprecated(since = "9.1.7.0")
     public static final String DEFAULT_RUBY_VERSION = RUBY_MAJOR_VERSION;
     
     /**
@@ -67,7 +67,7 @@ public final class Constants {
     /**
      * The max count of active methods eligible for JIT-compilation.
      */
-    @Deprecated
+    @Deprecated(since = "9.2.9.0")
     public static final int JIT_MAX_METHODS_LIMIT = JIT_MAX_LIMIT;
 
     /**
@@ -87,7 +87,7 @@ public final class Constants {
     
     private static String jruby_revision = "@jruby.revision@";
 
-    @Deprecated
+    @Deprecated(since = "1.6.0")
     public static final String JRUBY_PROPERTIES = "/org/jruby/jruby.properties";
 
     public static final String BOGUS_REVISION = "ffffffffff";
@@ -105,9 +105,9 @@ public final class Constants {
 
     private Constants() {}
 
-    @Deprecated
+    @Deprecated(since = "9.0.0.0")
     public static final int    RUBY_PATCHLEVEL = 0;
 
-    @Deprecated
+    @Deprecated(since = "9.4.0.0")
     public static final int    RUBY_REVISION = 1;
 }


### PR DESCRIPTION
The "since" attributes added here reflect the first release after each deprecation was added. We will use this to remove oldest deprecations (by some measure of oldest) in an upcoming release.

The Ruby script used to make this change is provided here:

```ruby
Dir[ARGV[0] + "/**/*.java"].each do |file|
  file_lines = File.readlines(file)
  file_lines.each_with_index do |line, i|
    line.gsub!(/@Deprecated\S*$/) do
      sha = `git blame -L #{i+1},#{i+1} #{file}`.split(" ")[0]
      tag = `git describe --abbrev=0 --tags --contains #{sha}`.split("~")[0]
      "@Deprecated(since = \"#{tag}\")"
    end
  end
  File.write(file, file_lines.join(''))
  puts "process #{file}"
end
```

There may be places where sources moved or the deprecation line does not reflect the true earliest version, but worst case the deprecations stick around a little longer, or require manual investigation.