### PR TITLE
Move fiddle back to default temporarily for resolv

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -38,6 +38,8 @@ default_gems = [
   # https://github.com/ruby/fcntl/issues/9
   # ['fcntl', '1.3.0'],
   ['ffi', '1.17.0'],
+  # Temporarily moved back to default gems, see https://github.com/jruby/jruby/issues/9278
+  ['fiddle', '1.1.8'],
   ['fileutils', '1.8.0'],
   ['find', '0.2.0'],
   ['forwardable', '1.4.0'],
@@ -105,7 +107,6 @@ bundled_gems = [
   # ['debug', '1.11.1'],
   ['debug', '0.2.1'],
   ['drb', '2.2.3'],
-  ['fiddle', '1.1.8'],
   ['getoptlong', '0.2.1'],
   ['irb', '1.16.0'],
   ['logger', '1.7.0'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -163,6 +163,19 @@ DO NOT MODIFY - GENERATED CODE
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>
+      <artifactId>fiddle</artifactId>
+      <version>1.1.8</version>
+      <type>gem</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>rubygems</groupId>
+          <artifactId>jar-dependencies</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
       <artifactId>fileutils</artifactId>
       <version>1.8.0</version>
       <type>gem</type>
@@ -774,19 +787,6 @@ DO NOT MODIFY - GENERATED CODE
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>
-      <artifactId>fiddle</artifactId>
-      <version>1.1.8</version>
-      <type>gem</type>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>rubygems</groupId>
-          <artifactId>jar-dependencies</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>rubygems</groupId>
       <artifactId>getoptlong</artifactId>
       <version>0.2.1</version>
       <type>gem</type>
@@ -1154,6 +1154,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/erb-6.0.1*</include>
           <include>specifications/error_highlight-0.7.1*</include>
           <include>specifications/ffi-1.17.0*</include>
+          <include>specifications/fiddle-1.1.8*</include>
           <include>specifications/fileutils-1.8.0*</include>
           <include>specifications/find-0.2.0*</include>
           <include>specifications/forwardable-1.4.0*</include>
@@ -1201,7 +1202,6 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/csv-3.3.5*</include>
           <include>specifications/debug-0.2.1*</include>
           <include>specifications/drb-2.2.3*</include>
-          <include>specifications/fiddle-1.1.8*</include>
           <include>specifications/getoptlong-0.2.1*</include>
           <include>specifications/irb-1.16.0*</include>
           <include>specifications/logger-1.7.0*</include>
@@ -1238,6 +1238,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/erb-6.0.1*/**/*</include>
           <include>gems/error_highlight-0.7.1*/**/*</include>
           <include>gems/ffi-1.17.0*/**/*</include>
+          <include>gems/fiddle-1.1.8*/**/*</include>
           <include>gems/fileutils-1.8.0*/**/*</include>
           <include>gems/find-0.2.0*/**/*</include>
           <include>gems/forwardable-1.4.0*/**/*</include>
@@ -1285,7 +1286,6 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/csv-3.3.5*/**/*</include>
           <include>gems/debug-0.2.1*/**/*</include>
           <include>gems/drb-2.2.3*/**/*</include>
-          <include>gems/fiddle-1.1.8*/**/*</include>
           <include>gems/getoptlong-0.2.1*/**/*</include>
           <include>gems/irb-1.16.0*/**/*</include>
           <include>gems/logger-1.7.0*/**/*</include>
@@ -1322,6 +1322,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/erb-6.0.1*</include>
           <include>cache/error_highlight-0.7.1*</include>
           <include>cache/ffi-1.17.0*</include>
+          <include>cache/fiddle-1.1.8*</include>
           <include>cache/fileutils-1.8.0*</include>
           <include>cache/find-0.2.0*</include>
           <include>cache/forwardable-1.4.0*</include>
@@ -1369,7 +1370,6 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/csv-3.3.5*</include>
           <include>cache/debug-0.2.1*</include>
           <include>cache/drb-2.2.3*</include>
-          <include>cache/fiddle-1.1.8*</include>
           <include>cache/getoptlong-0.2.1*</include>
           <include>cache/irb-1.16.0*</include>
           <include>cache/logger-1.7.0*</include>


### PR DESCRIPTION
The resolv library in JRuby still uses fiddle to bind registry logic on Windows, but because resolv is default and fiddle is not, bundle exec calls using resolv will fail to load that registry binding.

This moves fiddle back to default gems temporarily until we can replace the fiddle win32 wrapper with something that works out of default stdlib.

See https://github.com/jruby/jruby/issues/9278