### PR TITLE
Propagate newline from if to bodies

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1401,6 +1401,14 @@ public abstract class RubyParserBase {
         if (node == null || orig == null) return;
 
         node.setLine(orig.getLine());
+
+        // Detect IfNode and propagate newline to the bodies.
+        // This is a bit of a form-fitted fix, but the full reduce_nodes logic from CRuby
+        // defied an initial porting attempt. See jruby/jruby#9293.
+        if (node.isNewline() && node instanceof IfNode ifNode) {
+            if (ifNode.getThenBody() instanceof Node thenNode) thenNode.setNewline();
+            if (ifNode.getElseBody() instanceof Node elseNode) elseNode.setNewline();
+        }
     }
 
     public Node new_fcall(ByteList operation) {


### PR DESCRIPTION
This is a somewhat form-fitted fix for jruby/jruby#9293 that only assists with line numbers of the then and else bodies of IfNode. In the linked issue, a trailing `if` or `unless` modifier will be used as the line number that an associated call gets associated with, causing stack output like from `caller_locations` to be incorrect. In CRuby, this newline propagation appears to be done during the `reduce_nodes` function, but that function has many side effects in its macro-heavy logic and an initial attempt to port it did not fix the issue in question. Instead, I just detect this specific case and propagate the newline manually.

There may be other such cases, and once we encounter those there may be a better justification for formally duplicating the newline side-effect logic from `reduce_node`. For now, this quick fix is probably good enough.

Fixes jruby/jruby#9293