### PR TITLE
Properly complete Fiber#raise transfer

### DIFF
--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -406,11 +406,9 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         try {
             result = exchangeWithFiber(context, currentFiberData, data, val);
         } finally {
-            if (result == null) {
-                // exception raised, mark transfer as completed
-                data.prev = null;
-                currentFiberData.transferred = false;
-            }
+                // exception transferred, mark as completed
+            data.prev = null;
+            currentFiberData.transferred = false;
         }
 
         if (result.type == RequestType.RAISE) {


### PR DESCRIPTION
Fiber#raise still returns a request from the target fiber, but the finally block intended to finish the transfer would only do so if a exception was immediately raised during the transfer. As a result the fiber was left in a "resumed" state and further resumes would error.

These state changes need to be re-audited and cleaned up but at least in this case it's clear that the completion of the raise request should not leave the fiber stuck in resume mode.

Fixes jruby/jruby#9297