### PR TITLE
Properly handle keywords in {Kernel|Thread|Fiber}#raise

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1057,14 +1057,15 @@ public class RubyKernel {
         return null; // not reached
     }
 
-    @JRubyMethod(name = {"raise", "fail"}, optional = 4, checkArity = false, module = true, visibility = PRIVATE, omit = true)
+    @JRubyMethod(name = {"raise", "fail"}, optional = 4, checkArity = false, module = true, visibility = PRIVATE, omit = true, keywords = true)
     public static IRubyObject raise(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = args.length;
         boolean forceCause = false;
 
         // semi extract_raise_opts :
+        int callInfo = ThreadContext.resetCallInfo(context);
         IRubyObject cause = null;
-        if (argc > 0) {
+        if (ThreadContext.hasNonemptyKeywords(callInfo) && argc > 0) {
             IRubyObject last = args[argc - 1];
             if (last instanceof RubyHash opt) {
                 RubySymbol key;

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -227,7 +227,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         throw runtime.newFiberError("fiber called across threads");
     }
 
-    @JRubyMethod(optional = 4)
+    @JRubyMethod(optional = 4, checkArity = false, keywords = true)
     public IRubyObject raise(ThreadContext context, IRubyObject[] args) {
         return raise(context, RubyThread.prepareRaiseException(context, args));
     }


### PR DESCRIPTION
Any code calling these methods from Java and wishing to pass the cause: keyword must set callInfo.