### PR TITLE
[fix] MatchData#deconstruct_keys: include non-participating captures

### DIFF
--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -951,7 +951,7 @@ public class RubyMatchData extends RubyObject {
 
                 for (int b : entry.getBackRefs()) {
                     IRubyObject value = RubyRegexp.nth_match(context, b, this);
-                    if (value.isTrue()) hash.op_aset(context, key, value);
+                    hash.op_aset(context, key, value);
                 }
             });
         } else if (what instanceof RubyArray arr) {
@@ -967,8 +967,6 @@ public class RubyMatchData extends RubyObject {
                 if (index == -1) break;
 
                 IRubyObject value = RubyRegexp.nth_match(context, index, this);
-                if (!value.isTrue()) break;
-
                 hash.op_aset(context, requestedKey, value);
             }
         } else {

--- a/spec/regression/matchdata_deconstruct_keys_nil_capture_spec.rb
+++ b/spec/regression/matchdata_deconstruct_keys_nil_capture_spec.rb
@@ -1,0 +1,33 @@
+require 'rspec'
+
+# Regression test for MatchData#deconstruct_keys with non-participating
+# named captures.
+#
+# When a named capture group doesn't participate in the match (e.g.
+# an optional group like (?<b>world)?), deconstruct_keys should include
+# the key with a nil value, not omit it entirely.
+
+describe "MatchData#deconstruct_keys with non-participating captures" do
+  let(:match) { "hello".match(/(?<a>hello)(?<b>world)?/) }
+
+  it "includes non-participating captures as nil for nil argument" do
+    result = match.deconstruct_keys(nil)
+    expect(result).to eq({ a: "hello", b: nil })
+  end
+
+  it "includes non-participating captures as nil for explicit keys" do
+    result = match.deconstruct_keys([:a, :b])
+    expect(result).to eq({ a: "hello", b: nil })
+  end
+
+  it "does not stop iterating at non-participating captures" do
+    m = "hello!".match(/(?<a>hello)(?<b>world)?(?<c>!)/)
+    result = m.deconstruct_keys([:b, :c, :a])
+    expect(result).to eq({ b: nil, c: "!", a: "hello" })
+  end
+
+  it "preserves key order from argument" do
+    result = match.deconstruct_keys([:b, :a])
+    expect(result.keys).to eq([:b, :a])
+  end
+end


### PR DESCRIPTION
JRuby skipped named capture groups that did not participate in the match (value is nil).

With nil argument, such keys were omitted entirely. With explicit keys, iteration stopped at the first non-participating capture.

CRuby includes non-participating captures with nil values in all cases. This is important for pattern matching where the absence of a key means "does not match" while nil means "matched nothing".