### PR TITLE
Prevent modifying state in RubyProc

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -239,8 +239,7 @@ public class RubyMethod extends AbstractRubyMethod {
                 receiver, originModule, originName, getFilename(), line == -1 ? -1 : line - 1);
         Block b = MethodBlockBody.createMethodBlock(body);
 
-        RubyProc proc = RubyProc.newProc(context.runtime, b, Block.Type.LAMBDA);
-        proc.setFromMethod();
+        RubyProc proc = RubyProc.newMethodProc(context.runtime, b);
         return proc;
     }
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3030,9 +3030,7 @@ public class RubyModule extends RubyObject {
         block.getBinding().getFrame().setName(name);
 
         // a normal block passed to define_method changes to do arity checking; make it a lambda
-        RubyProc proc = runtime.newProc(Block.Type.LAMBDA, block);
-
-        proc.setFromMethod();
+        RubyProc proc = RubyProc.newMethodProc(runtime, block);
 
         // various instructions can tell this scope is not an ordinary block but a block representing
         // a method definition.


### PR DESCRIPTION
A change during 9.4.x accidentally modified this code to update the "file" field on RubyProc, rather than using a local variable. This restores that local variable and subsequent commits will make the fields final to avoid this happening in the future.

Fixes jruby/jruby#9110