### PR TITLE
Clear callInfo so it does not taint other calls

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -234,6 +234,9 @@ public class RubyDir extends RubyObject implements Closeable {
     private static void globOptions(ThreadContext context, IRubyObject[] args, String[] keys, GlobOptions options) {
         Ruby runtime = context.runtime;
 
+        // just clear callInfo for now; future PR will handle it appropriately
+        ThreadContext.resetCallInfo(context);
+
         if (args.length > 1) {
             IRubyObject tmp = TypeConverter.checkHashType(runtime, args[args.length - 1]);
             boolean processFlags = keys == BASE_FLAGS_KEYWORDS;


### PR DESCRIPTION
This is the trivial fix for jruby/jruby#9281. A separate PR in jruby/jruby#9284 did not correctly untangle the kwarg handling logic, so we're pushing it to a future release.

Fixes jruby/jruby#9281