### PR TITLE
Add ruby_bug for spec of Data with no members being frozen

### DIFF
--- a/spec/ruby/core/data/initialize_spec.rb
+++ b/spec/ruby/core/data/initialize_spec.rb
@@ -7,7 +7,7 @@ describe "Data#initialize" do
       it "is frozen" do
         data = Data.define
 
-        data.new.frozen?.should == true
+        data.new.should.frozen?
       end
     end
   end


### PR DESCRIPTION
This makes the spec pass on Ruby 4.0.0 and earlies as well. This saves some issues with the next spec sync.
