### PR TITLE
[fix] Digest::Base: synchronize MessageDigest mutation

### DIFF
--- a/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
+++ b/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
@@ -532,7 +532,9 @@ public class RubyDigest {
             from.checkFrozen();
 
             try {
-                this.algo = (MessageDigest) from.algo.clone();
+                synchronized (from) {
+                    this.algo = (MessageDigest) from.algo.clone();
+                }
             } catch (CloneNotSupportedException e) {
                 String name = from.algo.getAlgorithm();
                 throw typeError(context, "Could not initialize copy of digest (" + name + ")");
@@ -541,7 +543,7 @@ public class RubyDigest {
         }
 
         @JRubyMethod(name = {"update", "<<"})
-        public IRubyObject update(IRubyObject obj) {
+        public synchronized IRubyObject update(IRubyObject obj) {
             ByteList bytes = obj.convertToString().getByteList();
             algo.update(bytes.getUnsafeBytes(), bytes.getBegin(), bytes.getRealSize());
             return this;
@@ -553,7 +555,7 @@ public class RubyDigest {
         }
 
         @JRubyMethod()
-        public IRubyObject finish(ThreadContext context) {
+        public synchronized IRubyObject finish(ThreadContext context) {
             IRubyObject digest = RubyString.newStringNoCopy(context.runtime, algo.digest());
             algo.reset();
             return digest;
@@ -581,13 +583,13 @@ public class RubyDigest {
         }
 
         @JRubyMethod()
-        public IRubyObject reset() {
+        public synchronized IRubyObject reset() {
             algo.reset();
             return this;
         }
 
         @JRubyMethod()
-        public IRubyObject bubblebabble(ThreadContext context) {
+        public synchronized IRubyObject bubblebabble(ThreadContext context) {
             final byte[] digest = algo.digest();
             return newString(context, BubbleBabble.bubblebabble(digest, 0, digest.length));
         }

--- a/test/jruby/test_digest2.rb
+++ b/test/jruby/test_digest2.rb
@@ -17,6 +17,22 @@ class TestDigest2 < Test::Unit::TestCase
     assert_equal(false, (a.eql?(b)))
   end
 
+  # Concurrent update on a shared Digest::Base instance should not raise.
+  # Without synchronization, java.security.MessageDigest corrupts its
+  # internal state under concurrent access, typically throwing
+  # ArrayIndexOutOfBoundsException from the JDK's digest implementation.
+  def test_concurrent_update
+    digest = Digest::SHA256.new
+
+    threads = 10.times.map do
+      Thread.new do
+        100.times { digest.update("hello") }
+      end
+    end
+
+    assert_nothing_raised { threads.each(&:join) }
+  end
+
   # JRUBY-5147
   def test_initialize_args
     assert_raises(ArgumentError) do


### PR DESCRIPTION
`java.security.MessageDigest` is not thread-safe, concurrent calls to update/finish/reset on a shared Digest object from multiple Ruby threads would corrupt the internal state, producing wrong digests or `ArrayIndexOutOfBoundsException` (reproduces with included test)