### PR TITLE
fix: clear code-range when re-using a string buffer

### DIFF
--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -1333,7 +1333,7 @@ public class EncodingUtils {
             str = obj.convertToString();
             int clen = str.size();
             if (clen >= len) {
-                str.modify();
+                str.modifyAndClearCodeRange();
                 return str;
             }
             str.modifyExpand(len);

--- a/test/jruby/test_io.rb
+++ b/test/jruby/test_io.rb
@@ -173,6 +173,27 @@ class TestIO < Test::Unit::TestCase
      assert_equal " ", f.read(1, nil)
   end
 
+  def test_file_read_into_buffer_code_range
+    buf = String.new
+    buf.concat "¿Cómo estás? Ça va bien?"
+    assert_false buf.ascii_only? # base-line: scan and set the code-range for the buffer
+
+    require 'tempfile'
+    tmpfile = Tempfile.new('file')
+    tmpfile.open
+    tmpfile.write("ascii only")
+    tmpfile.flush
+    tmpfile.close
+
+    File.open(tmpfile.path, encoding: 'binary') do |file|
+      file.read(10, buf) # read less then buf.size
+    end
+    tmpfile.delete
+
+    assert_true buf.ascii_only? # reading into the buffer should have cleared the code-range
+    assert_equal 'ascii only', buf
+  end
+
   def test_open
     ensure_files @file
 


### PR DESCRIPTION
closing #9035