### PR TITLE
Fixes #8952.  Nested 'it' behavior broken

### DIFF
--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -293,7 +293,7 @@ public class StaticScope implements Serializable, Cloneable {
         implicitVariables.set(slot);
     }
 
-    private int addVariableName(String name) {
+    public int addVariableName(String name) {
         // Clear constructor since we are adding a name
         constructor = null;
 


### PR DESCRIPTION
'it' should not be seen by an inner 'it' UNLESS the outer 'it' is not a special 'it' but merely an ordinary variable.