### PR TITLE
[9.4] fix(launcher): correct parsing of java release files under Bash/msys2 etc on Windows 

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -244,12 +244,13 @@ if [ -r "/dev/urandom" ]; then
     JAVA_SECURITY_EGD="file:/dev/urandom"
 fi
 
-# Gather environment information as we go
-readonly cr='
+cr="$(printf '\r')" && readonly cr
+readonly nl='
 '
+# Gather environment information as we go
 environment_log=""
 add_log() {
-    environment_log="${environment_log}${cr}${*-}"
+    environment_log="${environment_log}${nl}${*-}"
 }
 
 # Logic to process "arguments files" on both Java 8 and Java 9+
@@ -265,7 +266,7 @@ process_java_opts() {
             append java_opts_from_files "@$java_opts_file"
         else
             local line=
-            while read -r line; do
+            while IFS="$cr" read -r line; do
                 if [ "$line" ]; then
                     # shellcheck disable=2086  # Split options on whitespace
                     append java_opts_from_files $line
@@ -533,7 +534,7 @@ java_major=8
 # shellcheck source=/dev/null
 if [ -f "$JAVA_HOME/release" ]; then
     # Get java version from JAVA_HOME/release file
-    while IFS= read -r line; do
+    while IFS="$cr" read -r line; do
         case $line in
             (\#*) continue ;;
         esac
@@ -573,8 +574,9 @@ fi
 # Default java_runtime_version to $java_version
 : "${java_runtime_version:=$java_version}"
 
-add_log "Detected Java version: $java_version"
+add_log "Detected Java version: $java_version (major: $java_major)"
 add_log "Detected Java runtime version: $java_runtime_version"
+add_log "Detected JRuby minimum java version: $minimum_java_version"
 
 # Present a useful error if running a Java version lower than bin/.java-version
 if [ "$java_major" -lt "$minimum_java_version" ]; then
@@ -1009,7 +1011,7 @@ add_log "  $*"
 
 # shellcheck source=/dev/null
 if $print_environment_log; then
-    environment_log="JRuby Environment${cr}=================${cr}${cr}JRuby version: ${jruby_version}${environment_log}"
+    environment_log="JRuby Environment${nl}=================${nl}${nl}JRuby version: ${jruby_version}${environment_log}"
     echo "$environment_log"
     exit 0
 fi


### PR DESCRIPTION
Backport of #9127 for 9.4.x (given other launcher changes for `10.0.x` have been ported across).