### PR TITLE
Use JDK for File#flock on Windows

### DIFF
--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -216,7 +216,8 @@ public class PosixShim {
 
         int real_fd = fd.realFileno;
 
-        if (posix.isNative() && real_fd != -1 && real_fd < FilenoUtil.FIRST_FAKE_FD && !Platform.IS_SOLARIS) {
+        if (!Platform.IS_SOLARIS && !Platform.IS_WINDOWS &&
+                posix.isNative() && real_fd != -1 && real_fd < FilenoUtil.FIRST_FAKE_FD) {
             // we have a real fd and not on Solaris...try native flocking
             // see jruby/jruby#3254 and jnr/jnr-posix#60
             int result = posix.flock(real_fd, lockMode);


### PR DESCRIPTION
Windows does not use native file descriptors and does not properly bind a native `flock` function, so this logic should not be used on Windows.

Forcing this logic to use the JDK equivalent flocking API appears to resolve issues with the Logger gem.

Fixes jruby/jruby#8801