### PR TITLE
Use prepared accessors to retrieve Data fields

### DIFF
--- a/core/src/main/java/org/jruby/RubyData.java
+++ b/core/src/main/java/org/jruby/RubyData.java
@@ -123,7 +123,7 @@ public class RubyData {
             String keyString = toSymbol(context, k).idString();
             VariableAccessor variableAccessor = variableAccessors.get(keyString);
             if (variableAccessor != null) {
-                selfObj.setInternalVariable(keyString, v);
+                variableAccessor.set(self, v);
             } else {
                 RubyArray unknownKeywords = unknownKeywordsPtr[0];
                 if (unknownKeywords == null) {


### PR DESCRIPTION
Data types are initialized with a set of accessors for the requested fields, which allows caching those accessors and avoiding costly hash lookups for future accesses. Due to a bug in how these accessors are initialized, parent and subclasses may have a different view of how those fields are stored in the object.

Here, the cached accessors are iterated, but then not used to read the field. This results in a second field being created for the subclass, in a different order from definition time. Using the original accessor here accesses the correct field.

Fixes jruby/jruby#9241.

Note that there's other problems with the data layout inside a Data type and other fixes will be needed to clean up how these accessors are allocated and shared with subclasses.