### PR TITLE
Additional fixes for import_methods with JIT

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -33,6 +33,7 @@ import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.IRMethodArgs;
+import org.jruby.internal.runtime.methods.MixedModeIRMethod;
 import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
@@ -169,7 +170,12 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
     @Override
     public Object clone() {
         try {
-            return super.clone();
+            AbstractIRMethod clone = (AbstractIRMethod) super.clone();
+            clone.callCount = 0;
+            if (clone instanceof MixedModeIRMethod mixedMode) {
+                mixedMode.reset();
+            }
+            return clone;
         } catch (CloneNotSupportedException cnse) {
             throw new RuntimeException("not cloneable: " + this);
         }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -65,6 +65,11 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
         return actualMethod;
     }
 
+    public void reset() {
+        this.callCount = 0;
+        this.actualMethod = null;
+    }
+
     protected void post(InterpreterContext ic, ThreadContext context) {
         // update call stacks (pop: ..)
         context.popFrame();

--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -35,6 +35,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.jruby.ir.passes.DeadCodeElimination;
 import org.jruby.ir.passes.OptimizeDelegationPass;
 import org.jruby.ir.passes.OptimizeDynScopesPass;
@@ -94,6 +96,7 @@ public class IRManager {
     private final RubyInstanceConfig config;
     public final Ruby runtime;
     private IRBuilderFactory builderFactory;
+    private AtomicLong callSiteCounter = new AtomicLong(1);
 
     public IRManager(Ruby runtime, RubyInstanceConfig config) {
         this.runtime = runtime;
@@ -444,5 +447,9 @@ public class IRManager {
 
     public BuiltinClass getSymbolClass() {
         return symbolClass;
+    }
+
+    public long nextCallSiteID() {
+        return callSiteCounter.incrementAndGet();
     }
 }

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -2762,7 +2762,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
         int[] flags = new int[] { 0 };
         Operand value = buildYieldArgs(argNode, flags);
 
-        addInstr(new YieldInstr(result, getYieldClosureVariable(), value, flags[0], unwrap));
+        addInstr(new YieldInstr(scope, result, getYieldClosureVariable(), value, flags[0], unwrap));
 
         return result;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/ArrayDerefInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ArrayDerefInstr.java
@@ -14,7 +14,6 @@ import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -36,16 +35,6 @@ public class ArrayDerefInstr extends OneOperandArgNoBlockCallInstr {
         return new ArrayDerefInstr(scope, result, obj, arg0, flags);
     }
 
-    // clone constructor
-    public ArrayDerefInstr(IRScope scope, Variable result, Operand obj, FrozenString arg0, int flags,
-                           CallSite callSite, long callSiteId) {
-        super(scope, Operation.ARRAY_DEREF, CallType.FUNCTIONAL, result,
-                scope.getManager().getRuntime().newSymbol(AREF), obj, new Operand[] {arg0}, flags, false,
-                callSite, callSiteId);
-
-        key = arg0;
-    }
-
     // normal constructor
     public ArrayDerefInstr(IRScope scope, Variable result, Operand obj, FrozenString arg0, int flags) {
         super(scope, Operation.ARRAY_DEREF, CallType.FUNCTIONAL, result,
@@ -57,7 +46,7 @@ public class ArrayDerefInstr extends OneOperandArgNoBlockCallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new ArrayDerefInstr(ii.getScope(), (Variable) getResult().cloneForInlining(ii),
-                getReceiver().cloneForInlining(ii), key, getFlags(), getCallSite(), getCallSiteId());
+                getReceiver().cloneForInlining(ii), key, getFlags());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/AsStringInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/AsStringInstr.java
@@ -1,6 +1,5 @@
 package org.jruby.ir.instructions;
 
-import org.jruby.compiler.NotCompilableException;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
@@ -13,7 +12,6 @@ import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -38,23 +36,6 @@ public class AsStringInstr extends ZeroOperandArgNoBlockCallInstr {
         assert isPotentiallyRefined : "AsStringInstr should only be needed in refined scopes";
     }
 
-    private AsStringInstr(IRScope scope, Variable result, Operand source, boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
-        super(
-                scope,
-                Operation.AS_STRING,
-                CallType.FUNCTIONAL,
-                result,
-                scope.getManager().getRuntime().newSymbol(TO_S),
-                nonNull(source),
-                Operand.EMPTY_ARRAY,
-                0,
-                isPotentiallyRefined,
-                callSite,
-                callSiteId);
-
-        assert isPotentiallyRefined : "AsStringInstr should only be needed in refined scopes";
-    }
-
     private static Operand nonNull(Operand source) {
         return source == null ? MutableString.EMPTY_STRING : source;
     }
@@ -62,7 +43,7 @@ public class AsStringInstr extends ZeroOperandArgNoBlockCallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new AsStringInstr(ii.getScope(), (Variable) getResult().cloneForInlining(ii),
-                getReceiver().cloneForInlining(ii), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                getReceiver().cloneForInlining(ii), isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
@@ -36,9 +36,8 @@ public class AttrAssignInstr extends NoResultCallInstr {
 
     // clone constructor
     protected AttrAssignInstr(IRScope scope, CallType callType, RubySymbol name, Operand receiver,
-                              Operand[] args, int flags, boolean potentiallyRefined, CallSite callSite,
-                              long callSiteId) {
-        super(scope, Operation.ATTR_ASSIGN, callType, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined, callSite, callSiteId);
+                              Operand[] args, int flags, boolean potentiallyRefined) {
+        super(scope, Operation.ATTR_ASSIGN, callType, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined);
     }
 
     // normal constructor
@@ -51,7 +50,7 @@ public class AttrAssignInstr extends NoResultCallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new AttrAssignInstr(ii.getScope(), getCallType(), getName(), getReceiver().cloneForInlining(ii),
-                cloneCallArgs(ii), getFlags(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
@@ -11,18 +11,13 @@ import org.jruby.ir.instructions.specialized.OneOperandArgBlockCallInstr;
 import org.jruby.ir.instructions.specialized.OneOperandArgNoBlockCallInstr;
 import org.jruby.ir.instructions.specialized.TwoOperandArgNoBlockCallInstr;
 import org.jruby.ir.instructions.specialized.ZeroOperandArgNoBlockCallInstr;
-import org.jruby.ir.operands.Hash;
 import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
-import org.jruby.util.KeyValuePair;
-
-import java.util.List;
 
 /*
  * args field: [self, receiver, *args]
@@ -64,16 +59,6 @@ public class CallInstr extends CallBase implements ResultInstr {
     public CallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name, Operand receiver, Operand[] args,
                      Operand closure, int flags, boolean potentiallyRefined) {
         this(scope, Operation.CALL, callType, result, name, receiver, args, closure, flags, potentiallyRefined);
-    }
-
-    // clone constructor
-    protected CallInstr(IRScope scope, Operation op, CallType callType, Variable result, RubySymbol name, Operand receiver,
-                                Operand[] args, Operand closure, int flags, boolean potentiallyRefined, CallSite callSite, long callSiteId) {
-        super(scope, op, callType, name, receiver, args, closure, flags, potentiallyRefined, callSite, callSiteId);
-
-        assert result != null;
-
-        this.result = result;
     }
 
     // normal constructor
@@ -141,8 +126,8 @@ public class CallInstr extends CallBase implements ResultInstr {
         return new CallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii),
-                getFlags(), isPotentiallyRefined(),
-                getCallSite(), getCallSiteId());
+                getFlags(), isPotentiallyRefined()
+        );
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
@@ -22,16 +22,6 @@ import java.util.EnumSet;
 public class ClassSuperInstr extends CallInstr {
     private final boolean isLiteralBlock;
 
-    // clone constructor
-    protected ClassSuperInstr(IRScope scope, Variable result, Operand receiver, RubySymbol name, Operand[] args,
-                              Operand closure, int flags, boolean potentiallyRefined, CallSite callSite,
-                              long callSiteId) {
-        super(scope, Operation.CLASS_SUPER, CallType.SUPER, result, name, receiver, args, closure, flags,
-                potentiallyRefined, callSite, callSiteId);
-
-        isLiteralBlock = closure instanceof WrappedIRClosure;
-    }
-
     // normal constructor
     public ClassSuperInstr(IRScope scope, Variable result, Operand definingModule, RubySymbol name, Operand[] args,
                            Operand closure, int flags, boolean isPotentiallyRefined) {
@@ -58,7 +48,7 @@ public class ClassSuperInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new ClassSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()), getDefiningModule().cloneForInlining(ii),
                 name, cloneCallArgs(ii), getClosureArg().cloneForInlining(ii),
-                getFlags(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                getFlags(), isPotentiallyRefined());
     }
 
     public static ClassSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
@@ -13,7 +13,6 @@ import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -25,16 +24,6 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
     // treating the array as a single value.
     private final boolean splattedValue;
     private final boolean pattern;
-
-    // clone constructor
-    protected EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean pattern, boolean isPotentiallyRefined, CallSite callSite,
-                       long callSiteID) {
-        super(scope, Operation.EQQ, CallType.FUNCTIONAL, result, scope.getManager().getRuntime().newSymbol("==="),
-                v1, new Operand[] { v2 }, NullBlock.INSTANCE, 0, isPotentiallyRefined, callSite, callSiteID);
-
-        this.splattedValue = splattedValue;
-        this.pattern = pattern;
-    }
 
     // normal constructor
     public EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean pattern, boolean isPotentiallyRefined) {
@@ -63,7 +52,7 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new EQQInstr(ii.getScope(), ii.getRenamedVariable(result), getReceiver().cloneForInlining(ii),
-                getArg1().cloneForInlining(ii), isSplattedValue(), isPattern(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                getArg1().cloneForInlining(ii), isSplattedValue(), isPattern(), isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
@@ -43,7 +43,6 @@ import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -53,16 +52,6 @@ import java.util.EnumSet;
 
 public class InstanceSuperInstr extends CallInstr {
     private final boolean isLiteralBlock;
-
-    // clone constructor
-    protected InstanceSuperInstr(IRScope scope, Variable result, Operand definingModule, RubySymbol name, Operand[] args,
-                                 Operand closure, int flags, boolean isPotentiallyRefined, CallSite callSite,
-                                 long callSiteId) {
-        super(scope, Operation.INSTANCE_SUPER, CallType.SUPER, result, name, definingModule, args, closure, flags,
-                isPotentiallyRefined, callSite, callSiteId);
-
-        isLiteralBlock = closure instanceof WrappedIRClosure;
-    }
 
     // normal constructor
     public InstanceSuperInstr(IRScope scope, Variable result, Operand definingModule, RubySymbol name, Operand[] args,
@@ -90,7 +79,7 @@ public class InstanceSuperInstr extends CallInstr {
         return new InstanceSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()),
                 getDefiningModule().cloneForInlining(ii), getName(), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                isPotentiallyRefined());
     }
 
     public static InstanceSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/MatchInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/MatchInstr.java
@@ -11,7 +11,6 @@ import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.util.ByteList;
 
@@ -21,12 +20,6 @@ import static org.jruby.ir.IRFlags.REQUIRES_BACKREF;
 
 public class MatchInstr extends CallInstr implements FixedArityInstr {
     private static final ByteList MATCH = new ByteList(new byte[] {'=', '~'});
-
-    // clone constructor
-    protected MatchInstr(IRScope scope, Variable result, Operand receiver, Operand arg, CallSite callSite, long callSiteId) {
-        super(scope, Operation.MATCH, CallType.NORMAL, result, scope.getManager().getRuntime().newSymbol(MATCH),
-                receiver, new Operand[]{arg}, NullBlock.INSTANCE, 0, false, callSite, callSiteId);
-    }
 
     // normal constructor
     public MatchInstr(IRScope scope, Variable result, Operand receiver, Operand arg) {
@@ -48,7 +41,7 @@ public class MatchInstr extends CallInstr implements FixedArityInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new MatchInstr(ii.getScope(), (Variable) result.cloneForInlining(ii), getReceiver().cloneForInlining(ii),
-                getArg1().cloneForInlining(ii), getCallSite(), getCallSiteId());
+                getArg1().cloneForInlining(ii));
     }
 
     // We do not call super here to bypass having to pass this exaclty like a call.

--- a/core/src/main/java/org/jruby/ir/instructions/NoResultCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/NoResultCallInstr.java
@@ -11,7 +11,6 @@ import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 
 public class NoResultCallInstr extends CallBase {
@@ -23,13 +22,6 @@ public class NoResultCallInstr extends CallBase {
         }
 
         return new NoResultCallInstr(scope, Operation.NORESULT_CALL, callType, name, receiver, args, closure, flags, isPotentiallyRefined);
-    }
-
-    // clone constructor
-    protected NoResultCallInstr(IRScope scope, Operation op, CallType callType, RubySymbol name, Operand receiver,
-                                Operand[] args, Operand closure, int flags, boolean potentiallyRefined,
-                                CallSite callSite, long callSiteId) {
-        super(scope, op, callType, name, receiver, args, closure, flags, potentiallyRefined, callSite, callSiteId);
     }
 
     // normal constructor
@@ -52,7 +44,7 @@ public class NoResultCallInstr extends CallBase {
         return new NoResultCallInstr(ii.getScope(), getOperation(), getCallType(), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                isPotentiallyRefined());
     }
 
     public static NoResultCallInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
@@ -16,7 +16,6 @@ import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -32,16 +31,6 @@ public class UnresolvedSuperInstr extends CallInstr {
 
     private static final ByteList DYNAMIC_SUPER_TARGET =
             new ByteList("-dynamic-super_target-".getBytes(), USASCIIEncoding.INSTANCE, false);
-
-    // clone constructor
-    public UnresolvedSuperInstr(IRScope scope, Operation op, Variable result, Operand receiver, Operand[] args,
-                                Operand closure, int flags, boolean isPotentiallyRefined, CallSite callSite,
-                                long callSiteId) {
-        super(scope, op, CallType.SUPER, result, scope.getManager().getRuntime().newSymbol(DYNAMIC_SUPER_TARGET),
-                receiver, args, closure, flags, isPotentiallyRefined, callSite, callSiteId);
-
-        isLiteralBlock = closure instanceof WrappedIRClosure;
-    }
 
     // normal constructor
     public UnresolvedSuperInstr(IRScope scope, Operation op, Variable result, Operand receiver, Operand[] args,
@@ -72,7 +61,7 @@ public class UnresolvedSuperInstr extends CallInstr {
         return new UnresolvedSuperInstr(ii.getScope(), Operation.UNRESOLVED_SUPER, ii.getRenamedVariable(getResult()),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                isPotentiallyRefined());
     }
 
     public static UnresolvedSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/YieldInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/YieldInstr.java
@@ -1,5 +1,6 @@
 package org.jruby.ir.instructions;
 
+import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Interp;
 import org.jruby.ir.Operation;
@@ -22,14 +23,14 @@ public class YieldInstr extends TwoOperandResultBaseInstr implements FixedArityI
     private final int flags;
     private long callSiteId;
 
-    public YieldInstr(Variable result, Operand block, Operand arg, int flags, boolean unwrapArray) {
+    public YieldInstr(IRScope scope, Variable result, Operand block, Operand arg, int flags, boolean unwrapArray) {
         super(Operation.YIELD, result, block, arg == null ? UndefinedValue.UNDEFINED : arg);
 
         assert result != null: "YieldInstr result is null";
 
         this.flags = flags;
         this.unwrapArray = unwrapArray;
-        this.callSiteId = CallBase.callSiteCounter++;
+        this.callSiteId = scope.getManager().nextCallSiteID();
     }
 
     public Operand getBlockArg() {
@@ -49,7 +50,7 @@ public class YieldInstr extends TwoOperandResultBaseInstr implements FixedArityI
         // FIXME: Is it necessary to clone a yield instruction in a method
         // that is being inlined, i.e. in METHOD_INLINE clone mode?
         // Fix BasicBlock.java:clone!!
-        return new YieldInstr(ii.getRenamedVariable(result), getBlockArg().cloneForInlining(ii),
+        return new YieldInstr(ii.getScope(), ii.getRenamedVariable(result), getBlockArg().cloneForInlining(ii),
                 getYieldArg().cloneForInlining(ii), flags, unwrapArray);
     }
 
@@ -72,7 +73,7 @@ public class YieldInstr extends TwoOperandResultBaseInstr implements FixedArityI
     }
 
     public static YieldInstr decode(IRReaderDecoder d) {
-        return new YieldInstr(d.decodeVariable(), d.decodeOperand(), d.decodeOperand(), d.decodeInt(), d.decodeBoolean());
+        return new YieldInstr(d.getCurrentScope(), d.decodeVariable(), d.decodeOperand(), d.decodeOperand(), d.decodeInt(), d.decodeBoolean());
     }
 
     @Interp

--- a/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
@@ -14,7 +14,6 @@ import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -23,11 +22,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import java.util.EnumSet;
 
 public class ZSuperInstr extends UnresolvedSuperInstr {
-    public ZSuperInstr(IRScope scope, Variable result, Operand receiver, Operand[] args, Operand closure, int flags,
-                       boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
-        super(scope, Operation.ZSUPER, result, receiver, args, closure, flags, isPotentiallyRefined, callSite, callSiteId);
-    }
-
+    // normal constructor
     public ZSuperInstr(IRScope scope, Variable result, Operand receiver, Operand[] args, Operand closure, int flags,
                        boolean isPotentiallyRefined) {
         super(scope, Operation.ZSUPER, result, receiver, args, closure, flags, isPotentiallyRefined);
@@ -45,7 +40,7 @@ public class ZSuperInstr extends UnresolvedSuperInstr {
     public Instr clone(CloneInfo ii) {
         return new ZSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()), getReceiver().cloneForInlining(ii),
                 cloneCallArgs(ii), getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                isPotentiallyRefined());
     }
 
     public static ZSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
@@ -2,7 +2,6 @@ package org.jruby.ir.instructions.specialized;
 
 import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
-import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.AttrAssignInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.NullBlock;
@@ -15,9 +14,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 public class OneArgOperandAttrAssignInstr extends AttrAssignInstr {
     // clone constructor
     protected OneArgOperandAttrAssignInstr(IRScope scope, CallType callType, RubySymbol name, Operand receiver,
-                                           Operand[] args, int flags, boolean potentiallyRefined, CallSite callSite,
-                                           long callSiteId) {
-        super(scope, callType, name, receiver, args, flags, potentiallyRefined, callSite, callSiteId);
+                                           Operand[] args, int flags, boolean potentiallyRefined) {
+        super(scope, callType, name, receiver, args, flags, potentiallyRefined);
     }
 
     // normal constructor
@@ -29,7 +27,7 @@ public class OneArgOperandAttrAssignInstr extends AttrAssignInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new OneArgOperandAttrAssignInstr(ii.getScope(), getCallType(), getName(), getReceiver().cloneForInlining(ii),
-                cloneCallArgs(ii), getFlags(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
@@ -12,7 +12,6 @@ import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -20,16 +19,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 public class OneFixnumArgNoBlockCallInstr extends CallInstr {
     private final long fixNum;
-
-    // clone constructor
-    protected OneFixnumArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
-                                           Operand receiver, Operand[] args, int flags, boolean potentiallyRefined,
-                                           CallSite callSite, long callSiteId) {
-        super(scope, Operation.CALL_1F, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined,
-                callSite, callSiteId);
-
-        fixNum = ((Fixnum) args[0]).value;
-    }
 
     // normal constructor
     public OneFixnumArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
@@ -44,7 +33,7 @@ public class OneFixnumArgNoBlockCallInstr extends CallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new OneFixnumArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined(), callSite, callSiteId);
+                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
     }
 
     public long getFixnumArg() {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
@@ -12,7 +12,6 @@ import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -20,16 +19,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 public class OneFloatArgNoBlockCallInstr extends CallInstr {
     private final double flote;
-
-    // clone constructor
-    protected OneFloatArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
-                                          Operand receiver, Operand[] args, int flags, boolean potentiallyRefined,
-                                          CallSite callSite, long callSiteId) {
-        super(scope, Operation.CALL_1D, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined,
-                callSite, callSiteId);
-
-        this.flote = ((Float) args[0]).value;
-    }
 
     // normal constructor
     public OneFloatArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
@@ -44,8 +33,8 @@ public class OneFloatArgNoBlockCallInstr extends CallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new OneFloatArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined(),
-                getCallSite(), getCallSiteId());
+                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined()
+        );
     }
 
     public double getFloatArg() {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
@@ -11,21 +11,12 @@ import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class OneOperandArgBlockCallInstr extends CallInstr {
-    // clone constructor
-    public OneOperandArgBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
-                                       Operand receiver, Operand[] args, Operand closure, int flags,
-                                       boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
-        super(scope, Operation.CALL_1OB, callType, result, name, receiver, args, closure, flags, isPotentiallyRefined,
-                callSite, callSiteId);
-    }
-
     // normal constructor
     public OneOperandArgBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                        Operand receiver, Operand[] args, Operand closure, int flags,
@@ -37,8 +28,8 @@ public class OneOperandArgBlockCallInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getClosureArg().cloneForInlining(ii), getFlags(), isPotentiallyRefined(),
-                getCallSite(), getCallSiteId());
+                getClosureArg().cloneForInlining(ii), getFlags(), isPotentiallyRefined()
+        );
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
@@ -11,7 +11,6 @@ import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -22,13 +21,6 @@ public class OneOperandArgNoBlockCallInstr extends CallInstr {
     public OneOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                          Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined) {
         this(scope, Operation.CALL_1O, callType, result, name, receiver, args, flags, isPotentiallyRefined);
-    }
-
-    // clone constructor
-    public OneOperandArgNoBlockCallInstr(IRScope scope, Operation op, CallType callType, Variable result,
-                                         RubySymbol name, Operand receiver, Operand[] args, int flags,
-                                         boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
-        super(scope, op, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined, callSite, callSiteId);
     }
 
     // normal constructor
@@ -42,7 +34,7 @@ public class OneOperandArgNoBlockCallInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgNoBlockCallInstr(ii.getScope(), Operation.CALL_1O, getCallType(),
                 ii.getRenamedVariable(result), getName(), getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getFlags(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                getFlags(), isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockNoResultCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockNoResultCallInstr.java
@@ -5,24 +5,15 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.NoResultCallInstr;
-import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class OneOperandArgNoBlockNoResultCallInstr extends NoResultCallInstr {
-    // clone constructor
-    protected OneOperandArgNoBlockNoResultCallInstr(IRScope scope, CallType callType, RubySymbol name, Operand receiver,
-                                                    Operand[] args, Operand closure, int flags, boolean potentiallyRefined,
-                                                    CallSite callSite, long callSiteId) {
-        super(scope, Operation.NORESULT_CALL_1O, callType, name, receiver, args, closure, flags, potentiallyRefined, callSite, callSiteId);
-    }
-
     // normal constructor
     public OneOperandArgNoBlockNoResultCallInstr(IRScope scope, CallType callType, RubySymbol name, Operand receiver,
                                                  Operand[] args, Operand closure, int flags,
@@ -34,7 +25,7 @@ public class OneOperandArgNoBlockNoResultCallInstr extends NoResultCallInstr {
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgNoBlockNoResultCallInstr(ii.getScope(), getCallType(), getName(), getReceiver().cloneForInlining(ii),
                 cloneCallArgs(ii), getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
@@ -11,21 +11,12 @@ import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class TwoOperandArgNoBlockCallInstr  extends CallInstr  {
-    // clone constructor
-    protected TwoOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
-                                            Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined,
-                                            CallSite callSite, long callSiteId) {
-        super(scope, Operation.CALL_2O, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined,
-                callSite, callSiteId);
-    }
-
     // normal constructor
     public TwoOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                          Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined) {
@@ -35,8 +26,8 @@ public class TwoOperandArgNoBlockCallInstr  extends CallInstr  {
     @Override
     public Instr clone(CloneInfo ii) {
         return new TwoOperandArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined(),
-                getCallSite(), getCallSiteId());
+                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined()
+        );
     }
 
     public Operand getArg2() {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
@@ -11,20 +11,12 @@ import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
-import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class ZeroOperandArgNoBlockCallInstr extends CallInstr {
-    // clone constructor
-    public ZeroOperandArgNoBlockCallInstr(IRScope scope, Operation op, CallType callType, Variable result,
-                                          RubySymbol name, Operand receiver, Operand[] args, int flags,
-                                          boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
-        super(scope, op, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined, callSite, callSiteId);
-    }
-
     // normal constructor
     protected ZeroOperandArgNoBlockCallInstr(IRScope scope, Operation op, CallType callType, Variable result,
                                              RubySymbol name, Operand receiver, Operand[] args, int flags,
@@ -41,7 +33,7 @@ public class ZeroOperandArgNoBlockCallInstr extends CallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new ZeroOperandArgNoBlockCallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
     }
 
     @Override


### PR DESCRIPTION
Additional fixes on top of #9237.

That PR modified `import_module` logic to partially clear optimized interpreter state from cloned methods, but did not do the same for JIT-compiled methods. This PR has the additional changes:

* Always create a new `CallSite` in the primary `CallBase` constructor. This avoids the extra logic to fix up non-refined call sites being passed in from cloned call instructions when a refined site is needed. It is better for us to have the call site and call site ID be new for every call instruction anyway.
* Clean up and reduce visibility of all call instruction constructor paths used solely for cloning.
* Add a `reset` method to `MixedModeIRMethod` to also clear any JIT-compiled version of the method.

This does not fix the larger problem of precompiled methods (AOT, at boot or at load, using `CompiledIRMethod`) being unable to recompile after they have been cloned, but 99% of users will run in interpreted or JIT mode, not AOT.