### PR TITLE
Add an error for running jruby.sh from a broken JRUBY_HOME

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -671,6 +671,11 @@ for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
     fi
     jruby_jar="$j"
 done
+
+if [ -z "${jruby_jar-}" ]; then
+    echo "JRUBY_HOME at ${JRUBY_HOME} contains no lib/jruby.jar, exiting."
+    exit 1
+fi
 readonly jruby_jar
 
 if $cygwin; then


### PR DESCRIPTION
In #9216 @eregon reported that JRuby was failing to run specs with an error about unbound variable `JRUBY_CP`. This variable can only be left unset if the `bin/jruby.sh` being executed is not accompanied by a sibling `lib/jruby.jar`, as might happen when running from a fresh repository clone.

The issue in #9216 was that for some reason, subprocesses launching `ruby` were choosing the bin scripts from a fresh JRuby clone rather than the one in `PATH` associated with a fully-functional JRuby.

This configuration is unsupported; `bin/jruby.sh` uses relative pathing to find its associated `lib/jruby.jar`, and if it is not present there's no way to proceed with execution. But the error message provided is cryptic and does not help a user debug the issue.

This path adds a check for the missing jar and terminates early with the following error message (negotiable):

```
[] jruby $ which ruby
/Users/headius/work/jruby/bin/ruby
[] jruby $ ls /Users/headius/work/jruby/lib/*.jar
zsh: no matches found: /Users/headius/work/jruby/lib/*.jar
[] jruby $ ruby -v
JRUBY_HOME at /Users/headius/work/jruby contains no lib/jruby.jar, exiting.
[] jruby $
```