### PR TITLE
Copy Data type's var table manager with new realClass

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -550,7 +550,7 @@ public class RubyClass extends RubyModule {
                 baseName(name);
         clazz.makeMetaClass(context, superClass.getMetaClass());
         if (setParent) clazz.setParent(parent);
-        clazz.copyVariableTableManager(context, superClass);
+        clazz.copyVariableTableManagerForData(context, superClass);
         parent.setConstant(context, name, clazz, file, line);
         superClass.invokeInherited(context, superClass, clazz);
         return clazz;
@@ -1073,7 +1073,7 @@ public class RubyClass extends RubyModule {
         allocator = superClazz.allocator;
         makeMetaClass(context, superClazz.getMetaClass());
         superClazz.addSubclass(this);
-        copyVariableTableManager(context, superClazz);
+        copyVariableTableManagerForData(context, superClazz);
 
         marshal = superClazz.marshal;
 
@@ -1083,11 +1083,11 @@ public class RubyClass extends RubyModule {
         return this;
     }
 
-    private void copyVariableTableManager(ThreadContext context, RubyClass superClazz) {
+    private void copyVariableTableManagerForData(ThreadContext context, RubyClass superClazz) {
         VariableTableManager variableTableManager = superClazz.getVariableTableManager();
         if (variableTableManager.getRealClass().superClass() == context.runtime.getData()) {
             // duplicate data's variable table in subclasses
-            this.variableTableManager = variableTableManager.duplicate();
+            this.variableTableManager = variableTableManager.duplicateForData(this);
         }
     }
 

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -107,13 +107,14 @@ public class VariableTableManager {
     }
 
     /**
-     * Copy constructor with deep cloning.
+     * Copy constructor with deep cloning for subclasses of Data types. The new realClass will be the
+     * subclass rather than the original Data type.
      *
      * @param original VariableTableManager to copy
      */
-    VariableTableManager(VariableTableManager original) {
+    VariableTableManager(VariableTableManager original, RubyClass realClass) {
         synchronized (original) {
-            this.realClass = original.realClass;
+            this.realClass = realClass;
             this.variableAccessors = copyVariableAccessors(original.variableAccessors);
             this.variableNames = original.variableNames.clone();
             this.hasObjectID = original.hasObjectID;
@@ -544,8 +545,8 @@ public class VariableTableManager {
         }
     }
 
-    public VariableTableManager duplicate() {
-        return new VariableTableManager(this);
+    public VariableTableManager duplicateForData(RubyClass newRealClass) {
+        return new VariableTableManager(this, newRealClass);
     }
 
     /**


### PR DESCRIPTION
In order to allow Data types to specialize their fields completely, we introduced a copy constructor for VariableTableManager that duplicates the Data type's VTM into the new subclass. But because that duplicate still used the same realClass, variable accessors would frequently return to the original Data type's VTM rather than use the duplicate.

This patch fixes the duplication process to also reset the realClass to the new Data type subclass, keeping all future usages and updates at the correct level. Without this, new instance variables discovered on subtypes would add an accessor on the subtype, but then proceed to allocate the variable table based on the size of the table in the old VTM from the Data supertype.