### PR TITLE
fix(launcher): correct parsing of java release files under Bash/msys2 etc on Windows

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -244,12 +244,13 @@ if [ -r "/dev/urandom" ]; then
     JAVA_SECURITY_EGD="file:/dev/urandom"
 fi
 
-# Gather environment information as we go
-readonly cr='
+cr="$(printf '\r')" && readonly cr
+readonly nl='
 '
+# Gather environment information as we go
 environment_log=""
 add_log() {
-    environment_log="${environment_log}${cr}${*-}"
+    environment_log="${environment_log}${nl}${*-}"
 }
 
 # Logic to process "arguments files" on both Java 8 and Java 9+
@@ -265,7 +266,7 @@ process_java_opts() {
             append java_opts_from_files "@$java_opts_file"
         else
             local line=
-            while read -r line; do
+            while IFS="$cr" read -r line; do
                 if [ "$line" ]; then
                     # shellcheck disable=2086  # Split options on whitespace
                     append java_opts_from_files $line
@@ -533,7 +534,7 @@ java_major=8
 # shellcheck source=/dev/null
 if [ -f "$JAVA_HOME/release" ]; then
     # Get java version from JAVA_HOME/release file
-    while IFS= read -r line; do
+    while IFS="$cr" read -r line; do
         case $line in
             (\#*) continue ;;
         esac
@@ -573,8 +574,9 @@ fi
 # Default java_runtime_version to $java_version
 : "${java_runtime_version:=$java_version}"
 
-add_log "Detected Java version: $java_version"
+add_log "Detected Java version: $java_version (major: $java_major)"
 add_log "Detected Java runtime version: $java_runtime_version"
+add_log "Detected JRuby minimum java version: $minimum_java_version"
 
 # Present a useful error if running a Java version lower than bin/.java-version
 if [ "$java_major" -lt "$minimum_java_version" ]; then
@@ -1010,7 +1012,7 @@ add_log "  $*"
 
 # shellcheck source=/dev/null
 if $print_environment_log; then
-    environment_log="JRuby Environment${cr}=================${cr}${cr}JRuby version: ${jruby_version}${environment_log}"
+    environment_log="JRuby Environment${nl}=================${nl}${nl}JRuby version: ${jruby_version}${environment_log}"
     echo "$environment_log"
     exit 0
 fi


### PR DESCRIPTION
- fixes #9122 

The Eclipse Temurin files have CRLFs on Windows which breaks the parsing and unquoting here.

Notes
- After this change any other trailing whitespace still breaks the parsing (at least with bash); this only trims a single trailing CR.
- Parsing `.jruby.java_opts` in the non-module JVM case seems to work fine as-is, because it splits on whitespace anyway (which also means it doesn't work for any args with intentional whitespace in them anyway; quoted or unquoted in the file); but I aligned the `IFS=` to isolate from the environment and do things consistently anyway.
- Made some minor tweaks to the shellcheck rules to be a bit more conservative and make IntelliJ IDEA's integration happen
- Logged the parsed major version and minimum versions to assist debugging with `--environment` in future.
- Corrected typo to use `JAVA_RUNTIME_VERSION` correctly as intended per conversation in https://github.com/jruby/jruby/pull/9127#discussion_r2603455725

Example 1 (Temurin x64 on Windows, with CRLF)
```
IMPLEMENTOR="Eclipse Adoptium"
IMPLEMENTOR_VERSION="Temurin-21.0.9+10"
JAVA_RUNTIME_VERSION="21.0.9+10-LTS"
JAVA_VERSION="21.0.9"
JAVA_VERSION_DATE="2025-10-21"
LIBC="default"
MODULES="java.base java.compiler java.datatransfer java.xml java.prefs java.desktop java.instrument java.logging java.management java.security.sasl java.naming java.rmi java.management.rmi java.net.http java.scripting java.security.jgss java.transaction.xa java.sql java.sql.rowset java.xml.crypto java.se java.smartcardio jdk.accessibility jdk.internal.jvmstat jdk.attach jdk.charsets jdk.internal.opt jdk.zipfs jdk.compiler jdk.crypto.ec jdk.crypto.cryptoki jdk.crypto.mscapi jdk.dynalink jdk.internal.ed jdk.editpad jdk.hotspot.agent jdk.httpserver jdk.incubator.vector jdk.internal.le jdk.internal.vm.ci jdk.internal.vm.compiler jdk.internal.vm.compiler.management jdk.jartool jdk.javadoc jdk.jcmd jdk.management jdk.management.agent jdk.jconsole jdk.jdeps jdk.jdwp.agent jdk.jdi jdk.jfr jdk.jlink jdk.jpackage jdk.jshell jdk.jsobject jdk.jstatd jdk.localedata jdk.management.jfr jdk.naming.dns jdk.naming.rmi jdk.net jdk.nio.mapmode jdk.random jdk.sctp jdk.security.auth jdk.security.jgss jdk.unsupported jdk.unsupported.desktop jdk.xml.dom"
OS_ARCH="x86_64"
OS_NAME="Windows"
SOURCE=".:git:759062135b07"
BUILD_SOURCE="git:839fa0b45d809157cffd3dc8515aad262a4a1776"
BUILD_SOURCE_REPO="https://github.com/adoptium/temurin-build.git"
SOURCE_REPO="https://github.com/adoptium/jdk21u.git"
FULL_VERSION="21.0.9+10-LTS"
SEMANTIC_VERSION="21.0.9+10"
BUILD_INFO="OS: Windows Server 2022 Version: 10.0"
JVM_VARIANT="Hotspot"
JVM_VERSION="21.0.9+10-LTS"
IMAGE_TYPE="JDK"
```

Example 2 (Microsoft aarch64 on Windows, with CRLF)
```
IMPLEMENTOR="Microsoft"
IMPLEMENTOR_VERSION="Microsoft-11952137"
JAVA_RUNTIME_VERSION="21.0.8+9-LTS"
JAVA_VERSION="21.0.8"
JAVA_VERSION_DATE="2025-07-15"
LIBC="default"
MODULES="java.base java.compiler java.datatransfer java.xml java.prefs java.desktop java.instrument java.logging java.management java.security.sasl java.naming java.rmi java.management.rmi java.net.http java.scripting java.security.jgss java.transaction.xa java.sql java.sql.rowset java.xml.crypto java.se java.smartcardio jdk.accessibility jdk.internal.jvmstat jdk.attach jdk.charsets jdk.internal.opt jdk.zipfs jdk.compiler jdk.crypto.ec jdk.crypto.cryptoki jdk.crypto.mscapi jdk.dynalink jdk.internal.ed jdk.editpad jdk.hotspot.agent jdk.httpserver jdk.incubator.vector jdk.internal.le jdk.internal.vm.ci jdk.internal.vm.compiler jdk.internal.vm.compiler.management jdk.jartool jdk.javadoc jdk.jcmd jdk.management jdk.management.agent jdk.jconsole jdk.jdeps jdk.jdwp.agent jdk.jdi jdk.jfr jdk.jlink jdk.jpackage jdk.jshell jdk.jsobject jdk.jstatd jdk.localedata jdk.management.jfr jdk.naming.dns jdk.naming.rmi jdk.net jdk.nio.mapmode jdk.random jdk.sctp jdk.security.auth jdk.security.jgss jdk.unsupported jdk.unsupported.desktop jdk.xml.dom"
OS_ARCH="aarch64"
OS_NAME="Windows"
SOURCE=".:git:bd8efd5c847d"
```

