### PR TITLE
Fix version output to reflect current runtime

### DIFF
--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -167,7 +167,7 @@ public class RubyGlobal {
         Object.defineConstant(context, "RUBY_RELEASE_DATE", release);
         Object.defineConstant(context, "RUBY_PLATFORM", platform);
 
-        IRubyObject description = RubyString.newFString(runtime, OutputStrings.getVersionString());
+        IRubyObject description = RubyString.newFString(runtime, OutputStrings.getVersionString(instanceConfig));
         Object.defineConstant(context, "RUBY_DESCRIPTION", description);
 
         IRubyObject copyright = RubyString.newFString(runtime, OutputStrings.getCopyrightString());

--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -1013,7 +1013,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * @return version information.
      */
     public String getSupportedRubyVersion() {
-        return OutputStrings.getVersionString().trim();
+        return OutputStrings.getVersionString(getProvider().getRuntime().getInstanceConfig()).trim();
     }
 
     /**

--- a/core/src/main/java/org/jruby/main/Main.java
+++ b/core/src/main/java/org/jruby/main/Main.java
@@ -511,7 +511,7 @@ public class Main {
 
     private void doShowVersion() {
         if (config.isShowVersion()) {
-            config.getOutput().println(OutputStrings.getVersionString());
+            config.getOutput().println(OutputStrings.getVersionString(config));
         }
     }
 

--- a/core/src/main/java/org/jruby/management/Config.java
+++ b/core/src/main/java/org/jruby/management/Config.java
@@ -16,7 +16,7 @@ public class Config implements ConfigMBean {
     }
     
     public String getVersionString() {
-        return OutputStrings.getVersionString();
+        return OutputStrings.getVersionString(ruby.get().getInstanceConfig());
     }
 
     public String getCopyrightString() {

--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -1,6 +1,7 @@
 package org.jruby.util.cli;
 
 import com.headius.options.Option;
+import org.jruby.RubyInstanceConfig;
 import org.jruby.ext.rbconfig.RbConfigLibrary;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Constants;
@@ -139,6 +140,36 @@ public class OutputStrings {
         return sb.append(Option.formatOptions(Options.PROPERTIES)).toString();
     }
 
+    /**
+     * Produce a version string based on the given configuration.
+     *
+     * @param config the configuraton
+     * @return a version string representing the given configuraton
+     */
+    public static String getVersionString(RubyInstanceConfig config) {
+        return String.format(
+                "jruby %s (%s) %s %s %s %s on %s%s%s [%s-%s]",
+                Constants.VERSION,
+                Constants.RUBY_VERSION,
+                Constants.COMPILE_DATE,
+                Constants.REVISION.substring(0, 10),
+                SafePropertyAccessor.getProperty("java.vm.name", "Unknown JVM"),
+                SafePropertyAccessor.getProperty("java.vm.version", "Unknown JVM version"),
+                SafePropertyAccessor.getProperty("java.runtime.version", SafePropertyAccessor.getProperty("java.version", "Unknown version")),
+                Options.COMPILE_INVOKEDYNAMIC.load() ? " +indy" : " -indy",
+                config.getCompileMode().shouldJIT() ? " +jit" : " -jit",
+                RbConfigLibrary.getArchitecture(),
+                RbConfigLibrary.getOSName()
+        );
+    }
+
+    /**
+     * Produce a version string containing only static values for JRuby and system properties.
+     *
+     * Use {@link #getVersionString(RubyInstanceConfig)} to reflect current runtime's parameters.
+     *
+     * @return a version string containing static information about the available JRuby version
+     */
     public static String getVersionString() {
         return String.format(
                 "jruby %s (%s) %s %s %s %s on %s%s%s [%s-%s]",


### PR DESCRIPTION
The JIT mode may change from the global property value by passing the -X-C flag to JRuby or by modifying the compile mode in RubyInstanceConfig. The version output did not reflect this, and would still show `+jit` when one of these two mechanisms was used to disable JIT.

This change adds a version of this output that can use a config object to determine whether JIT is actually enabled.