### PR TITLE
Fix Array#slice raises a RangeError when the start index is out of range of Fixnum

### DIFF
--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -297,7 +297,7 @@ public class RubyNumeric extends RubyObject {
     @Deprecated(since = "10.0.0.0")
     public static long float2long(RubyFloat flt) {
         final double aFloat = flt.value;
-        if (aFloat <= (double) Long.MAX_VALUE && aFloat >= (double) Long.MIN_VALUE) {
+        if (aFloat < (double) Long.MAX_VALUE && aFloat >= (double) Long.MIN_VALUE) {
             return (long) aFloat;
         }
         // TODO: number formatting here, MRI uses "%-.10g", 1.4 API is a must?

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -532,7 +532,7 @@ public class Convert {
     public static long toLong(ThreadContext context, RubyFloat value) {
         final double aFloat = value.getValue();
 
-        if (aFloat <= (double) Long.MAX_VALUE && aFloat >= (double) Long.MIN_VALUE) {
+        if (aFloat < (double) Long.MAX_VALUE && aFloat >= (double) Long.MIN_VALUE) {
             return (long) aFloat;
         }
 
@@ -566,7 +566,7 @@ public class Convert {
     public static long toInt(ThreadContext context, RubyFloat value) {
         final double aFloat = value.getValue();
 
-        if (aFloat <= (double) Long.MAX_VALUE && aFloat >= (double) Long.MIN_VALUE) {
+        if (aFloat < (double) Long.MAX_VALUE && aFloat >= (double) Long.MIN_VALUE) {
             return (long) aFloat;
         }
 

--- a/spec/tags/ruby/core/array/slice_tags.txt
+++ b/spec/tags/ruby/core/array/slice_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#slice raises a RangeError when the start index is out of range of Fixnum


### PR DESCRIPTION
Compare to TruffleRuby's FloatToIntegerNode.java: https://github.com/truffleruby/truffleruby/blob/52901a41b53bc3c3546a111db4d5826c760a195d/src/main/java/org/truffleruby/core/cast/FloatToIntegerNode.java#L39