### PR TITLE
Separate Java version out of rbconfig 'arch'

### DIFF
--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -256,8 +256,10 @@ public class RbConfigLibrary implements Library {
         String javaSpecVersion = System.getProperty("java.specification.version");
         if (javaSpecVersion.equals("1.8")) javaSpecVersion = "8";
 
-        // Rubygems is too specific on host cpu so until we have real need lets default to universal
-        setConfig(context, CONFIG, "arch", "universal-java-" + javaSpecVersion);
+        // Rubygems uses this to indicate extensions have been built, so we separate the Java version.
+        // See https://github.com/ruby/rubygems/issues/3520
+        setConfig(context, CONFIG, "arch", "universal-java");
+        setConfig(context, CONFIG, "arch_version", javaSpecVersion);
 
         // Use property for binDir if available, otherwise fall back to common bin default
         String binDir = SafePropertyAccessor.getProperty("jruby.bindir");


### PR DESCRIPTION
The 'arch' field in RbConfig::CONFIG is used by RubyGems to name a directory where the build artifacts from extension gems list. When a gem has been installed, but its extension does not appear in this directory, RubyGems knows the extension needs to be rebuilt and warns.

JRuby extensions are almost never platform-specific, so we have used a Java-related string for 'arch', with the current Java specification version appended like 'universal-java-21'. However because the version is included, any gems that have an extension build -- even if they don't actually build it on JRuby -- get associated with that exact 'arch' string. Switching to a different version of Java causes RubyGems to mistakenly think an extension needs to be built, and it warns.

See https://github.com/ruby/rubygems/issues/3520 for related discussions.

The RubyGems team originally suggested ignoring the 'arch' version, since a similar situation affected CRuby on macOS (with an 'arch' of 'darwin-<version>'), but ultimately they only ended up patching Bundler to ignore this version. Rather than try to further modify RubyGems to ignore this version component, JRuby will omit it in 'arch' and move it to a separate 'arch_version' field users can query if desired.