### PR TITLE
Fix non-native IO.popen env + kwargs handling

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -4518,13 +4518,15 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         int firstArg = 0;
 
-        if (argc > 0 && !TypeConverter.checkHashType(runtime, args[0]).isNil()) {
-            firstArg++;
+        // process trailing keyword arguments hash
+        if (argc > 0 && !(tmp = TypeConverter.checkHashType(runtime, args[argc - 1])).isNil()) {
+            options = (RubyHash)tmp;
             argc--;
         }
 
-        if (argc > 0 && !(tmp = TypeConverter.checkHashType(runtime, args[argc - 1])).isNil()) {
-            options = (RubyHash)tmp;
+        // process leading env hash
+        if (argc > 0 && !TypeConverter.checkHashType(runtime, args[0]).isNil()) {
+            firstArg++;
             argc--;
         }
 


### PR DESCRIPTION
When both an env hash and a keyword arguments hash were provided here, the env hash logic would decrement argc resulting in the keyword arguments hash detection accessing the wrong argument. The fix here aligns this logic with the newer PopenExecutor and ensures the keyword arguments hash is handled first.

The argument processing logic for these two popen implementations should be unified, but this simple fix gets popen working better right now.

Fixes jruby/jruby#9295