### PR TITLE
Fix Time subsecond precision loss from floating point arithmetic

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -113,6 +113,7 @@ public class RubyTime extends RubyObject {
     private static final BigDecimal ONE_MILLION_BD = BigDecimal.valueOf(1000000);
     private static final BigDecimal ONE_BILLION_BD = BigDecimal.valueOf(1000000000);
     public static final int TIME_SCALE = 1_000_000_000;
+    public static final BigInteger TIME_SCALE_BI = BigInteger.valueOf(TIME_SCALE);
     public static final int TIME_SCALE_DIGITS = 9;
 
     private DateTime dt;

--- a/core/src/main/java/org/jruby/util/time/TimeArgs.java
+++ b/core/src/main/java/org/jruby/util/time/TimeArgs.java
@@ -136,7 +136,7 @@ public class TimeArgs {
                     }
 
                     long subSeconds = BigInteger.valueOf(numerator)
-                            .multiply(BigInteger.valueOf(TIME_SCALE))
+                            .multiply(RubyTime.TIME_SCALE_BI)
                             .divide(BigInteger.valueOf(denominator))
                             .longValue();
 


### PR DESCRIPTION
Use integer arithmetic when computing millis/nanos from Rational

Fixes Psych::Visitors::TestToRuby#test_time

https://github.com/jruby/jruby/actions/runs/22045652593/job/63693879405