### PR TITLE
Reduce load factor for Hash from 5 to 2

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -526,7 +526,7 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     private static final int MIN_CAPA = 8;
-    private static final int ST_DEFAULT_MAX_DENSITY = 5;
+    private static final int ST_DEFAULT_MAX_DENSITY = 2;
     private final void MRICheckResize() {
         if (size / table.length > ST_DEFAULT_MAX_DENSITY) {
             int forSize = table.length + 1; // size + 1;


### PR DESCRIPTION
The default load factor here was inherited from CRuby, which also used a load factor of 5 for its "chained bucket" implementation of Hash. Since then, they have moved on to a more space and cache- efficient open-addressing implementation.

In jruby/jruby#9113, a user reported that large Hash initialization regressed in performance relative to JRuby 1.7 and CRuby 3.4, and this high load factor was found to be a big part of that.

A load factor of five means a saturated Hash may do 5x as much work to find a given entry, because up to five chained entries must be searched in a given bucket. Reducing this to a load factor of one may be too aggressive, so we use a load factor of two here to cut the maximum number of extra hops down to one.

Given 32-bit compressed OOPS and non-Liliput, we can do some math for the size increase:

A 1000-element Hash at load factor = 5 consumes 800 bytes for the bucket array and about 40_000 bytes for the entry objects for a total of 40_000 bytes (not including the Hash object itself).

The same Hash at load factor = 2 consumes 2000 bytes for the bucket array, an extra 1200 bytes or 2.9% size increase.