### PR TITLE
Force build-time gem installs to use current JRuby config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ failures
 .debug.properties
 .redcar
 /.rbx/
-build
 build.properties
 build_graph.png
 core/src/main/java/org/jruby/runtime/Constants.java

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -213,6 +213,10 @@ project 'JRuby Lib Setup' do
 
     log "using jruby #{JRUBY_VERSION}"
 
+    # force platform to match build JRuby
+    Gem.set_target_rbconfig(File.join(File.dirname(__FILE__), "ruby/stdlib/jruby/build/rbconfig.rb"))
+    Gem.instance_variable_set :@ruby_api_version, Gem.target_rbconfig['ruby_version']
+
     target = ctx.project.build.directory.to_pathname
     gem_home = File.join(target, 'rubygems')
     gems = File.join(gem_home, 'gems')
@@ -251,6 +255,7 @@ project 'JRuby Lib Setup' do
         say 'Skipping native extensions.'
 
         FileUtils.mkdir_p File.dirname(@spec.gem_build_complete_path)
+        p @spec.gem_build_complete_path
         FileUtils.touch @spec.gem_build_complete_path
       end
     end

--- a/lib/ruby/stdlib/jruby/build/rbconfig.rb
+++ b/lib/ruby/stdlib/jruby/build/rbconfig.rb
@@ -1,0 +1,13 @@
+# This file is used by JRuby's build to override the RubyGems platform
+
+module RbConfig
+    build_props = {}
+    File.open(File.join(__FILE__, "../../../../../../default.build.properties")) do |file|
+      build_props = java.util.Properties.new
+      build_props.load(file.to_input_stream)
+    end
+
+    CONFIG = {}
+    CONFIG['ruby_version'] = build_props["version.ruby.major"] + '.0'
+    CONFIG['arch'] = 'universal-java'
+end


### PR DESCRIPTION
The RubyGems we run at build time runs with JRuby 9.4, which causes it to use properties from that version for things like gem paths and extension directories. This is related to the extension disabling change in jruby/jruby#8415 and causes the build-time extension faking to use the wrong path. For example:

  .../gems/shared/extensions/universal-java-25/3.1.0

when it should be

  .../gems/shared/extensions/universal-java/3.4.0

The change here uses RubyGems' cross-compiling capability by forcing a specific rbconfig.rb to be use, and additionally fakes out the Ruby API version by setting @ruby_api_version on the Gem module.

This was discovered while attempting to switch fully to the syslog gem in jruby/jruby#9109, since as a bundled gem it will not be activated unless we successfully fake-out the extension build.

See also this bug related to the resolv gem installing extensions:

* https://github.com/jruby/jruby/issues/8649