### PR TITLE
Use same key match for containsKey

### DIFF
--- a/core/src/main/java/org/jruby/util/collections/HashMapInt.java
+++ b/core/src/main/java/org/jruby/util/collections/HashMapInt.java
@@ -95,12 +95,12 @@ public class HashMapInt<V> {
         return contains(value);
     }
 
-    public boolean containsKey(Object key) {
+    public boolean containsKey(V key) {
         Entry<V>[] tab = table;
         int hash = getHash(key);
         int index = (hash & 0x7FFFFFFF) % tab.length;
         for (Entry<V> e = tab[index]; e != null; e = e.next) {
-            if (e.hash == hash && e.key.equals(key)) {
+            if (e.hash == hash && keyMatches(key, e)) {
                 return true;
             }
         }
@@ -307,10 +307,7 @@ public class HashMapInt<V> {
 
         @Override
 		public boolean contains(Object o) {
-			if(o instanceof Number) {
-				return containsKey(((Number)o).intValue());
-			}
-			return false;
+			return containsKey((V) o);
 		}
 
         @Override

--- a/core/src/test/java/org/jruby/util/collections/HashMapIntTest.java
+++ b/core/src/test/java/org/jruby/util/collections/HashMapIntTest.java
@@ -1,0 +1,54 @@
+package org.jruby.util.collections;
+
+import org.junit.Test;
+
+import static java.lang.Runtime.getRuntime;
+import static java.util.concurrent.CompletableFuture.anyOf;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Test for {@link HashMapInt}
+ */
+public class HashMapIntTest {
+
+    @Test
+    public void testContainsKey() throws Throwable {
+        HashMapInt<String> map = new HashMapInt<>();
+        map.put("present", 1);
+
+        assertTrue("Should contain 'present'", map.containsKey("present"));
+        assertFalse("Should not contain 'absent'", map.containsKey("absent"));
+
+        // with identity mode
+        map = new HashMapInt<>(1, true);
+
+        String key1 = new String();
+        map.put(key1, 1);
+
+        // Generate a duplicate key concurrently
+        CompletableFuture[] list = new CompletableFuture[getRuntime().availableProcessors() * 2];
+        Arrays.setAll(list, i -> CompletableFuture.supplyAsync(() -> findDuplicate(key1)).orTimeout(5, SECONDS));
+        String key2;
+        try {
+            key2 = (String) anyOf(list).get();
+        } catch (ExecutionException e) {
+            // could not find a duplicate key within timeout, skip test
+            return;
+        }
+
+        assertTrue("Should contain key1", map.containsKey(key1));
+        assertFalse("Should not contain duplicate but idempotent key2", map.containsKey(key2));
+    }
+
+    private static Object findDuplicate(Object key1) {
+        while (true) {
+            String key = new String();
+            if (System.identityHashCode(key1) == System.identityHashCode(key)) return key;
+        }
+    }
+}


### PR DESCRIPTION
The containsKey method was never modified to support identity mode and will inccorrectly return true for distinct object keys that are equals and have the same identity hashcode. This led to bugs in Marshal.dump when many of the same value occurred in an object graph. containsKey would report that such an object was already in the link map, but a subsequent get of that key would produce -1 to be written to the dump. Later loading of that dump would error due to the invalid link index.

The fix here modifies containsKey to use the same matching logic as get, with awareness of identity comparison.

A test is included that will usually exercise the given logic, if it can produce a duplicate key object within a 5s timeout. If it cannot do that, it will no-op and skip the test. On my MacBook Air M4 with 10ish cores, it finds such a duplicate about 90% of the time.

Fixes #9152