### PR TITLE
*nil no longer calls nil.to_a, similar to how **nil does not call nil…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,9 +55,9 @@ DO NOT MODIFY - GENERATED CODE
     <test.results.dir>${build.dir}/test-results</test.results.dir>
     <tzdata.scope>provided</tzdata.scope>
     <tzdata.version>2019c</tzdata.version>
-    <version.ruby>3.4.5</version.ruby>
-    <version.ruby.major>3.4</version.ruby.major>
-    <version.ruby.minor>5</version.ruby.minor>
+    <version.ruby>3.5.0</version.ruby>
+    <version.ruby.major>3.5</version.ruby.major>
+    <version.ruby.minor>0</version.ruby.minor>
   </properties>
   <dependencies>
     <dependency>

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2036,6 +2036,11 @@ public class IRRuntimeHelpers {
      */
     @JIT @Interp
     public static RubyArray splatArray(ThreadContext context, IRubyObject ary, boolean dupArray) {
+        // FIXME: In MRI this is adds ARG_SPLAT vs ARG_SPLAT_MUT and will return a cache frozen empty array if not mut
+        // To add this we need another boolean passed from splatarray instr which then needs to add this new field and
+        // detect literal *nil.
+        if (ary.isNil()) return newEmptyArray(context); // Ruby 4+: *nil does not to_ary
+
         IRubyObject tmp = TypeConverter.convertToTypeWithCheck(context, ary, arrayClass(context), sites(context).to_a_checked);
 
         if (tmp.isNil()) return newArray(context, ary);

--- a/default.build.properties
+++ b/default.build.properties
@@ -28,7 +28,7 @@ rake.args=
 install4j.executable=/Applications/install4j9/bin/install4jc
 
 # Ruby versions
-version.ruby=3.4.5
-version.ruby.major=3.4
-version.ruby.minor=5
+version.ruby=3.5.0
+version.ruby.major=3.5
+version.ruby.minor=0
 


### PR DESCRIPTION
….to_hash

*nil no longer calls nil.to_a, similar to how **nil does not call nil.to_hash. [Feature #21047]

This could be optimized more but this matches semantics.  The missing optimization is the parser(s) need to see literal `nil` and then set a new flag on build_splat marking that fact.  Then the helper can use a cached empty frozen array.  The bulk of the improvement is not dispatching so this will be a smaller percentage of improvement on a pretty uncommon case.