### PR TITLE
Default to universal newline conversion on Windows

### DIFF
--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -70,9 +70,21 @@ import static org.jruby.util.StringSupport.CR_UNKNOWN;
 import static org.jruby.util.StringSupport.searchNonAscii;
 
 public class EncodingUtils {
-    public static final int ECONV_DEFAULT_NEWLINE_DECORATOR = Platform.IS_WINDOWS ? EConvFlags.CRLF_NEWLINE_DECORATOR : 0;
+    /*
+    CRuby uses CRLF_NEWLINE here, which it uses to detect that *only* CRLF conversion is needed. If no explicit
+    conversion has been specified (with UNIVERSAL_NEWLINE or "rt" textmode flags) CRuby will fall back on using the
+    O_TEXT file mode, allowing the Windows C library to handle the conversion more efficiently.
+
+    We do not have access to the O_TEXT mode via JDK classes, so we must always use the explicit UNIVERSAL_NEWLINE mode
+    here and set up a transcoder to convert newlines.
+
+    See the following commit for the first introduction of this optimization into CRuby:
+
+    https://github.com/ruby/ruby/commit/f9a6a1dd0c687dfc6e63e5d20bc3812416def301#diff-686754e19b3c08fbc0880fade77986fed2c09fdd27dcc163fc68e0a7e22b7913R318-R321
+     */
+    public static final int ECONV_DEFAULT_NEWLINE_DECORATOR = Platform.IS_WINDOWS ? EConvFlags.UNIVERSAL_NEWLINE_DECORATOR : 0;
     public static final int DEFAULT_TEXTMODE = Platform.IS_WINDOWS ? OpenFile.TEXTMODE : 0;
-    public static final int TEXTMODE_NEWLINE_DECORATOR_ON_WRITE = Platform.IS_WINDOWS ? EConvFlags.CRLF_NEWLINE_DECORATOR : 0;
+    public static final int TEXTMODE_NEWLINE_DECORATOR_ON_WRITE = Platform.IS_WINDOWS ? EConvFlags.UNIVERSAL_NEWLINE_DECORATOR : 0;
 
     private static final byte[] NULL_BYTE_ARRAY = ByteList.NULL_ARRAY;
 


### PR DESCRIPTION
Universal newline conversion is a transcoding mode used when the conversion of newlines from one encoding to another is desired during the IO process. It also handles Windows newlines ("\r\n"), and was originally the mechanism by which CRuby handled newline normalization on Windows.

See https://github.com/ruby/ruby/commit/876146772787599c894369801034f1fed1d16b54#diff-686754e19b3c08fbc0880fade77986fed2c09fdd27dcc163fc68e0a7e22b7913R319

Later, CRuby was modified to leverage the O_TEXT mode on Windows, which does OS-level normalization of newlines, and to indicate this new watered-down default they switched it to a non-universal CRLF_NEWLINE mode. Logic later in the transcoding creation and read conversion processes would check whether NEED_READCONV and then use O_TEXT mode instead of a transcoder.

See https://github.com/ruby/ruby/commit/f9a6a1dd0c687dfc6e63e5d20bc3812416def301#diff-686754e19b3c08fbc0880fade77986fed2c09fdd27dcc163fc68e0a7e22b7913R318-R321

JRuby's ported logic largely matches this, except we have no way to specify O_TEXT when opening files with the JDK, so that mode ends up getting ignored and we don't actually do the newline conversions.

A short-term fix, which is really what we should have done years ago, is to switch the default windows transcoding flag from the watered down CRLF_NEWLINE mode back to the UNIVERSAL_NEWLINE mode, forcing the use of the transcoder.

Future improvements to this code could restore the optimized logic if O_TEXT becomes available to us.

This should fix a number of newline conversion issues, but may have other unexpected consequences.