### PR TITLE
Update all jnr dependencies

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -45,11 +45,11 @@ project 'JRuby Base' do
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages
   jar 'com.github.jnr:jnr-netdb:1.2.0', exclusions: ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-enxio:0.32.18', exclusions: ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-unixsocket:0.38.23', exclusions: ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-posix:3.1.20', exclusions: ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-enxio:0.32.19', exclusions: ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-unixsocket:0.38.24', exclusions: ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-posix:3.1.21', exclusions: ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-constants:0.10.4', exclusions: ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-ffi:2.2.17'
+  jar 'com.github.jnr:jnr-ffi:2.2.18'
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,7 +89,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.32.18</version>
+      <version>0.32.19</version>
       <exclusions>
         <exclusion>
           <groupId>com.github.jnr</groupId>
@@ -100,7 +100,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.38.23</version>
+      <version>0.38.24</version>
       <exclusions>
         <exclusion>
           <groupId>com.github.jnr</groupId>
@@ -111,7 +111,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.1.20</version>
+      <version>3.1.21</version>
       <exclusions>
         <exclusion>
           <groupId>com.github.jnr</groupId>
@@ -133,7 +133,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.17</version>
+      <version>2.2.18</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>

--- a/pom.rb
+++ b/pom.rb
@@ -76,7 +76,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
              "ant.version": '1.9.8',
              "asm.version": '9.7.1',
              "jar-dependencies.version": '0.4.1',
-             "jffi.version": '1.3.13',
+             "jffi.version": '1.3.14',
              "joda.time.version": '2.14.0')
 
   plugin_management do

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ DO NOT MODIFY - GENERATED CODE
     <its.j2ee>j2ee*/pom.xml</its.j2ee>
     <its.osgi>osgi*/pom.xml</its.osgi>
     <jar-dependencies.version>0.4.1</jar-dependencies.version>
-    <jffi.version>1.3.13</jffi.version>
+    <jffi.version>1.3.14</jffi.version>
     <joda.time.version>2.14.0</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>


### PR DESCRIPTION
This is mostly to pull latest fixes for jffi in 1.3.14:

https://github.com/jnr/jffi/milestone/36?closed=1

jffi: 1.3.14
jnr-ffi: 2.2.18
jnr-posix: 3.1.21
jnr-enxio: 0.32.19
jnr-unixsocket: 0.38.24