### PR TITLE
Cleanup recursion guards

### DIFF
--- a/core/src/main/java/org/jruby/RubyArrayNative.java
+++ b/core/src/main/java/org/jruby/RubyArrayNative.java
@@ -1635,7 +1635,9 @@ public class RubyArrayNative<T extends IRubyObject> extends RubyArray<T> {
     /** inspect_ary
      *
      */
-    protected IRubyObject inspectAry(ThreadContext context) {
+    protected IRubyObject inspectAry(ThreadContext context, boolean recur) {
+        if (recur) return newSharedString(context, RECURSIVE_ARRAY_BL);
+
         RubyString str = RubyString.newStringLight(context.runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);
         str.cat((byte) '[');
 
@@ -1661,14 +1663,7 @@ public class RubyArrayNative<T extends IRubyObject> extends RubyArray<T> {
     public RubyString inspect(ThreadContext context) {
         final Ruby runtime = context.runtime;
         if (realLength == 0) return newSharedString(context, EMPTY_ARRAY_BL);
-        if (runtime.isInspecting(this)) return newSharedString(context, RECURSIVE_ARRAY_BL);
-
-        try {
-            runtime.registerInspecting(this);
-            return (RubyString) inspectAry(context);
-        } finally {
-            runtime.unregisterInspecting(this);
-        }
+        return (RubyString) context.execRecursive((ctx, state, obj, recur) -> state.inspectAry(ctx, recur), this, this, "inspect");
     }
 
     // MRI: rb_ary_first

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -128,8 +128,8 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
     }
 
     @Override
-    protected IRubyObject inspectAry(ThreadContext context) {
-        if (!packed()) return super.inspectAry(context);
+    protected IRubyObject inspectAry(ThreadContext context, boolean recur) {
+        if (recur || !packed()) return super.inspectAry(context, recur);
 
         final Ruby runtime = context.runtime;
         RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -149,8 +149,8 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
     }
 
     @Override
-    protected IRubyObject inspectAry(ThreadContext context) {
-        if (!packed()) return super.inspectAry(context);
+    protected IRubyObject inspectAry(ThreadContext context, boolean recur) {
+        if (recur || !packed()) return super.inspectAry(context, recur);
 
         final Ruby runtime = context.runtime;
         RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);


### PR DESCRIPTION
While working on recursive Object inspect output for Ruby 4.0 I realized many places we are using "outer" recursion checking where CRuby passes false for "outer". This builds off that discovery to clean up other places where we do recursion checking differently than CRuby.