### PR TITLE
Add riscv64 platform support

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -92,6 +92,7 @@ public class Platform {
         ARM,
         AARCH64,
         LOONGARCH64,
+        RISCV64,
         UNKNOWN;
         @Override
         public String toString() { return name().toLowerCase(LOCALE); }
@@ -157,6 +158,8 @@ public class Platform {
             return CPU.AARCH64;
         } else if ("loongarch64".equals(archString)) {
             return CPU.LOONGARCH64;
+        } else if ("riscv64".equals(archString)) {
+            return CPU.RISCV64;
 	} else if ("universal".equals(archString)) {
             // OS X OpenJDK7 builds report "universal" right now
             String bits = SafePropertyAccessor.getProperty("sun.arch.data.model");
@@ -217,6 +220,7 @@ public class Platform {
                 case S390X:
                 case AARCH64:
                 case LOONGARCH64:
+                case RISCV64:
                     dataModel = 64;
                     break;
                 default:

--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -113,6 +113,7 @@ public class RbConfigLibrary implements Library {
         if ("amd64".equals(architecture)) architecture = "x86_64";
         if ("aarch64".equals(architecture) && Platform.IS_MAC) architecture = "arm64";
         if ("loongarch64".equals(architecture)) architecture = "loongarch64";
+        if ("riscv64".equals(architecture)) architecture = "riscv64";
 
         return architecture;
     }

--- a/install/jruby.install4j
+++ b/install/jruby.install4j
@@ -83,6 +83,7 @@
           <entry location="lib/jni/i386-FreeBSD" />
           <entry location="lib/jni/i386-OpenBSD" />
           <entry location="lib/jni/loongarch64-Linux" />
+          <entry location="lib/jni/riscv64-Linux" />
           <entry location="lib/jni/ppc-AIX" />
           <entry location="lib/jni/ppc64-Linux" />
           <entry location="lib/jni/ppc64le-Linux" />
@@ -108,6 +109,7 @@
           <entry location="lib/jni/i386-SunOS" />
           <entry location="lib/jni/i386-Windows" />
           <entry location="lib/jni/loongarch64-Linux" />
+          <entry location="lib/jni/riscv64-Linux" />
           <entry location="lib/jni/ppc64-Linux" />
           <entry location="lib/jni/ppc64le-Linux" />
           <entry location="lib/jni/ppc-AIX" />

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -20,6 +20,8 @@ module TestLibrary
       "x86_64"
     when /loongarch64/
       "loongarch64"
+    when /riscv64/
+      "riscv64"
     when /ppc64|powerpc64/
       "powerpc64"
     when /ppc|powerpc/


### PR DESCRIPTION
This PR adds RISC-V architecture support to JRuby ([issue #9286](https://github.com/jruby/jruby/issues/9286)). The changes are modeled after the LoongArch implementation in #7518 to ensure the support is as comprehensive and accurate as possible.