### PR TITLE
Ignore empty kwrest in Data subtypes' constructors

### DIFF
--- a/core/src/main/java/org/jruby/RubyData.java
+++ b/core/src/main/java/org/jruby/RubyData.java
@@ -40,6 +40,7 @@ import static org.jruby.ir.runtime.IRRuntimeHelpers.setCallInfo;
 import static org.jruby.runtime.Arity.checkArgumentCount;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD;
+import static org.jruby.runtime.ThreadContext.CALL_KEYWORD_EMPTY;
 import static org.jruby.runtime.ThreadContext.clearCallInfo;
 import static org.jruby.runtime.ThreadContext.hasKeywords;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
@@ -309,7 +310,7 @@ public class RubyData {
 
             RubyHash init;
             int callInfo = resetCallInfo(context);
-            if (hasKeywords(callInfo)) {
+            if (hasKeywords(callInfo) && (callInfo & CALL_KEYWORD_EMPTY) == 0) {
                 if (!(hashOrElt instanceof RubyHash)) {
                     throw argumentError(context, 1, 0, 0);
                 }


### PR DESCRIPTION
When passing empty kwrest into a method, `hasKeyword` will be true but there will not actually be any keyword hash in the argument list. We need to also check for "empty" keywords before proceeding to use any incoming kwargs hash.

Fixes jruby/jruby#9214