### PR TITLE
[fix] Encoding.compatible?: check when swapping args

### DIFF
--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -151,13 +151,11 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         if (!(obj1 instanceof RubyString) && enc1 instanceof USASCIIEncoding) return enc2;
 
         if (!(obj1 instanceof RubyString)) {
-            IRubyObject objTmp = obj1; // swap1 obj1 & obj2
+            IRubyObject objTmp = obj1; // swap obj1 & obj2
             obj1 = obj2;
             obj2 = objTmp;
-
-            Encoding encTmp = enc1;  // swap their encodings
-            enc1 = enc2;
-            enc2 = encTmp;
+            // Note: enc1/enc2 are NOT swapped — they retain the
+            // original argument order, matching CRuby's rb_enc_compatible.
         }
 
         if (obj1 instanceof RubyString) {

--- a/spec/ruby/core/encoding/compatible_spec.rb
+++ b/spec/ruby/core/encoding/compatible_spec.rb
@@ -557,6 +557,11 @@ describe "Encoding.compatible? String, Regexp" do
       [Encoding, "\x82\xa0".dup.force_encoding("shift_jis"),  Encoding::Shift_JIS],
     ].should be_computed_by(:compatible?, /abc/)
   end
+
+  it "returns the Regexp's Encoding if the String is ASCII only and the Regexp is not" do
+    r = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    Encoding.compatible?("hello".dup.force_encoding("utf-8"), r).should == Encoding::EUC_JP
+  end
 end
 
 describe "Encoding.compatible? String, Symbol" do
@@ -619,6 +624,15 @@ describe "Encoding.compatible? Regexp, String" do
     Encoding.compatible?(/abc/, str).should == Encoding::US_ASCII
   end
 
+  it "returns the String's Encoding when the String is ASCII only with a different encoding" do
+    r = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    Encoding.compatible?(r, "hello".dup.force_encoding("utf-8")).should == Encoding::UTF_8
+  end
+
+  it "returns the Regexp's Encoding if the String has the same non-ASCII encoding" do
+    r = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    Encoding.compatible?(r, "hello".dup.force_encoding("euc-jp")).should == Encoding::EUC_JP
+  end
 end
 
 describe "Encoding.compatible? Regexp, Regexp" do


### PR DESCRIPTION
When the first argument is not a String (e.g. Regexp) and the second is, areCompatible check swaps objects so that String is first.

However, JRuby also swapped encoding values, which is wrong — CRuby's enc_compatible_latter (encoding.c) only swaps the object/isstr/idx references but keeps enc1/enc2 derived from the original idx values before the swap, so they retain the original argument order.

This caused `Encoding.compatible?(regexp_eucjp, string_utf8)` to return `EUC-JP` instead of `UTF-8` when the string was ASCII-only.