### PR TITLE
Make `refine` method of `Module` private

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -989,7 +989,7 @@ public class RubyModule extends RubyObject {
         return metaClass.getRealClass().getName(context) + ":0x" + Integer.toHexString(System.identityHashCode(this));
     }
 
-    @JRubyMethod(name = "refine", reads = SCOPE)
+    @JRubyMethod(name = "refine", visibility = PRIVATE, reads = SCOPE)
     public IRubyObject refine(ThreadContext context, IRubyObject klass, Block block) {
         if (!block.isGiven()) throw argumentError(context, "no block given");
         if (block.isEscaped()) throw argumentError(context, "can't pass a Proc as a block to Module#refine");


### PR DESCRIPTION
In MRI refine method [is defined as private](https://github.com/ruby/ruby/blob/master/eval.c#L2237). But in JRuby it is public leading to inconsistency between the implementations.

```
irb(main):001> [RUBY_ENGINE, RUBY_VERSION]
=> ["jruby", "3.4.2"]
irb(main):002> Module.instance_methods.include?(:refine)
=> true
```

```
irb(main):001> [RUBY_ENGINE, RUBY_VERSION]
=> ["ruby", "3.4.1"]
irb(main):002> Module.instance_methods.include?(:refine)
=> false
```