### PR TITLE
simple and blunt fix for BiVariableMap memory leak

### DIFF
--- a/core/src/main/java/org/jruby/embed/AttributeName.java
+++ b/core/src/main/java/org/jruby/embed/AttributeName.java
@@ -87,6 +87,29 @@ public enum AttributeName {
     SHARING_VARIABLES("org.jruby.embed.sharing.variables"),
 
     /**
+     * A key used in an attribute map to turn on/off sharing of instance variables.
+     * Default is false, which means instance variables are not accessible via the
+     * embedding interface. If set to true, and {@link #SHARING_VARIABLES} is also
+     * true, instance variables of an object become accessible via the BiVariableMap
+     * interface when
+     * <ul>
+     * <li>a method on that object has been called from Java 
+     * <li>that object is returned from a method call
+     * <li>that object is returned by the evaluation of a script
+     * </ul>
+     * <p>
+     * Note that enabling this option will prevent those objects from being garbage
+     * collected. Therefore, if this feature is enabled, the user becomes
+     * responsible for removing unused objects' instance variables from the
+     * BiVariableMap once they are no longer needed. Otherwise, <i>memory
+     * leaks will be expected</i>.
+     * <p>
+     * This attribute can be set using a System property,
+     * org.jruby.embed.sharing.instance.variables.
+     */
+    SHARING_INSTANCE_VARIABLES("org.jruby.embed.sharing.instance.variables"),
+
+    /**
      * A key used in an attribute map to turn on/off clearing variables.
      * This attribute is for JSR223 only.
      *

--- a/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
+++ b/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
@@ -41,8 +41,10 @@ import java.util.Set;
 
 import org.jruby.Ruby;
 import org.jruby.RubyObject;
+import org.jruby.embed.AttributeName;
 import org.jruby.embed.LocalVariableBehavior;
 import org.jruby.embed.variable.BiVariable;
+import org.jruby.embed.variable.InstanceVariable;
 import org.jruby.embed.variable.VariableInterceptor;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -335,7 +337,9 @@ public class BiVariableMap implements Map<String, Object> {
         }
         else { // creates new value
             var = VariableInterceptor.getVariableInstance(provider.getLocalVariableBehavior(), robj, key, value);
-            if ( var != null ) update(key, var);
+            // for consistency, do not inject instance variables when they wouldn't be retrieverd from Ruby
+            if (var != null && (isSharingInstanceVariables() || !(var instanceof InstanceVariable)))
+                update(key, var);
         }
         return oldValue;
     }
@@ -571,6 +575,14 @@ public class BiVariableMap implements Map<String, Object> {
      */
     public boolean isLazy() {
         return lazy;
+    }
+
+    public boolean isSharingInstanceVariables() {
+        final Object sharing = provider.getAttributeMap().get(AttributeName.SHARING_INSTANCE_VARIABLES);
+        if ( sharing instanceof Boolean && ((Boolean) sharing).booleanValue() == true ) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
+++ b/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
@@ -169,7 +169,8 @@ public class VariableInterceptor {
                 PersistentLocalVariable.retrieve(receiver, map);
             // continues to the default case
             default:
-                InstanceVariable.retrieve(receiver, map);
+                if (map.isSharingInstanceVariables())
+                    InstanceVariable.retrieve(receiver, map);
                 GlobalVariable.retrieve(receiver, map);
                 ClassVariable.retrieve(receiver, map);
                 Constant.retrieve(receiver, map);
@@ -200,7 +201,7 @@ public class VariableInterceptor {
             default:
                 if (GlobalVariable.isValidName(key)) {
                     GlobalVariable.retrieveByKey(receiver.getRuntime(), map, (String)key);
-                } else if (InstanceVariable.isValidName(key)) {
+                } else if (InstanceVariable.isValidName(key) && map.isSharingInstanceVariables()) {
                     InstanceVariable.retrieveByKey((RubyObject) receiver,map, (String)key);
                 } else if (ClassVariable.isValidName(key)) {
                     ClassVariable.retrieveByKey((RubyObject)receiver, map, (String)key);


### PR DESCRIPTION
This introduces an attribute `SHARING_INSTANCE_VARIABLES` to control whether instance variables are accessible via the embedding interface. It is disabled by default and has a clear warning that enabling it will lead to a memory leak unless cleaned up manually.

This is incomplete; I haven't adjusted the testcase yet. The testcase would now need to test the different behaviors with `SHARING_INSTANCE_VARIABLES` enabled and disabled, respectively. However, I think the code already shows the "simple and blunt" way of fixing the #8527 memory leak.