### PR TITLE
Use live counts for event hook stats

### DIFF
--- a/core/src/main/java/org/jruby/runtime/TraceEventManager.java
+++ b/core/src/main/java/org/jruby/runtime/TraceEventManager.java
@@ -46,8 +46,6 @@ public class TraceEventManager {
     private final Ruby runtime;
     private volatile EventHook[] eventHooks = EMPTY_HOOKS;
     private boolean hasEventHooks;
-    private volatile int added;
-    private volatile int deleted;
     private final CallTraceFuncHook callTraceFuncHook = new CallTraceFuncHook(null);
 
     private final MutableCallSite callTrace = new MutableCallSite(TRACE_OFF);
@@ -86,7 +84,6 @@ public class TraceEventManager {
         eventHooks = newHooks;
 
         hasEventHooks = true;
-        added++;
 
         enableTraceSites(hook);
     }
@@ -118,8 +115,6 @@ public class TraceEventManager {
 
             disableTraceSites(hook);
         }
-        added--;
-        deleted++;
     }
 
     private void enableTraceSites(EventHook hook) {
@@ -183,9 +178,6 @@ public class TraceEventManager {
 
             disableTraceSites();
         }
-
-        added -= size - newHooks.length;
-        deleted += size - newHooks.length;
     }
 
     public void callEventHooks(ThreadContext context, RubyEvent event, String file, int line, String name, IRubyObject type) {
@@ -221,7 +213,7 @@ public class TraceEventManager {
     }
 
     public int[] eventHookStats() {
-        return new int[] {added, deleted};
+        return new int[] {eventHooks.length, 0};
     }
 
     public static class CallTraceFuncHook extends EventHook {


### PR DESCRIPTION
In CRuby, the deleted count in the stats appears to indicate those hooks that have been slated for removal from the hook list but not yet actually removed. JRuby actively removes the hook immediately when requested, so this deleted count is not really accurate.

The added count is all the other hooks in the list that have not been slated for removal, and should be calculated live from that list.

Tracking these values separately is error prone and we did not really represent deleted the way it seems to be used in CRuby.