### PR TITLE
Experiment to use hash4j algorithms for String#hash

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -80,6 +80,8 @@ project 'JRuby Base' do
 
   jar 'org.crac:crac:1.5.0'
 
+  jar 'com.dynatrace.hash4j:hash4j:0.29.0'
+
   plugin_management do
     plugin('org.eclipse.m2e:lifecycle-mapping:1.0.0',
            lifecycleMappingMetadata: {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -237,6 +237,11 @@ DO NOT MODIFY - GENERATED CODE
       <artifactId>crac</artifactId>
       <version>1.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.dynatrace.hash4j</groupId>
+      <artifactId>hash4j</artifactId>
+      <version>0.29.0</version>
+    </dependency>
   </dependencies>
   <build>
     <defaultGoal>package</defaultGoal>

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -39,6 +39,8 @@
 
 package org.jruby;
 
+import com.dynatrace.hash4j.hashing.Hasher64;
+import com.dynatrace.hash4j.hashing.Hashing;
 import jnr.posix.POSIX;
 
 import org.jcodings.Config;
@@ -171,6 +173,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     // Follow-up work should reevaluate this value (Currently only explicit capacity to initialize is using
     // this value).
     private static final int STRING_MINIMUM_SIZE = 4;
+    private static final Hasher64 RAPIDHASHER = Hashing.rapidhash3(Ruby.getHashSeed0());
 
     public static RubyString[] NULL_ARRAY = {};
 
@@ -1583,8 +1586,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     Ruby.getHashSeed1(), value.getUnsafeBytes(), value.getBegin(),
                     value.getRealSize());
         } else {
-            hash = PerlHash.hash(Ruby.getHashSeed0(),
-            value.getUnsafeBytes(), value.getBegin(), value.getRealSize());
+//            hash = PerlHash.hash(Ruby.getHashSeed0(),
+//            value.getUnsafeBytes(), value.getBegin(), value.getRealSize());
+            hash = RAPIDHASHER.hashBytesToLong(value.getUnsafeBytes(), value.getBegin(), value.getRealSize());
         }
         hash ^= (enc.isAsciiCompatible() && scanForCodeRange() == CR_7BIT ? 0 : enc.getIndex());
         return (int) hash;

--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -38,6 +38,9 @@ project 'JRuby Core' do
                                      'Enable-Native-Access' => 'ALL-UNNAMED',
                                    }
                                  }],
+                  filters: [
+                    { artifact: 'com.dynatrace.hash4j:hash4j', excludes: '**/25/**' },
+                  ],
                   createSourcesJar: false,
                   compress: false)
   end

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -63,6 +63,12 @@ DO NOT MODIFY - GENERATED CODE
                   </manifestEntries>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>com.dynatrace.hash4j:hash4j</artifact>
+                  <excludes>**/25/**</excludes>
+                </filter>
+              </filters>
               <createSourcesJar>false</createSourcesJar>
               <compress>false</compress>
             </configuration>


### PR DESCRIPTION
This experiment hooks up the hash4j library to String#hash. Any of the algorithms it provides can be used here by changing a line of code. This is proof-of-concept code used to compare the performance of the different algorithms.

Testing of the algorithms can use, among other things, the benchmark at https://bugs.ruby-lang.org/issues/21833 which compares different sizes of strings.