### PR TITLE
Check if respond_to_missing? exists before respond_to?

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -2225,9 +2225,22 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
         if (getMetaClass().respondsToMethod(name.idString(), !includePrivate, context.getCurrentStaticScope())) return context.tru;
 
-        Ruby runtime = context.runtime;
-        IRubyObject result = sites(context).respond_to_missing.call(context, this, this, name, runtime.newBoolean(includePrivate));
-        return context.runtime.newBoolean(result.isTrue());
+        IRubyObject respondToMissing = basicObjectRespondToMissing(context, getMetaClass(), this, name, includePrivate);
+        if (respondToMissing == UNDEF) return context.fals;
+        return asBoolean(context, respondToMissing.isTrue());
+    }
+
+    // MRI: basic_obj_respond_to_missing, sort of
+    private IRubyObject basicObjectRespondToMissing(ThreadContext context, RubyClass klass, IRubyObject obj,
+                                 IRubyObject mid, boolean includePrivate)
+    {
+        CacheEntry entry = sites(context).respond_to_missing.retrieveCache(this);
+
+        if (!entry.method.isUndefined()) {
+            return entry.method.call(context, this, klass, "respond_to_missing?", mid, asBoolean(context, includePrivate));
+        }
+
+        return UNDEF;
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -61,7 +61,7 @@ public class JavaSites {
 
     public static class BasicObjectSites {
         public final CallSite respond_to = new FunctionalCachingCallSite("respond_to?");
-        public final CallSite respond_to_missing = new FunctionalCachingCallSite("respond_to_missing?");
+        public final CachingCallSite respond_to_missing = new FunctionalCachingCallSite("respond_to_missing?");
         public final CallSite initialize_dup = new FunctionalCachingCallSite("initialize_dup");
         public final CallSite initialize_clone = new FunctionalCachingCallSite("initialize_clone");
         public final CallSite to_s = new FunctionalCachingCallSite("to_s");


### PR DESCRIPTION
Old logic did a hard dispatch to respond_to_missing? if respond_to? returned false. This breaks any case where respond_to_missing? has been removed from a class altogether.

The change here tries to mimic the CRuby logic, first checking if respond_to? exists and returns true, and if it does not, only call respond_to_missing? if it exists.

Fixes jruby/jruby#9258