### PR TITLE
Fix BigDecimal#+, #-, #add, #sub failing when coercing doesn't return a BigDecimal

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1268,7 +1268,7 @@ public class RubyBigDecimal extends RubyNumeric {
             // return callCoerced(context, op, b, true); -- this is MRI behavior.
             // We'll use ours for now, thus providing an ability to add Floats.
             IRubyObject ret = callCoerced(context, sites(context).op_plus, b, true);
-            if (ret != null && ret instanceof RubyBigDecimal bd) {
+            if (ret instanceof RubyBigDecimal bd) {
                 bd.setResult(context, prec);
             }
             return ret;
@@ -1335,7 +1335,7 @@ public class RubyBigDecimal extends RubyNumeric {
     private IRubyObject subInternal(ThreadContext context, RubyBigDecimal val, IRubyObject b, int prec) {
         if (val == null) {
             IRubyObject ret = callCoerced(context, sites(context).op_minus, b, true);
-            if (ret != null && ret instanceof RubyBigDecimal bd) {
+            if (ret instanceof RubyBigDecimal bd) {
                 bd.setResult(context, prec);
             }
             return ret;


### PR DESCRIPTION
Fixes #9194

For some reason, only in cases of addition and subtraction precision gets assigned to result. Probably, this is why only in these two methods there was a cast. Now, there is a test for type of result in both cases. Also for `null`, as subtraction didn't check for that. Addition and subtraction with tricky types works now:
```
irb(main):002> BigDecimal(10) + Complex(1,2)
=> (0.11e2+2i)
irb(main):003> BigDecimal(10) - Complex(1,2)
=> (0.9e1-2i)
```
---
`mult()` has this:
```java
        if (val == null) { // TODO: what about n arg?
            return callCoerced(context, sites(context).op_times, b, true);
        }
```
So it seems that precision may be lost or ignored in most operations. This PR does not address any of that.