### PR TITLE
Correctly initialize Data field accessors

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -545,7 +545,7 @@ public class VariableTableManager {
         }
     }
 
-    public VariableTableManager duplicateForData(RubyClass newRealClass) {
+    public VariableTableManager duplicateFor(RubyClass newRealClass) {
         return new VariableTableManager(this, newRealClass);
     }
 


### PR DESCRIPTION
Part of the root cause of #9241 was the improper initialization of variable accessors during `Data` type setup. The changes here attempt to address that and make sure that:

* Data type fields are properly set up with native Java field accessors. Previously, a specialized object shape was allocated, but the accessors had already been initialized to use the growable varTable. This could lead to child classes having a different view of the varTable and mismatching fields to values.
* Always copy the parent class's variable table manager to the child. This was previously added just for cases where the direct superclass is `Data`, which could again lead to child classes forming their own picture of the object's shape.

The changes here extend #9252 and may be too experimental for a 10.0 maintenance release, but without them all `Data` objects are being allocated much larger than they should be and not using native fields.