### PR TITLE
Avoid triggering PR actions on jruby/jruby branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: JRuby CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    repositories: [!jruby/jruby]
 
 env:
   JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx1G -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'


### PR DESCRIPTION
When we do a PR from a branch on the jruby/jruby repo, it will trigger our CI action to run twice: once for the push and once for the PR. We don't want this wasted effort, so this PR will attempt to fix the triggers to only run for pushes to jruby/jruby branches and not for PRs made from those branches.