### PR TITLE
Mask native elements for MRI backtrace

### DIFF
--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -174,7 +174,7 @@ public class TraceType {
         else if (style.equalsIgnoreCase("ruby_framed")) return new TraceType(Gather.NORMAL, Format.JRUBY);
         else if (style.equalsIgnoreCase("normal")) return new TraceType(Gather.NORMAL, Format.JRUBY);
         else if (style.equalsIgnoreCase("full")) return new TraceType(Gather.FULL, Format.JRUBY);
-        else if (style.equalsIgnoreCase("mri")) return new TraceType(Gather.NORMAL, Format.MRI);
+        else if (style.equalsIgnoreCase("mri")) return new TraceType(Gather.CALLER, Format.MRI);
         else return new TraceType(Gather.NORMAL, Format.JRUBY);
     }
 
@@ -228,7 +228,7 @@ public class TraceType {
         },
 
         /**
-         * Normal Ruby-style backtrace, showing only Ruby and core class methods.
+         * Normal JRuby-style backtrace, showing internal and external Ruby lines and bound core class methods.
          */
         NORMAL {
             public BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> stackStream) {


### PR DESCRIPTION
This PR builds off of #9154 by also masking internal frames for MRI-formatted backtrace elements. It appears at some point we started showing Java lines in the MRI-formatted trace:

```
$ cx jruby-10.0.2.0 ruby -Xbacktrace.style=mri -e "def foo = 1 / 0; foo"
org/jruby/RubyFixnum.java:694:in '/': divided by 0 (ZeroDivisionError)
	from -e:1:in 'foo'
	from -e:1:in '<main>'
```

This differs from user expectations and the contents of `caller` traces, which both filter out internal methods (native or Ruby) by replacing them with the most recent external Ruby frame (CRuby also implements `Integer#/` in native code):

```
$ cx ruby-4.0 ruby -e 'def foo = 1/0; foo'
-e:1:in 'Integer#/': divided by 0 (ZeroDivisionError)
	from -e:1:in 'Object#foo'
	from -e:1:in '<main>'
```

The patch here simply uses the `caller` backtrace-gathering logic for the MRI-mode backtrace data.

This is opened as a draft because I'm unsure how long this behavior has been broken, and I'm not sure what impact fixing it will have yet. Being based on #9154, that PR should be merged first, but this one needs more evaluation.