### PR TITLE
[fix] Bignum#eql?: use type-strict comparison (not ==)

### DIFF
--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -1076,13 +1076,7 @@ public class RubyBignum extends RubyInteger {
         return asBoolean(context, value.compareTo(otherValue) == 0);
     }
 
-    /** rb_big_eql
-     *
-     */
-    @Override
-    public IRubyObject eql_p(ThreadContext context, IRubyObject other) {
-        return op_equal(context, other);  // '==' and '===' are the same, but they differ from 'eql?'.
-    }
+    // eql_p inherited from RubyNumeric: type-strict check (getClass) + equalInternal
 
     // MRI: rb_big_hash
     public RubyFixnum hash(ThreadContext context) {

--- a/spec/regression/bignum_eql_type_check_spec.rb
+++ b/spec/regression/bignum_eql_type_check_spec.rb
@@ -1,0 +1,35 @@
+require 'rspec'
+
+# Regression test for Bignum#eql? type-strict semantics.
+#
+# Ruby's eql? must be type-strict: it should return false when
+# comparing an Integer with a Float or Rational, even if they
+# represent the same numeric value. The bug was that RubyBignum
+# delegated eql? to == which accepts cross-type comparisons.
+
+describe "Bignum#eql?" do
+  it "returns true for same-value Bignums" do
+    expect((2**100).eql?(2**100)).to be true
+  end
+
+  it "returns false for different-value Bignums" do
+    expect((2**100).eql?(2**100 + 1)).to be false
+  end
+
+  it "returns false for Float with same numeric value" do
+    expect((2**100).eql?((2**100).to_f)).to be false
+  end
+
+  it "returns false for Rational with same numeric value" do
+    expect((2**100).eql?(Rational(2**100))).to be false
+  end
+
+  it "returns false for Fixnum-range Integer" do
+    expect((2**100).eql?(42)).to be false
+  end
+
+  it "does not affect == which remains type-loose" do
+    expect((2**100) == (2**100).to_f).to be true
+    expect((2**100) == Rational(2**100)).to be true
+  end
+end


### PR DESCRIPTION
RubyBignum overrode eql_p to delegate to op_equal (==), which accepts Floats and Rationals. In Ruby, eql? must be type-strict: `(2**100).eql?((2**100).to_f)` should return false.

Remove the override so the parent `RubyNumeric.eql_p` handles it correctly with a `getClass()` check before value comparison.