### PR TITLE
Shrink varTableStamp

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -174,7 +174,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     public transient Object[] varTable;
 
     /** locking stamp for Unsafe ops updating the vartable */
-    public transient volatile int varTableStamp;
+    public transient volatile byte varTableStamp;
 
     /**
      * The error message used when some one tries to modify an

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
@@ -65,7 +65,7 @@ public abstract class VariableAccessor {
 
         VarHandle sh;
         try {
-            sh = MethodHandles.lookup().findVarHandle(RubyBasicObject.class, "varTableStamp", int.class);
+            sh = MethodHandles.lookup().findVarHandle(RubyBasicObject.class, "varTableStamp", byte.class);
         } catch (Throwable throwable) {
             throw new ExceptionInInitializerError(throwable);
         }

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -446,7 +446,7 @@ public class VariableTableManager {
             Object[] otherVars = ((RubyBasicObject) other).varTable;
 
             for(;;) {
-                int oldStamp = self.varTableStamp;
+                byte oldStamp = self.varTableStamp;
                 // wait for read mode
                 if((oldStamp & 0x01) == 1)
                     continue;
@@ -460,7 +460,7 @@ public class VariableTableManager {
                 VariableAccessor.VAR_TABLE_HANDLE.setRelease(self, newTable);
 
                 // release write mode
-                self.varTableStamp = oldStamp+1;
+                self.varTableStamp = (byte) (oldStamp+1);
                 break;
             }
 


### PR DESCRIPTION
This PR will experiment with and eventually proceed with changes to reduce the size of the `varTableStamp` we currently use to guard concurrent, atomic growth of the `varTable` field.

Initial experiments simply shrink the stamp to a `byte`, which still accommodates up to 64 concurrent mutators. It may be possible to reduce it to a single bit by forcing other mutators to block for a (very) short time while the var table is being updated, but we'll want to have some tests that show this does not lead to any deadlocks (unlikely, since this code does not trigger further locking) or false positive locks as well as benchmarks to show that we are not adversely impacting concurrent updates (both contended and non-contended).