### PR TITLE
Add file path to error message when unlinking non-existing file

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1213,9 +1213,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
         var cwd = context.runtime.getCurrentDirectory();
         for (int i = 0; i < args.length; i++) {
-            var toUnlink = JRubyFile.create(cwd, get_path(context, args[i]).toString()).getAbsolutePath();
+            var path = get_path(context, args[i]).toString();
+            var toUnlink = JRubyFile.create(cwd, path).getAbsolutePath();
 
-            if (posix.unlink(toUnlink) < 0) throw context.runtime.newErrnoFromInt(posix.errno());
+            if (posix.unlink(toUnlink) < 0) throw context.runtime.newErrnoFromInt(posix.errno(), path);
         }
 
         return asFixnum(context, args.length);


### PR DESCRIPTION
This changes error message when doing `FileUtils.rm` on a non-existing file.

Ruby 3.4.1:

```
irb(main):005> FileUtils.rm("/tmp/blah")
/home/katafrakt/.local/share/mise/installs/ruby/3.4.1/lib/ruby/3.4.0/fileutils.rb:2332:in 'File.unlink': No such file or directory @ apply2files - /tmp/blah (Errno::ENOENT)
	from /home/katafrakt/.local/share/mise/installs/ruby/3.4.1/lib/ruby/3.4.0/fileutils.rb:2332:in 'block in FileUtils::Entry_#remove_file'
```

In JRuby 10.0.2.0:

```
irb(main):003> FileUtils.rm("/tmp/blah")
org/jruby/RubyFile.java:1218:in 'unlink': No such file or directory - No such file or directory (Errno::ENOENT)
	from /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.2.0/lib/ruby/stdlib/fileutils.rb:2332:in 'block in remove_file'
```

After changes in this PR:

```
irb(main):001> FileUtils.rm("/tmp/blah")
org/jruby/RubyFile.java:1219:in 'unlink': No such file or directory - /tmp/blah (Errno::ENOENT)
	from /home/katafrakt/dev/github/jruby/lib/ruby/stdlib/fileutils.rb:2332:in 'block in remove_file'
```