### PR TITLE
Reduce BigInteger construction

### DIFF
--- a/core/src/main/java/org/jruby/util/time/TimeArgs.java
+++ b/core/src/main/java/org/jruby/util/time/TimeArgs.java
@@ -128,21 +128,29 @@ public class TimeArgs {
                 if (secondObj instanceof RubyRational subSecond) {
                     if (subSecond.isNegativeNumber(context)) throw argumentError(context, "argument out of range");
 
-                    var numerator = subSecond.getNumerator().asBigInteger(context);
-                    var denominator = subSecond.getDenominator().asBigInteger(context);
-                    long subSeconds;
-                    if (numerator.compareTo(denominator) >= 0) {
-                        secondsInRational = numerator.divide(denominator).intValue();
-                        numerator = numerator.mod(denominator);
+                    RubyInteger num = subSecond.getNumerator();
+                    RubyInteger den = subSecond.getDenominator();
+                    if (num.equals(den)) {
+                        secondsInRational = 1;
+                    } else {
+                        var numerator = num.asBigInteger(context);
+                        var denominator = den.asBigInteger(context);
+                        long subSeconds;
+                        int cmp = numerator.compareTo(denominator);
+
+                        if (cmp > 0) {
+                            secondsInRational = numerator.divide(denominator).intValue();
+                            numerator = numerator.mod(denominator);
+                        }
+
+                        subSeconds = numerator
+                                .multiply(RubyTime.TIME_SCALE_BI)
+                                .divide(denominator)
+                                .longValue();
+
+                        millis = subSeconds / 1_000_000;
+                        nanos = subSeconds % 1_000_000;
                     }
-
-                    subSeconds = numerator
-                            .multiply(RubyTime.TIME_SCALE_BI)
-                            .divide(denominator)
-                            .longValue();
-
-                    millis = subSeconds / 1_000_000;
-                    nanos = subSeconds % 1_000_000;
                 } else {
                     double secs = toDouble(context, secondObj);
 


### PR DESCRIPTION
The numerator and denominator need to be BigInteger, so request them as such and reuse those instances. This reduces the number of BigIntegers constructed to four in the case where they are both already RubyBignum instances and numerator is less than denominator, and eight in the worst case where neither of them are RubyBignum instances and numerator is greater than denominator.

Previously, the best case was six BigInteger (extra from numerator and denominator being recreated).