### PR TITLE
Use smaller default size for many collections

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -76,6 +76,7 @@ import org.jruby.util.StrptimeParser;
 import org.jruby.util.StrptimeToken;
 import org.jruby.util.WeakIdentityHashMap;
 import org.jruby.util.collections.ConcurrentWeakHashMap;
+import org.jruby.util.collections.IntHashMap;
 import org.jruby.util.io.EncodingUtils;
 import org.objectweb.asm.util.TraceClassVisitor;
 
@@ -1707,7 +1708,7 @@ public final class Ruby implements Constantizable {
         }
     }
 
-    private final Map<Integer, RubyClass> errnos = new HashMap<>();
+    private final IntHashMap<RubyClass> errnos = new IntHashMap<>(Errno.values().length);
 
     public RubyClass getErrno(int n) {
         return errnos.get(n);
@@ -5461,7 +5462,7 @@ public final class Ruby implements Constantizable {
     // NOTE: module instances are unique and we only addModule from <init> - could use a ConcurrentLinkedQueue
     private final ConcurrentWeakHashMap<RubyModule, Object> allModules = new ConcurrentWeakHashMap<>(128);
 
-    private final Map<String, DateTimeZone> timeZoneCache = new HashMap<>();
+    private final Map<String, DateTimeZone> timeZoneCache = new HashMap<>(1);
 
     /**
      * A list of "external" finalizers (the ones, registered via ObjectSpace),

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1247,7 +1247,7 @@ public class RubyClass extends RubyModule {
 
     private static RubyClassSet getOrCreateSubclasses(RubyClassSet subclasses) {
         if (subclasses != null && subclasses != EMPTY_RUBYCLASS_SET) return subclasses;
-        return new WeakRubyClassSet();
+        return new WeakRubyClassSet(4);
     }
 
     interface RubyClassSet {
@@ -1281,10 +1281,6 @@ public class RubyClass extends RubyModule {
 
     static class WeakRubyClassSet extends WeakHashMap<RubyClass, Object> implements RubyClassSet {
         final ReentrantLock lock = new ReentrantLock();
-
-        public WeakRubyClassSet() {
-            super();
-        }
 
         public WeakRubyClassSet(int size) {
             super(size);

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -99,7 +99,7 @@ public class RubyConverter extends RubyObject {
     public static final int XML_ATTR_QUOTE_DECORATOR = EConvFlags.XML_ATTR_QUOTE_DECORATOR;
     
     // TODO: This is a little ugly...we should have a table of these in jcodings.
-    public static final Map<Encoding, Encoding> NONASCII_TO_ASCII = new HashMap<Encoding, Encoding>();
+    public static final Map<Encoding, Encoding> NONASCII_TO_ASCII = new HashMap<>();
     static {
         NONASCII_TO_ASCII.put(UTF16BEEncoding.INSTANCE, UTF8Encoding.INSTANCE);
         NONASCII_TO_ASCII.put(UTF16LEEncoding.INSTANCE, UTF8Encoding.INSTANCE);

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -186,7 +186,7 @@ public class RubyDir extends RubyObject implements Closeable {
 // ----- Ruby Class Methods ----------------------------------------------------
 
     private static ArrayList<ByteList> dirGlobs(ThreadContext context, String cwd, IRubyObject[] args, int flags, boolean sort) {
-        ArrayList<ByteList> dirs = new ArrayList<>();
+        ArrayList<ByteList> dirs = new ArrayList<>(args.length);
 
         for ( int i = 0; i < args.length; i++ ) {
             dirs.addAll(Dir.push_glob(context.runtime, cwd, globArgumentAsByteList(context, RubyFile.get_path(context, args[i])), flags, sort));
@@ -332,7 +332,7 @@ public class RubyDir extends RubyObject implements Closeable {
         String base = options.base;
 
         if (base != null && !base.isEmpty() && !(JRubyFile.createResource(context, base).exists())){
-            dirs = new ArrayList<>();
+            dirs = Collections.EMPTY_LIST;
         } else {
             IRubyObject tmp = args[0].checkArrayType();
             String dir = base == null || base.isEmpty() ? runtime.getCurrentDirectory() : base;

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -893,11 +893,11 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             String spattern = _path.asJavaString();
             ArrayList<String> patterns = Dir.braces(spattern, flags, new ArrayList<>());
 
-            ArrayList<Boolean> matches = new ArrayList<>();
+            boolean matches = false;
             for(int i = 0; i < patterns.size(); i++) {
-                matches.add(dir_fnmatch(new ByteList(patterns.get(i).getBytes()), path, flags));
+                matches |= dir_fnmatch(new ByteList(patterns.get(i).getBytes()), path, flags);
             }
-            braces_match = matches.contains(true);
+            braces_match = matches;
         }
 
         return braces_match || dir_fnmatch(pattern, path, flags) ? context.tru : context.fals;

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1563,16 +1563,16 @@ public class RubyInstanceConfig {
     }
 
     // from CommandlineParser
-    private List<String> loadPaths = new ArrayList<String>();
-    private Set<String> excludedMethods = new HashSet<String>();
-    private final StringBuffer inlineScript = new StringBuffer();
+    private List<String> loadPaths = new ArrayList<String>(0);
+    private Set<String> excludedMethods = new HashSet<String>(0);
+    private final StringBuffer inlineScript = new StringBuffer(0);
     private boolean hasInlineScript = false;
     private String scriptFileName = null;
-    private final Collection<String> requiredLibraries = new LinkedHashSet<String>();
+    private final Collection<String> requiredLibraries = new LinkedHashSet<String>(0);
     private boolean argvGlobalsOn = false;
     private boolean assumeLoop = Options.CLI_ASSUME_LOOP.load();
     private boolean assumePrinting = Options.CLI_ASSUME_PRINT.load();
-    private final Map<String, String> optionGlobals = new HashMap<String, String>();
+    private final Map<String, String> optionGlobals = new HashMap<String, String>(0);
     private boolean processLineEnds = Options.CLI_PROCESS_LINE_ENDS.load();
     private boolean split = Options.CLI_AUTOSPLIT.load();
     private Verbosity verbosity = Options.CLI_WARNING_LEVEL.load();

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2144,7 +2144,7 @@ public class RubyModule extends RubyObject {
         Map<String, Invalidator> invalidators = null;
         for (RubyModule mod : gatherModules(module)) {
             for (String name : mod.getConstantMap().keySet()) {
-                if (invalidators == null) invalidators = new HashMap<>();
+                if (invalidators == null) invalidators = new HashMap<>(4);
                 invalidators.put(name, context.runtime.getConstantInvalidator(name));
             }
         }
@@ -3156,7 +3156,7 @@ public class RubyModule extends RubyObject {
     }
 
     public List<IRubyObject> getAncestorList() {
-        ArrayList<IRubyObject> list = new ArrayList<>();
+        ArrayList<IRubyObject> list = new ArrayList<>(4);
 
         for (RubyModule module = this; module != null; module = module.getSuperClass()) {
             // FIXME this is silly. figure out how to delegate the getNonIncludedClass()
@@ -4430,7 +4430,7 @@ public class RubyModule extends RubyObject {
      * @return A list of all modules that would be included by including the given module
      */
     private List<RubyModule> gatherModules(RubyModule baseModule) {
-        List<RubyModule> modulesToInclude = new ArrayList<>();
+        List<RubyModule> modulesToInclude = new ArrayList<>(4);
 
         for (; baseModule != null; baseModule = baseModule.superClass) {
             // skip prepended roots

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -81,8 +81,8 @@ public class RubySignal {
     private static final Map<Integer, String> SIGNUM_MAP;
 
     static {
-        HashMap<String, Integer> signals = new HashMap<>();
-        HashMap<Integer, String> signums = new HashMap<>();
+        HashMap<String, Integer> signals = new HashMap<>(Signal.values().length);
+        HashMap<Integer, String> signums = new HashMap<>(Signal.values().length);
 
         Signal[] values = Signal.values();
         for (Signal s : values) {

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1016,7 +1016,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         if (locals == null) {
             synchronized (this) {
                 locals = fiberLocalVariables;
-                if (locals == null) locals = fiberLocalVariables = new HashMap<>();
+                if (locals == null) locals = fiberLocalVariables = new HashMap<>(4);
             }
         }
         return locals;
@@ -1032,7 +1032,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         if (locals == null) {
             synchronized (this) {
                 locals = threadLocalVariables;
-                if (locals == null) locals = threadLocalVariables = new HashMap<>();
+                if (locals == null) locals = threadLocalVariables = new HashMap<>(4);
             }
         }
         return locals;

--- a/core/src/main/java/org/jruby/ast/HashNode.java
+++ b/core/src/main/java/org/jruby/ast/HashNode.java
@@ -45,7 +45,7 @@ import org.jruby.util.KeyValuePair;
  * of default values or kwarg in a method call.
  */
 public class HashNode extends Node implements ILiteralNode {
-    private final List<KeyValuePair<Node,Node>> pairs = new ArrayList<>();
+    private final List<KeyValuePair<Node,Node>> pairs = new ArrayList<>(1);
     // contains at least one **k {a: 1, **k}, {**{}, **{}}
     private boolean hasRestKwarg = false;
 
@@ -159,7 +159,7 @@ public class HashNode extends Node implements ILiteralNode {
     }
 
     public List<Node> childNodes() {
-        List<Node> children = new ArrayList<>();
+        List<Node> children = new ArrayList<>(pairs.size() * 2);
 
         for (KeyValuePair<Node,Node> pair: pairs) {
             children.add(pair.getKey());

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -57,6 +57,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
 import org.jruby.util.StringSupport;
+import org.jruby.util.collections.IntList;
 
 import static org.jruby.api.Access.kernelModule;
 import static org.jruby.api.Access.getModule;
@@ -2472,7 +2473,7 @@ public class RubyBigDecimal extends RubyNumeric {
       BigDecimal v = BigDecimal.ONE.divide(TWO.multiply(x), nMC);        // v0 = 1/(2*x)
 
       // Collect iteration precisions beforehand
-      ArrayList<Integer> nPrecs = new ArrayList<>();
+      IntList nPrecs = new IntList();
 
       assert nInit > 3 : "Never ending loop!";                // assume nInit = 16 <= prec
 

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
@@ -74,7 +74,7 @@ public final class GlobalVariable {
 
     public void addTrace(RubyProc command) {
         if (traces == null) {
-            traces = new ArrayList<IRubyObject>();
+            traces = new ArrayList<IRubyObject>(1);
         }
         traces.add(command);
     }

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -47,6 +47,7 @@ import org.jruby.runtime.ivars.MethodData;
 import org.jruby.util.ByteList;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,16 +87,18 @@ public class IRMethod extends IRScope {
         if (def != null) { // walk AST
             ivarNames = def.getMethodData();
         } else {
-            ivarNames = new ArrayList<>();
+            ivarNames = Collections.EMPTY_LIST;
             InterpreterContext context = lazilyAcquireInterpreterContext();
 
             // walk instructions
             for (Instr i : context.getInstructions()) {
                 switch (i.getOperation()) {
                     case GET_FIELD:
+                        if (ivarNames == Collections.EMPTY_LIST) ivarNames = new ArrayList<>(4);
                         ivarNames.add(((GetFieldInstr) i).getId());
                         break;
                     case PUT_FIELD:
+                        if (ivarNames == Collections.EMPTY_LIST) ivarNames = new ArrayList<>(4);
                         ivarNames.add(((PutFieldInstr) i).getId());
                         break;
                 }
@@ -145,8 +148,8 @@ public class IRMethod extends IRScope {
             int ipc = 0;
             int superIPC = -1;
             CallBase superCall = null;
-            Map<Label, Integer> labels = new HashMap<>();
-            List<Label> earlyJumps = new ArrayList<>();
+            Map<Label, Integer> labels = new HashMap<>(1);
+            List<Label> earlyJumps = new ArrayList<>(1);
             var context = getManager().getRuntime().getCurrentContext();
 
             for (Instr instr: interpreterContext.getInstructions()) {

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -103,7 +103,7 @@ public abstract class IRScope implements ParseResult {
 
     // List of all scopes this scope contains lexically.  This is not used
     // for execution, but is used during dry-runs for debugging.
-    private final List<IRScope> lexicalChildren = Collections.synchronizedList(new ArrayList<>());
+    private final List<IRScope> lexicalChildren = Collections.synchronizedList(new ArrayList<>(1));
 
     /** Startup interpretation depends on this */
     protected InterpreterContext interpreterContext;

--- a/core/src/main/java/org/jruby/ir/builder/EnsureBlockInfo.java
+++ b/core/src/main/java/org/jruby/ir/builder/EnsureBlockInfo.java
@@ -72,7 +72,7 @@ class EnsureBlockInfo {
         start       = s.getNewLabel("RESC_START");
         end         = s.getNewLabel("AFTER_RESC");
         dummyRescueBlockLabel = s.getNewLabel("RESC_DUMMY");
-        instrs = new ArrayList<>();
+        instrs = new ArrayList<>(4);
         savedGlobalException = null;
         innermostLoop = l;
         this.bodyRescuer = bodyRescuer;

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -2233,8 +2233,8 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         Variable errorString = copy(nil());
 
         label("pattern_case_end", end -> {
-            List<Label> labels = new ArrayList<>();
-            Map<Label, U> bodies = new HashMap<>();
+            List<Label> labels = new ArrayList<>(4);
+            Map<Label, U> bodies = new HashMap<>(4);
 
             // build each "when"
             Variable deconstructed = copy(nil());
@@ -2269,7 +2269,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
 
                 fcall(inspect, manager.getObjectClass(), "sprintf", new FrozenString("%s: key not found: :%s"), value, errorString);
                 Operand exceptionClass = searchModuleForConst(temp(), getManager().getObjectClass(), symbol("NoMatchingPatternKeyError"));
-                List<KeyValuePair<Operand, Operand>> kwargs = new ArrayList<>();
+                List<KeyValuePair<Operand, Operand>> kwargs = new ArrayList<>(4);
                 kwargs.add(new KeyValuePair<>(new Symbol(symbol("key")), errorString));
                 kwargs.add(new KeyValuePair<>(new Symbol(symbol("matchee")), value));
                 Variable exception = addResultInstr(CallInstr.create(scope, NORMAL, temp(), symbol("new"), exceptionClass, new Operand[] { inspect, new Hash(kwargs) }, NullBlock.INSTANCE, CALL_KEYWORD));
@@ -3069,7 +3069,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
     }
 
     public void addArgumentDescription(ArgumentType type, RubySymbol name) {
-        if (argumentDescriptions == null) argumentDescriptions = new ArrayList<>();
+        if (argumentDescriptions == null) argumentDescriptions = new ArrayList<>(2);
 
         argumentDescriptions.add(type);
         argumentDescriptions.add(name);

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -315,7 +315,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
     public Operand buildMultipleAsgn(MultipleAsgnNode multipleAsgnNode) {
         Node valueNode = multipleAsgnNode.getValueNode();
         Map<Node, Operand> reads = new HashMap<>();
-        final List<Tuple<Node, ResultInstr>> assigns = new ArrayList<>();
+        final List<Tuple<Node, ResultInstr>> assigns = new ArrayList<>(4);
         Variable values = temp();
         buildMultipleAssignment2(multipleAsgnNode, assigns, reads, values);
 
@@ -529,17 +529,17 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
         List<KeyValuePair<Node, Node>> pairs = keywordArgs.getPairs();
 
         if (pairs.size() == 1) { // Only a single rest arg here.  Do not bother to merge.
-            if (pairs.get(0).getValue() instanceof NilNode) return new Hash(new ArrayList<>()); // **nil
+            if (pairs.get(0).getValue() instanceof NilNode) return new Hash(new ArrayList<>(4)); // **nil
 
             Operand splat = buildWithOrder(pairs.get(0).getValue(), keywordArgs.containsVariableAssignment());
 
             return addResultInstr(new RuntimeHelperCall(temp(), HASH_CHECK, new Operand[] { splat }));
         }
 
-        Variable splatValue = copy(new Hash(new ArrayList<>()));
+        Variable splatValue = copy(new Hash(new ArrayList<>(1)));
         for (KeyValuePair<Node, Node> pair: pairs) {
             Operand splat = pair.getValue() instanceof NilNode ?
-                    new Hash(new ArrayList<>()) : // **nil
+                    new Hash(new ArrayList<>(1)) : // **nil
                     buildWithOrder(pair.getValue(), keywordArgs.containsVariableAssignment()); // **r
             addInstr(new RuntimeHelperCall(splatValue, MERGE_KWARGS, new Operand[] { splatValue, splat, fals() }));
         }
@@ -1242,8 +1242,8 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
     }
 
     private Variable buildStandardCaseWhen(CaseNode caseNode, Map<Node, Label> nodeBodies, Label endLabel, boolean hasElse, Label elseLabel, Operand value, Variable result) {
-        List<Label> labels = new ArrayList<>();
-        Map<Label, Node> bodies = new HashMap<>();
+        List<Label> labels = new ArrayList<>(4);
+        Map<Label, Node> bodies = new HashMap<>(4);
 
         // build each "when"
         for (Node aCase : caseNode.getCases().children()) {
@@ -2072,7 +2072,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
     // Multiple assignment in an ordinary expression (e.g a,b,*c=v).
     public void buildMultipleAssignment(final MultipleAsgnNode multipleAsgnNode, Operand values) {
         final ListNode masgnPre = multipleAsgnNode.getPre();
-        final List<Tuple<Node, Variable>> assigns = new ArrayList<>();
+        final List<Tuple<Node, Variable>> assigns = new ArrayList<>(4);
 
         int i = 0;
         if (masgnPre != null) {
@@ -2104,7 +2104,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
 
     // Multiple assignment in arguments (e.g. { |a,b,*c| ..})
     public void buildMultipleAssignmentArgs(final MultipleAsgnNode multipleAsgnNode, Operand argsArray) {
-        final List<Tuple<Node, Variable>> assigns = new ArrayList<>();
+        final List<Tuple<Node, Variable>> assigns = new ArrayList<>(4);
         int i = 0;
         ListNode masgnPre = multipleAsgnNode.getPre();
         if (masgnPre != null) {
@@ -2320,7 +2320,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
     }
 
     public Operand buildHash(HashNode hashNode) {
-        List<KeyValuePair<Operand, Operand>> args = new ArrayList<>();
+        List<KeyValuePair<Operand, Operand>> args = new ArrayList<>(1);
         boolean hasAssignments = hashNode.containsVariableAssignment();
         Variable hash = null;
         // Duplication checks happen when **{} are literals and not **h variable references.
@@ -2336,10 +2336,10 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
                  duplicateCheck = value instanceof HashNode && ((HashNode) value).isLiteral() ? tru() : fals();
                 if (hash == null) {                     // No hash yet. Define so order is preserved.
                     hash = copy(new Hash(args));
-                    args = new ArrayList<>();           // Used args but we may find more after the splat so we reset
+                    args = new ArrayList<>(1);           // Used args but we may find more after the splat so we reset
                 } else if (!args.isEmpty()) {
                     addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, new Hash(args), duplicateCheck}));
-                    args = new ArrayList<>();
+                    args = new ArrayList<>(1);
                 }
                 Operand splat = buildWithOrder(value, hasAssignments);
                 addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, splat, duplicateCheck}));

--- a/core/src/main/java/org/jruby/ir/builder/LazyMethodDefinitionAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/LazyMethodDefinitionAST.java
@@ -29,7 +29,7 @@ public class LazyMethodDefinitionAST implements LazyMethodDefinition<Node, DefNo
 
     @Override
     public List<String> getMethodData() {
-        List<String> ivarNames = new ArrayList<>();
+        List<String> ivarNames = new ArrayList<>(1);
 
         node.getBodyNode().accept(new AbstractNodeVisitor<Object>() {
             @Override

--- a/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
@@ -51,7 +51,7 @@ public class FullInterpreterContext extends InterpreterContext {
     private Map<String, DataFlowProblem> dataFlowProblems;
 
     /** What passes have been run on this scope? */
-    private final List<CompilerPass> executedPasses = new ArrayList<>();
+    private final List<CompilerPass> executedPasses = new ArrayList<>(4);
 
 
     /** Local variables defined in this scope */
@@ -107,7 +107,7 @@ public class FullInterpreterContext extends InterpreterContext {
         linearizeBasicBlocks();
 
         // Pass 1. Set up IPCs for labels and instructions and build linear instr list
-        List<Instr> newInstrs = new ArrayList<>();
+        List<Instr> newInstrs = new ArrayList<>(4);
         int ipc = 0;
         for (BasicBlock b: getLinearizedBBList()) {
             // All same-named labels must be same Java instance for this to work or we would need
@@ -176,7 +176,7 @@ public class FullInterpreterContext extends InterpreterContext {
     }
 
     public Map<String, DataFlowProblem> getDataFlowProblems() {
-        if (dataFlowProblems == null) dataFlowProblems = new HashMap<>();
+        if (dataFlowProblems == null) dataFlowProblems = new HashMap<>(1);
         return dataFlowProblems;
     }
 

--- a/core/src/main/java/org/jruby/ir/representations/BasicBlock.java
+++ b/core/src/main/java/org/jruby/ir/representations/BasicBlock.java
@@ -42,7 +42,7 @@ public class BasicBlock implements ExplicitVertexID, Comparable<BasicBlock> {
     }
 
     private void initInstrs() {
-        instrs = new ArrayList<>();
+        instrs = new ArrayList<>(1);
         if (RubyInstanceConfig.IR_COMPILER_DEBUG || RubyInstanceConfig.IR_DEBUG_IGV != null) {
             IRManager irManager = cfg.getManager();
             InstructionsListener listener = irManager.getInstructionsListener();

--- a/core/src/main/java/org/jruby/ir/representations/CFG.java
+++ b/core/src/main/java/org/jruby/ir/representations/CFG.java
@@ -44,7 +44,7 @@ public class CFG {
     private BasicBlock exitBB;
 
     /** List of bbs that have a 'return' instruction */
-    List<BasicBlock> returnBBs = new ArrayList<>();
+    List<BasicBlock> returnBBs = new ArrayList<>(1);
 
     /** BB that traps all exception-edges out of the cfg where we could add any cleanup/ensure code (ex: pop frames, etc.) */
     private BasicBlock globalEnsureBB;
@@ -59,8 +59,8 @@ public class CFG {
     public CFG(IRScope scope) {
         this.scope = scope;
         this.graph = new DirectedGraph<>();
-        this.bbMap = new HashMap<>();
-        this.rescuerMap = new HashMap<>();
+        this.bbMap = new HashMap<>(4);
+        this.rescuerMap = new HashMap<>(4);
         this.nextBBId = 0;
         this.entryBB = this.exitBB = null;
         this.globalEnsureBB = null;
@@ -211,13 +211,13 @@ public class CFG {
         Map<Label, List<BasicBlock>> forwardRefs = new HashMap<>();
 
         // List of bbs that have a 'throw' instruction
-        List<BasicBlock> exceptionBBs = new ArrayList<>();
+        List<BasicBlock> exceptionBBs = new ArrayList<>(1);
 
         // Stack of nested rescue regions
         Stack<ExceptionRegion> nestedExceptionRegions = new Stack<>();
 
         // List of all rescued regions
-        List<ExceptionRegion> allExceptionRegions = new ArrayList<>();
+        List<ExceptionRegion> allExceptionRegions = new ArrayList<>(1);
 
         // Dummy entry basic block (see note at end to see why)
         entryBB = createBB(nestedExceptionRegions);
@@ -357,7 +357,7 @@ public class CFG {
         }
 
         // Add a forward reference from target -> source
-        List<BasicBlock> forwardReferences = forwardRefs.computeIfAbsent(targetLabel, k -> new ArrayList<>());
+        List<BasicBlock> forwardReferences = forwardRefs.computeIfAbsent(targetLabel, k -> new ArrayList<>(1));
 
         forwardReferences.add(src);
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1184,8 +1184,9 @@ public class JVMVisitor extends IRVisitor {
 
     @Override
     public void BuildCompoundStringInstr(BuildCompoundStringInstr compoundstring) {
-        List<DStringElement> dstringElements = new ArrayList<>();
-        for (Operand p : compoundstring.getPieces()) {
+        Operand[] pieces = compoundstring.getPieces();
+        List<DStringElement> dstringElements = new ArrayList<>(pieces.length);
+        for (Operand p : pieces) {
             if (p instanceof StringLiteral str) {
                 dstringElements.add(new DStringElement(DStringElementType.STRING, p));
             } else {

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -559,7 +559,7 @@ public class MethodGatherer {
 
     Map<String, NamedInstaller> getStaticInstallersForWrite() {
         Map<String, NamedInstaller> staticInstallers = this.staticInstallers;
-        return staticInstallers == Collections.EMPTY_MAP ? this.staticInstallers = new HashMap() : staticInstallers;
+        return staticInstallers == Collections.EMPTY_MAP ? this.staticInstallers = new HashMap(4) : staticInstallers;
     }
 
     Map<String, NamedInstaller> getInstanceInstallers() {
@@ -568,7 +568,7 @@ public class MethodGatherer {
 
     Map<String, NamedInstaller> getInstanceInstallersForWrite() {
         Map<String, NamedInstaller> instanceInstallers = this.instanceInstallers;
-        return instanceInstallers == Collections.EMPTY_MAP ? this.instanceInstallers = new HashMap() : instanceInstallers;
+        return instanceInstallers == Collections.EMPTY_MAP ? this.instanceInstallers = new HashMap(4) : instanceInstallers;
     }
 
     @SuppressWarnings("deprecation")
@@ -720,8 +720,8 @@ public class MethodGatherer {
                 }
             }
 
-            this.instanceMethods = instanceMethods.toArray(new Method[instanceMethods.size()]);
-            this.staticMethods = staticMethods.toArray(new Method[staticMethods.size()]);
+            this.instanceMethods = instanceMethods.toArray(Method[]::new);
+            this.staticMethods = staticMethods.toArray(Method[]::new);
         }
 
         private static boolean filterAccessible(Method method, int mod) {

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -94,8 +94,8 @@ import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 public class JavaProxyClass extends JavaProxyReflectionObject {
 
     private final Class proxyClass;
-    private final ArrayList<JavaProxyMethod> methods = new ArrayList<>();
-    private final HashMap<String, ArrayList<JavaProxyMethod>> methodMap = new HashMap<>();
+    private final ArrayList<JavaProxyMethod> methods = new ArrayList<>(4);
+    private final HashMap<String, ArrayList<JavaProxyMethod>> methodMap = new HashMap<>(4);
 
     private JavaProxyClass(ThreadContext context, final Class<?> proxyClass) {
         super(context.runtime, Access.getClass(context, "Java", "JavaProxyClass"));

--- a/core/src/main/java/org/jruby/javasupport/util/JavaClassConfiguration.java
+++ b/core/src/main/java/org/jruby/javasupport/util/JavaClassConfiguration.java
@@ -56,14 +56,14 @@ public class JavaClassConfiguration implements Cloneable {
     public boolean allMethods = true;
     public boolean allClassMethods = true; // TODO: ensure defaults are sane
     public boolean javaConstructable = true;
-    public List<Class<?>[]> extraCtors = new ArrayList<>();
+    public List<Class<?>[]> extraCtors = new ArrayList<>(4);
 
     // for java proxies
     public boolean allCtors = false;
     public boolean rubyConstructable = true; //
     public boolean IroCtors = true;
 
-    public Map<String, String> renamedMethods = new HashMap<>();
+    public Map<String, String> renamedMethods = new HashMap<>(4);
     public String javaCtorMethodName = "initialize";
     private Set<String> excluded = null;
     private Set<String> included = null;

--- a/core/src/main/java/org/jruby/runtime/Arity.java
+++ b/core/src/main/java/org/jruby/runtime/Arity.java
@@ -39,6 +39,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.api.Error;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ArraySupport;
+import org.jruby.util.collections.IntHashMap;
 
 import static org.jruby.api.Error.argumentError;
 
@@ -47,7 +48,7 @@ import static org.jruby.api.Error.argumentError;
  */
 public final class Arity implements Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Map<Integer, Arity> arities = new HashMap<>();
+    private static final IntHashMap<Arity> arities = new IntHashMap<>();
     private final int value;
     
     public final static Arity NO_ARGUMENTS = newArity(0);

--- a/core/src/main/java/org/jruby/runtime/RubyEvent.java
+++ b/core/src/main/java/org/jruby/runtime/RubyEvent.java
@@ -38,7 +38,7 @@ public enum RubyEvent {
     private final String event_name;
     private final boolean requiresDebug;
 
-    private static final Map<String, RubyEvent> fromName = new HashMap<>();
+    private static final Map<String, RubyEvent> fromName = new HashMap<>(RubyEvent.values().length);
     static {
         for (RubyEvent event : RubyEvent.values()) {
             fromName.put(event.getName(), event);

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -1469,12 +1469,12 @@ public final class ThreadContext {
     private Map<IRubyObject, IRubyObject> safeRecurseGetGuards(String name) {
         Map<String, IdentityHashMap<IRubyObject, IRubyObject>> symToGuards = this.symToGuards;
         if (symToGuards == null) {
-            this.symToGuards = symToGuards = new HashMap<>();
+            this.symToGuards = symToGuards = new HashMap<>(4);
         }
 
         IdentityHashMap<IRubyObject, IRubyObject> guards = symToGuards.get(name);
         if (guards == null) {;
-            symToGuards.put(name, guards = new IdentityHashMap<>());
+            symToGuards.put(name, guards = new IdentityHashMap<>(4));
         }
 
         return guards;

--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -471,7 +471,7 @@ public class LibrarySearcher {
     class Feature {
         Feature(StringWrapper key, IRubyObject featurePath) {
             this.key = key;
-            this.featurePaths = new ArrayList<>();
+            this.featurePaths = new ArrayList<>(1);
 
             featurePaths.add(featurePath);
         }

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -174,13 +174,16 @@ public class LoadService {
         public static final String[] extensionSuffixes = LibrarySearcher.Suffix.EXTENSIONS.stream().map((suffix) -> suffix.name()).toArray(String[]::new);
     }
 
+    @Deprecated(since = "10.0.3.0")
     protected static final Pattern sourcePattern = Pattern.compile("\\.(?:rb)$");
+    @Deprecated(since = "10.0.3.0")
     protected static final Pattern extensionPattern = Pattern.compile("\\.(?:so|o|jar)$");
 
     protected RubyArray loadPath;
     protected StringArraySet loadedFeatures;
 
-    protected final Map<String, JarFile> jarFiles = new HashMap<>();
+    @Deprecated(since = "10.0.3.0")
+    protected final Map<String, JarFile> jarFiles = new HashMap<>(0);
 
     protected final Ruby runtime;
     protected LibrarySearcher librarySearcher;

--- a/core/src/main/java/org/jruby/runtime/profile/builtin/MethodData.java
+++ b/core/src/main/java/org/jruby/runtime/profile/builtin/MethodData.java
@@ -35,7 +35,7 @@ class MethodData extends InvocationSet {
     final int serialNumber;
 
     MethodData(int serial) {
-        super(new ArrayList<Invocation>());
+        super(new ArrayList<Invocation>(4));
         this.serialNumber = serial;
     }
 
@@ -65,7 +65,7 @@ class MethodData extends InvocationSet {
     }
 
     public InvocationSet invocationsForParent(int parentSerial) {
-        ArrayList<Invocation> p = new ArrayList<Invocation>();
+        ArrayList<Invocation> p = new ArrayList<Invocation>(4);
         for (Invocation inv : invocations) {
             int serial = inv.getParent().getMethodSerialNumber();
             if (serial == parentSerial) {
@@ -76,7 +76,7 @@ class MethodData extends InvocationSet {
     }
 
     public InvocationSet rootInvocationsFromParent(int parentSerial) {
-        ArrayList<Invocation> p = new ArrayList<Invocation>();
+        ArrayList<Invocation> p = new ArrayList<Invocation>(4);
         for (Invocation inv : invocations) {
             int serial = inv.getParent().getMethodSerialNumber();
             if (serial == parentSerial && inv.getRecursiveDepth() == 1) {
@@ -87,7 +87,7 @@ class MethodData extends InvocationSet {
     }
 
     public InvocationSet invocationsFromParent(int parentSerial) {
-        ArrayList<Invocation> p = new ArrayList<Invocation>();
+        ArrayList<Invocation> p = new ArrayList<Invocation>(4);
         for (Invocation inv : invocations) {
             int serial = inv.getParent().getMethodSerialNumber();
             if (serial == parentSerial) {
@@ -98,7 +98,7 @@ class MethodData extends InvocationSet {
     }
 
     public InvocationSet rootInvocationsOfChild(int childSerial) {
-        ArrayList<Invocation> p = new ArrayList<Invocation>();
+        ArrayList<Invocation> p = new ArrayList<Invocation>(4);
         for (Invocation inv : invocations) {
             Invocation childInv = inv.getChildren().get(childSerial);
             if (childInv != null && childInv.getRecursiveDepth() == 1) {
@@ -109,7 +109,7 @@ class MethodData extends InvocationSet {
     }
 
     public InvocationSet invocationsOfChild(int childSerial) {
-        ArrayList<Invocation> p = new ArrayList<Invocation>();
+        ArrayList<Invocation> p = new ArrayList<Invocation>(4);
         for (Invocation inv : invocations) {
             Invocation childInv = inv.getChildren().get(childSerial);
             if (childInv != null) {

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -54,6 +54,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
@@ -1342,13 +1343,12 @@ public class EncodingUtils {
     }
 
     public static List<String> encodingNames(byte[] name, int p, int end) {
-        final List<String> names = new ArrayList<String>();
 
         Encoding enc = ASCIIEncoding.INSTANCE;
         int s = p;
 
         int code = name[s] & 0xff;
-        if (enc.isDigit(code)) return names;
+        if (enc.isDigit(code)) return Collections.EMPTY_LIST;
 
         boolean hasUpper = false;
         boolean hasLower = false;
@@ -1359,6 +1359,7 @@ public class EncodingUtils {
             }
         }
 
+        final List<String> names = new ArrayList<String>(4);
         boolean isValid = false;
         if (s >= end) {
             isValid = true;

--- a/core/src/main/java/org/jruby/util/io/SelectExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/SelectExecutor.java
@@ -295,7 +295,7 @@ public class SelectExecutor {
                 // need to create pipe between alt impl selector and native NIO selector
                 Pipe pipe = Pipe.open();
                 ENXIOSelector enxioSelector = new ENXIOSelector(selector, pipe);
-                if (enxioSelectors.isEmpty()) enxioSelectors = new ArrayList<ENXIOSelector>();
+                if (enxioSelectors.isEmpty()) enxioSelectors = new ArrayList<ENXIOSelector>(1);
                 enxioSelectors.add(enxioSelector);
                 pipe.source().configureBlocking(false);
                 pipe.source().register(getSelector(context, pipe.source()), SelectionKey.OP_READ, enxioSelector);


### PR DESCRIPTION
Most of these collections will hold only a few items if any, but they were being set up with default constructors that may choose a too-big starting size. Set up some sane default sizes to avoid lots of wasted space.