### PR TITLE
Push a frame for thread toplevel

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
@@ -100,6 +100,7 @@ public class RubyRunnable implements ThreadedRunnable {
         // uber-ThreadKill catcher, since it should always just mean "be dead"
         try {
             // Push a frame for the toplevel of the thread
+            context.pushFrame();
 
             // Call the thread's code
             Block threadBlock = proc.getBlock();


### PR DESCRIPTION
A new Thread should have a toplevel frame, even if the code it runs has been frame-optimized or is not Ruby code. This prevents any attempts to get a current binding from failing to access the frame stack.

Fixes #9308.