### PR TITLE
Replace now-deprecated wait_timeout

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -187,6 +187,9 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     /** Thread-local tuple used for sleeping (semaphore, millis, nanos) */
     private final SleepTask2 sleepTask = new SleepTask2();
 
+    /** Thread-local tuple used for waiting (object, millis, nanos) */
+    private final WaitTask waitTask = new WaitTask();
+
     /** Whether this is an "adopted" thread not created by Ruby code */
     private final boolean adopted;
 
@@ -1674,6 +1677,67 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         }
     }
 
+    /**
+     * Wait for the object's monitor the specified number of seconds, or forever if seconds is zero.
+     *
+     * @param o the object to wait for
+     * @param seconds the number of seconds to wait, as a double
+     * @return whether the wait took at least the specified amount of time, or true if the time specified was zero
+     * @throws InterruptedException
+     */
+    public boolean waitForObject(Object o, double seconds) throws InterruptedException {
+        if (seconds > 0.0) {
+            long delay_ns = (long)(seconds * 1000000000.0);
+            int delay_ns_remainder = (int)( delay_ns % 1000000 );
+            long delay_ms = delay_ns / 1000000;
+            return waitForObject(o, delay_ms, delay_ns_remainder);
+        } else {
+            waitForObject(o);
+            return true;
+        }
+    }
+
+    /**
+     * Wait for the object's monitor until woken up or notified.
+     *
+     * Equivalent to calling {@link RubyThread#waitForObject(Object, long, int)} with 0 for millis and nanos.
+     *
+     * @param o the object to wait for
+     * @throws InterruptedException
+     */
+    public void waitForObject(Object o) throws InterruptedException {
+        waitTask.millis = 0;
+        waitTask.nanos = 0;
+        executeTaskBlocking(getContext(), o, waitTask);
+    }
+
+    /**
+     * Wait for the object's monitor the specified number of milliseconds and nanoseconds, or forever if they are zero.
+     *
+     * @param o the object to wait for
+     * @param millis the number of milliseconds to wait
+     * @param nanos the number of nanoseconds to wait
+     * @return whether the wait took at least the specified amount of time, or true if the time specified was zero
+     * @throws InterruptedException
+     */
+    public boolean waitForObject(Object o, long millis, int nanos) throws InterruptedException {
+        long totalNanos = millis * 1000000 + nanos;
+        if (totalNanos == 0) {
+            waitForObject(o);
+            return true;
+        }
+
+        long start_ns = System.nanoTime();
+        if (totalNanos > 0) {
+            waitTask.millis = millis;
+            waitTask.nanos = nanos;
+            executeTaskBlocking(getContext(), o, waitTask);
+        }
+        long end_ns = System.nanoTime();
+
+        return (end_ns - start_ns) <= totalNanos;
+    }
+
     public IRubyObject status() { // not used
         return status(getRuntime().getCurrentContext());
     }
@@ -1798,6 +1862,32 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         @Override
         public void wakeup(RubyThread thread, Object data) {
             semaphore.release();
+        }
+    }
+
+    /**
+     * A Task for waiting on an object's monitor.
+     */
+    private static class WaitTask implements Task<Object, Long> {
+        long millis;
+        int nanos;
+
+        @Override
+        public Long run(ThreadContext context, Object data) throws InterruptedException {
+            long start = System.nanoTime();
+
+            synchronized (data) {
+                data.wait(millis, nanos);
+            }
+
+            return System.nanoTime() - start;
+        }
+
+        @Override
+        public void wakeup(RubyThread thread, Object data) {
+            synchronized (data) {
+                data.notify();
+            }
         }
     }
 
@@ -2459,23 +2549,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         pollThreadEvents();
     }
 
-    // Deprecated but still used by concurrent_ruby
+    /**
+     * @deprecated use {@link RubyThread#waitForObject(Object, double)} and siblings
+     */
     @Deprecated(since = "10.1.0.0")
     public boolean wait_timeout(IRubyObject o, Double timeout) throws InterruptedException {
-        if ( timeout != null ) {
-            long delay_ns = (long)(timeout.doubleValue() * 1000000000.0);
-            long start_ns = System.nanoTime();
-            if (delay_ns > 0) {
-                long delay_ms = delay_ns / 1000000;
-                int delay_ns_remainder = (int)( delay_ns % 1000000 );
-                executeBlockingTask(new SleepTask(o, delay_ms, delay_ns_remainder));
-            }
-            long end_ns = System.nanoTime();
-            return ( end_ns - start_ns ) <= delay_ns;
-        } else {
-            executeBlockingTask(new SleepTask(o, 0, 0));
-            return true;
-        }
+        return waitForObject(o, timeout == null ? 0 : timeout.doubleValue());
     }
 
     public RubyThreadGroup getThreadGroup() {


### PR DESCRIPTION
BlockingTask has been deprecated since 9.0.0.0, but the SleepTask subclass and its consumer RubyThread.wait_timeout were left undeprecated. In order to provide a migration path, this patch introduces a new blessed version of wait_timeout that no longer uses the deprecated BlockingTask.

See ruby-concurrency/concurrent-ruby#1100.

concurrent-ruby will eventually need to migrate to the blessed API, but until JRuby 10.0 is EOL we must continue to support the older method.