### PR TITLE
Ignore missing exts on JRuby

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -57,6 +57,14 @@ end
 
 ## JAR FILES: Allow gem path entries to contain jar files
 class Gem::Specification
+  ##
+  # Ignore missing extensions on JRuby
+  #
+  # See https://github.com/ruby/rubygems/issues/3520
+  def missing_extensions?
+    false
+  end
+
   class << self
     # Replace existing dirs
     def dirs


### PR DESCRIPTION
This problem does not seem to be going away, so ignore all missing extensions on JRuby for now.

See https://github.com/ruby/rubygems/issues/3520