### PR TITLE
[fix] IO#reopen: copy encoding from source IO

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -533,6 +533,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         boolean locked2 = orig.lock(); // TODO: This WILL deadlock if two threads try to reopen the same IOs in opposite directions. Fix?
         try {
             fptr.setMode(orig.getMode() | (fptr.getMode() & (OpenFile.PREP | OpenFile.SYNC)));
+            fptr.encs = orig.encs;
             fptr.setProcess(orig.getProcess());
             fptr.setLineNumber(orig.getLineNumber());
             if (orig.getPath() != null) fptr.setPath(orig.getPath());

--- a/test/jruby/test_io.rb
+++ b/test/jruby/test_io.rb
@@ -153,6 +153,22 @@ class TestIO < Test::Unit::TestCase
     assert_nothing_raised { file.reopen(@file) }
   end
 
+  def test_reopen_copies_encoding
+    ensure_files @file, @file2
+    f1 = File.open(@file)
+    @to_close << f1
+    f1.set_encoding("EUC-JP:UTF-8")
+
+    f2 = File.open(@file2)
+    @to_close << f2
+    f2.set_encoding("ISO-8859-1:US-ASCII")
+
+    f1.reopen(f2)
+
+    assert_equal Encoding::ISO_8859_1, f1.external_encoding
+    assert_equal Encoding::US_ASCII, f1.internal_encoding
+  end
+
   def test_file_read
     ensure_files @file
     # test that read returns correct values


### PR DESCRIPTION
After reopen, the IO retained its old encoding settings instead of inheriting the source's external/internal encoding.

CRuby's io_reopen explicitly copies fptr->encs = orig->encs right after the mode assignment.