### PR TITLE
Add opens and native access to all jar manifests

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -265,7 +265,18 @@ project 'JRuby Base' do
          'additionalClasspathElements' => ['${basedir}/src/test/ruby'])
 
   plugin(:jar,
-         archive: { manifestEntries: { 'Automatic-Module-Name' => 'org.jruby' } })
+         archive: {
+           manifestEntries: {
+             # Module name for JRuby
+             'Automatic-Module-Name' => 'org.jruby.base',
+
+             # Open requested packages when not running as a module (i.e. JRuby is on classpath or -jar main jar)
+             'Add-Opens' => 'java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management',
+
+             # Enable native access for JRuby and classpath classes when run not as a module
+             'Enable-Native-Access' => 'ALL-UNNAMED',
+           }
+         })
 
   build do
     default_goal 'package'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -579,7 +579,9 @@ DO NOT MODIFY - GENERATED CODE
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>org.jruby</Automatic-Module-Name>
+              <Automatic-Module-Name>org.jruby.base</Automatic-Module-Name>
+              <Add-Opens>java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management</Add-Opens>
+              <Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
             </manifestEntries>
           </archive>
         </configuration>

--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -41,8 +41,14 @@ project 'JRuby Complete' do
              mainClass: 'org.jruby.main.Main'
            },
            manifestEntries: {
-             "Automatic-Module-Name": 'org.jruby.complete',
-             "Add-Opens": 'java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management'
+             # Module name for JRuby
+             'Automatic-Module-Name' => 'org.jruby.complete',
+
+             # Open requested packages when not running as a module (i.e. JRuby is on classpath or -jar main jar)
+             'Add-Opens' => 'java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management',
+
+             # Enable native access for JRuby and classpath classes when run not as a module
+             'Enable-Native-Access' => 'ALL-UNNAMED',
            }
          },
          instructions: {

--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -27,7 +27,17 @@ project 'JRuby Core' do
                   ],
                   transformers: [{ :@implementation => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
                                    mainClass: 'org.jruby.main.Main',
-                                   manifestEntries: { "Automatic-Module-Name": 'org.jruby.dist' } }],
+                                   manifestEntries: {
+                                     # Module name for JRuby
+                                     'Automatic-Module-Name' => 'org.jruby.dist',
+
+                                     # Open requested packages when not running as a module (i.e. JRuby is on classpath or -jar main jar)
+                                     'Add-Opens' => 'java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management',
+
+                                     # Enable native access for JRuby and classpath classes when run not as a module
+                                     'Enable-Native-Access' => 'ALL-UNNAMED',
+                                   }
+                                 }],
                   createSourcesJar: false,
                   compress: false)
   end

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -58,6 +58,8 @@ DO NOT MODIFY - GENERATED CODE
                   <mainClass>org.jruby.main.Main</mainClass>
                   <manifestEntries>
                     <Automatic-Module-Name>org.jruby.dist</Automatic-Module-Name>
+                    <Add-Opens>java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management</Add-Opens>
+                    <Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
                   </manifestEntries>
                 </transformer>
               </transformers>


### PR DESCRIPTION
This modifies the manifests of all executable jars we produce to include the appropriate Add-Opens and Enable-Native-Access flags:

* /core's jruby-base jar, executable but without any shaded dependencies
* /shaded's jruby-core jar, executable and used as the main dist jar
* /maven/jruby-complete's fully-shaded jar

Normal JRuby use will go through our launcher and apply these flags at the command line, but this allows these jars to be run with -jar at the command line without producing warnings about unopened packages or native library access.

Relates to the following issues that mention the native access warning or our warnings about certain IO packages not being open:

* https://github.com/jruby/jruby/issues/8727: JRuby being launched from within a Gradle plugin. Fixed by adding the opens flags, but probably also fixed by this commit.
* https://github.com/jruby/jruby/issues/6721: Warnings about our native process and IO subsystems being unable to access the core JDK classes needed. May not be fixed by this issue, since JRuby appears to be used as a library, not as the main jar.
* https://github.com/jruby/jruby/issues/8910: Not directly an issue related to these flags, but these flags will eliminate the warning for e.g. the SQLite JDBC driver when JRuby is not being run in the typical way.
* https://github.com/jruby/jruby-launcher/issues/58: More issues with native IO and process management not working properly on Windows due to the native launcher not yet including the necessary flags. May be fixed by this commit if the launcher is also still loading JRuby on classpath and not as a module.