### PR TITLE
Avoid array allocation for *nil, by not calling nil.to_a

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2036,12 +2036,7 @@ public class IRRuntimeHelpers {
      */
     @JIT @Interp
     public static RubyArray splatArray(ThreadContext context, IRubyObject ary, boolean dupArray) {
-        IRubyObject tmp = TypeConverter.convertToTypeWithCheck(context, ary, arrayClass(context), sites(context).to_a_checked);
-
-        if (tmp.isNil()) return newArray(context, ary);
-        if (dupArray) return ((RubyArray<?>) tmp).aryDup();
-
-        return (RubyArray<?>) tmp;
+        return dupArray ? splatArrayDup(context, ary) : splatArray(context, ary);
     }
 
     /**
@@ -2051,6 +2046,8 @@ public class IRRuntimeHelpers {
      */
     @JIT @Interp
     public static RubyArray splatArray(ThreadContext context, IRubyObject ary) {
+        if (ary.isNil()) return context.runtime.getEmptyFrozenArray();
+
         IRubyObject tmp = TypeConverter.convertToTypeWithCheck(context, ary, arrayClass(context), sites(context).to_a_checked);
 
         if (tmp.isNil()) return newArray(context, ary);
@@ -2065,9 +2062,13 @@ public class IRRuntimeHelpers {
      */
     @JIT @Interp
     public static RubyArray splatArrayDup(ThreadContext context, IRubyObject ary) {
+        if (ary.isNil()) return newEmptyArray(context);
+
         IRubyObject tmp = TypeConverter.convertToTypeWithCheck(context, ary, arrayClass(context), sites(context).to_a_checked);
 
-        return tmp.isNil() ? newArray(context, ary) : ((RubyArray<?>) tmp).aryDup();
+        if (tmp.isNil()) return newArray(context, ary);
+
+        return ((RubyArray<?>) tmp).aryDup();
     }
 
     public static IRubyObject irToAry(ThreadContext context, IRubyObject value) {


### PR DESCRIPTION
For Ruby 4.0 compatibility.

See https://bugs.ruby-lang.org/issues/21047

See https://github.com/jruby/jruby/issues/9061