### PR TITLE
Ensure we have a classloader to boot from

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1587,7 +1587,7 @@ public final class Ruby implements Constantizable {
     }
 
     private void loadBundler() {
-        loadService.loadFromClassLoader(getClassLoader(), "jruby/bundler/startup.rb", false);
+        loadService.loadFromClassLoader("jruby/bundler/startup.rb", false);
     }
 
     @SuppressWarnings("ReturnValueIgnored")
@@ -1781,7 +1781,7 @@ public final class Ruby implements Constantizable {
 
     private void initRubyKernel() {
         // load Ruby parts of core
-        loadService.loadFromClassLoader(getClassLoader(), "jruby/kernel.rb", false);
+        loadService.loadFromClassLoader("jruby/kernel.rb", false);
     }
 
     private void initRubyPreludes() {
@@ -1789,7 +1789,7 @@ public final class Ruby implements Constantizable {
         if (RubyInstanceConfig.DEBUG_PARSER) return;
 
         // load Ruby parts of core
-        loadService.loadFromClassLoader(getClassLoader(), "jruby/preludes.rb", false);
+        loadService.loadFromClassLoader("jruby/preludes.rb", false);
     }
 
     public IRManager getIRManager() {

--- a/core/src/main/java/org/jruby/ext/bigdecimal/BigDecimalLibrary.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/BigDecimalLibrary.java
@@ -43,6 +43,6 @@ public class BigDecimalLibrary implements Library {
         RubyBigDecimal.createBigDecimal(context);
 
         // using load since this file does not exist in MRI
-        loadService(context).loadFromClassLoader(Ruby.getClassLoader(), "jruby/bigdecimal.rb", false);
+        loadService(context).loadFromClassLoader("jruby/bigdecimal.rb", false);
     }
 }// BigDecimalLibrary

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -77,7 +77,7 @@ public class JRubyLibrary implements Library {
         var Object = objectClass(context);
 
         // load Ruby parts of the 'jruby' library
-        loadService(context).loadFromClassLoader(runtime.getJRubyClassLoader(), "jruby/jruby.rb", false);
+        loadService(context).loadFromClassLoader("jruby/jruby.rb", false);
 
         var JRuby = defineModule(context, "JRuby").
                 defineMethods(context, JRubyLibrary.class).defineMethods(context, JRubyUtilLibrary.class);

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -139,7 +139,7 @@ public class Java implements Library {
         RubyClass objectClass = (RubyClass) getProxyClass(context, java.lang.Object.class);
 
         // load Ruby parts of the 'java' library
-        loadService(context).loadFromClassLoader(Ruby.getClassLoader(), "jruby/java.rb", false);
+        loadService(context).loadFromClassLoader("jruby/java.rb", false);
 
         // rewire ArrayJavaProxy superclass to point at Object, so it inherits Object behaviors
         Access.getClass(context, "ArrayJavaProxy").

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -186,6 +186,7 @@ public class LoadService {
     protected final Map<String, JarFile> jarFiles = new HashMap<>(0);
 
     protected final Ruby runtime;
+    protected final ClassLoader systemClassLoader;
     protected LibrarySearcher librarySearcher;
 
     protected String mainScript;
@@ -193,6 +194,7 @@ public class LoadService {
 
     public LoadService(Ruby runtime) {
         this.runtime = runtime;
+        this.systemClassLoader = Ruby.getClassLoader();
         if (RubyInstanceConfig.DEBUG_LOAD_TIMINGS) {
             loadTimer = new TracingLoadTimer();
         } else {
@@ -381,6 +383,10 @@ public class LoadService {
             runtime.setCurrentLine(currentLine);
             loadTimer.endLoad(file, startTime);
         }
+    }
+
+    public void loadFromClassLoader(String file, boolean wrap) {
+        loadFromClassLoader(systemClassLoader, file, wrap);
     }
 
     public void loadFromClassLoader(ClassLoader classLoader, String file, boolean wrap) {


### PR DESCRIPTION
If JRuby is loaded in the bootstrap classloader, the direct getClassLoader for a Class object might return null. Use the alternative Ruby.getClassLoader instead which will fall back on the standard system classloader.