### PR TITLE
Ignore encoding when unmarshaling an Encoding

### DIFF
--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
@@ -177,8 +177,10 @@ public class MarshalLoader {
             if (encoding != null) {
                 if (object instanceof EncodingCapable) {
                     ((EncodingCapable) object).setEncoding(encoding);
+                } else if (object instanceof RubyEncoding) {
+                    // CRuby marshals Encoding with an encoding instance variable (https://bugs.ruby-lang.org/issues/21658)
                 } else {
-                    throw argumentError(context, str(context.runtime, object, "is not enc_capable"));
+                    throw argumentError(context, str(context.runtime, object, " is not enc_capable"));
                 }
                 if (hasEncoding != null) hasEncoding[0] = true;
             } else if (id.equals(SYMBOL_RUBY2_KEYWORDS_HASH_SPECIAL)) {


### PR DESCRIPTION
CRuby appears to marshal all Encoding objects with a special encoding instance variable indicating they have an encoding of US-ASCII, even though Encoding does not actually have an encoding. I've filed an issue about this for clarification below, but for now we ignore this peculiar situation.

https://bugs.ruby-lang.org/issues/21658

Fixes jruby/jruby#9050