### PR TITLE
Never trust external content for FString

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -972,7 +972,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     public FString dupAsFString(Ruby runtime) {
         shareLevel = SHARE_LEVEL_BYTELIST;
-        FString dup = new FString(runtime, value, getCodeRange());
+        FString dup = new FString(runtime, value.dup(), getCodeRange());
         dup.shareLevel = SHARE_LEVEL_BYTELIST;
         dup.flags |= FSTRING | FROZEN_F | (flags & CR_MASK);
 


### PR DESCRIPTION
When creating an FString for the first time, we should never trust that the incoming byte[] or ByteList are now ours to own. The caller might still have a reference to them that they continue to modify, resulting in a zombie FString that can't be found or that has incorrect contents.

This came up while trying to implement the "fake string" optimization for uncached headers in puma/puma#3838. Holding a reference to a RubyString and its ByteList that could be updated in-place and then used to caches new headers led to those cached FStrings being modified directly.