### PR TITLE
Fix CoverageData.mergeLines when coverage increases

### DIFF
--- a/core/src/main/java/org/jruby/ext/coverage/CoverageData.java
+++ b/core/src/main/java/org/jruby/ext/coverage/CoverageData.java
@@ -199,11 +199,12 @@ public class CoverageData {
         if (existingSize < startingLinesLength) {
             int[] newLines = new int[startingLinesLength];
             System.arraycopy(existing.toIntArray(), 0, newLines, 0, existingSize);
+            java.util.Arrays.fill(newLines, existingSize, startingLinesLength, -1);
             result = new IntList(newLines);
         }
 
         for (int i = 0; i < startingLinesLength; i++) {
-            int existingValue = existing.get(i);
+            int existingValue = result.get(i);
             int newValue = startingLines[i];
 
             if (newValue == -1) continue;


### PR DESCRIPTION
I've been having intermittent problems running RSpec tests on JRuby, with an `ArrayIndexOutOfBoundsException` happening all of a sudden.

Stacktrace shows that coverage is the problem:
```
An error occurred while loading spec_helper.
Failure/Error: Unable to find org.jruby.dist/org.jruby.util.collections.IntList.get(IntList.java to read failed line
Java::JavaLang::ArrayIndexOutOfBoundsException:
  Index 213 out of bounds for length 213
# org.jruby.dist/org.jruby.util.collections.IntList.get(IntList.java:25)
# org.jruby.dist/org.jruby.ext.coverage.CoverageData.mergeLines(CoverageData.java:206)
# org.jruby.dist/org.jruby.ext.coverage.CoverageData.prepareCoverage(CoverageData.java:184)
# org.jruby.dist/org.jruby.parser.RubyParserBase.finishCoverage(RubyParserBase.java:2417)
# org.jruby.dist/org.jruby.parser.RubyParserBase.addRootNode(RubyParserBase.java:473)
# org.jruby.dist/org.jruby.parser.RubyParser.lambda$static$1(RubyParser.java:2028)
# org.jruby.dist/org.jruby.parser.RubyParser.yyparse(RubyParser.java:1972)
# org.jruby.dist/org.jruby.parser.RubyParser.yyparse(RubyParser.java:1840)
# org.jruby.dist/org.jruby.parser.RubyParserBase.parse(RubyParserBase.java:2205)
# org.jruby.dist/org.jruby.parser.Parser.parse(Parser.java:129)
# org.jruby.dist/org.jruby.parser.Parser.parse(Parser.java:89)
# org.jruby.dist/org.jruby.parser.ParserManager.parseEval(ParserManager.java:95)
```

It also looks like enabling coverage for `eval`ed code may be the problem, as not enabling it solved it at least in most recent case. However, in a different project it makes no difference, so not sure. Also, in this case I was only using `class_eval` with a block, not a string :shrug:

Anyway, I looked in the code and found the problem. In `mergeLines` there is logic for increasing the size of the list, but the main merging loop was getting values from the original list instead, going out of bounds.

This PR solves the problem. I ran this against my RSpec suite, and there is no longer an error.