### PR TITLE
Initial hack to avoid exceptions in sleep wakes

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2560,7 +2560,11 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
             @Override
             public void wakeup(RubyThread thread, Condition condition) {
-                thread.getNativeThread().interrupt();
+                try {
+                    condition.signal();
+                } catch (IllegalMonitorStateException imse) {
+                    thread.getNativeThread().interrupt();
+                }
             }
         });
     }


### PR DESCRIPTION
As described in jruby/jruby#9140, sleep logic in JRuby based on a lock currently wakes that sleep by triggering an
InterruptedException. This adds significant overhead to every such wake-up operation, and is generally unnecessary if the thread doing the waking owns the lock and could simply signal it.

This attempts to reduce the chances that an InterruptedException will be triggered by first trying to signal the condition associated with the lock. If the lock is not owned, this will trigger an IllegalMonitorStateException and we proceed to the previous interrupt logic.

This does mean that non-owned lock wake-ups will have double the performance hit they did before, but such cases are generally only to shock a thread out of a lock sleep. This fix is also not ready for prime-time and will be pushed as a draft until we properly handle all lock-sleep uses without triggering any exceptions.