### PR TITLE
Don't restrict object search to modules

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4835,8 +4835,11 @@ public class RubyModule extends RubyObject {
     private IRubyObject getConstantSkipAutoload(String name, boolean inherit, boolean searchObject, boolean inheritObject) {
         IRubyObject constant = iterateConstantNoConstMissing(name, this, inherit, false, inheritObject);
 
-        if (constant == null && searchObject) {
-            constant = iterateConstantNoConstMissing(name, getRuntime().getObject(), inherit, false, true);
+        Ruby runtime = getRuntime();
+
+        // only search object if specified and this module is a class and does not extend from BasicObject
+        if (constant == null && searchObject && (!(this instanceof RubyClass) || ((RubyClass) this).getAllocator() != BASICOBJECT_ALLOCATOR)) {
+            constant = iterateConstantNoConstMissing(name, runtime.getObject(), inherit, false, true);
         }
 
         return constant;


### PR DESCRIPTION
I'm unsure why this change is here but I could find no equivalent logic in CRuby and this appears to prevent the search detailed in jruby/jruby#8924 from succeeding. Removing this restriction fixes that issue.

Fixes jruby/jruby#8924