### PR TITLE
Fix exception message when calling import_methods without a Module

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -6841,6 +6841,7 @@ public class RubyModule extends RubyObject {
 
             for (IRubyObject _module : modules) {
                 RubyModule module = castAsModule(context, _module);
+                if (module.getClass() != RubyModule.class) throw typeError(context, "wrong argument type Class (expected Module)");
 
                 if (module.getSuperClass() != null) {
                     warn(context, module.getName(context) + " has ancestors, but Refinement#import_methods doesn't import their methods");

--- a/spec/tags/ruby/core/refinement/import_methods_tags.txt
+++ b/spec/tags/ruby/core/refinement/import_methods_tags.txt
@@ -1,4 +1,2 @@
-fails:Refinement#import_methods doesn't import any methods if one of the arguments is not a module
 fails:Refinement#import_methods imports methods from multiple modules so that methods see other's module's methods
 fails:Refinement#import_methods imports methods from module so that methods can see each other
-fails:Refinement#import_methods when methods are defined in Ruby code throws an exception when argument is not a module


### PR DESCRIPTION
issue #8876 

Found some low hanging fruit while looking at this issue.