### PR TITLE
Reserve extra space before elements when unshifting

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1202,12 +1202,17 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (newLength < ARRAY_DEFAULT_SIZE) newLength = ARRAY_DEFAULT_SIZE;
 
         newLength = addBufferLength(context, valuesLength, newLength);
-
         IRubyObject[] vals = IRubyObject.array(newLength);
-        safeArrayCopy(context, values, begin, vals, 1, valuesLength);
-        Helpers.fillNil(context, vals, valuesLength + 1, newLength);
+
+        int shiftedBegin = newLength - valuesLength;
+        int unshiftedBegin = shiftedBegin - 1;
+
+        // copy existing elements to the end of the new array, to leave room for future unshifts
+        safeArrayCopy(context, values, begin, vals, shiftedBegin, valuesLength);
+        Helpers.fillNil(context, vals, 0, unshiftedBegin);
+
         values = vals;
-        begin = 0;
+        begin = unshiftedBegin;
     }
 
     public IRubyObject insert() {


### PR DESCRIPTION
This change expands the array for an unshift by sliding elements forward, leaving additional space for future unshifts to proceed without copying or reallocating. When expanding, the existing elements are moved to the end of the native array.

This assumes that if one value is unshifted, future values are also likely to be unshifted rather than pushed at the end. This could reduce performance if values are being both unshifted (at begin) and pushed (at end), but the trade-off to have the more common case of all unshifts seems worth it.

Fixes #9058