### PR TITLE
[compat] Thread#native_thread_id: using Java thread-id

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -35,7 +35,7 @@ package org.jruby;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.lang.management.ManagementFactory;
+
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
@@ -1503,21 +1503,10 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     public IRubyObject native_thread_id(ThreadContext context) {
         if (!isAlive()) return context.nil;
 
-        String encodedString = ManagementFactory.getRuntimeMXBean().getName();
-        int atIndex = encodedString.indexOf('@');
+        Thread nativeThread = getNativeThread();
+        if (nativeThread == null) return context.nil;
 
-        // Undocumented format: 1761769@localhost.localdomain
-        if (atIndex != -1) {
-            try {
-                int id = Integer.parseInt(encodedString.substring(0, atIndex));
-
-                return asFixnum(context, id);
-            } catch (NumberFormatException e) {
-                // if we fail to parse this we will just act like we don't support it
-            }
-        }
-
-        return context.nil;  // Not supported or failed to extract id
+        return asFixnum(context, nativeThread.threadId());
     }
 
     private IRubyObject genericRaise(ThreadContext context, RubyThread currentThread, IRubyObject... args) {

--- a/spec/tags/ruby/core/thread/native_thread_id_tags.txt
+++ b/spec/tags/ruby/core/thread/native_thread_id_tags.txt
@@ -1,1 +1,0 @@
-fails:Thread#native_thread_id each thread has different native thread id


### PR DESCRIPTION
Thread.threadId() (JDK 19+) returns a unique identifier per thread.

No need to rely on internal JMX hacks anymore, which aren't really working atm (same thread-id for multiple threads).