### PR TITLE
Backport implicitOrVariable code for prism parser

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -397,7 +397,7 @@ public abstract class RubyParserBase {
             node = new LocalVarNode(lexer.tokline, slot, name);
         } else if (dyna_in_block() && id.equals("it")) {
             if (!hasArguments()) {
-                int existing = currentScope.isDefinedNotImplicit(id);
+                int existing = currentScope.isDefinedOrImplicit(id);
                 boolean newIt = false;
 
                 if (existing == -1) {
@@ -416,7 +416,7 @@ public abstract class RubyParserBase {
                 node = new DVarNode(lexer.tokline, slot, name);
                 if (newIt) set_it_id(node);
             } else {
-                slot = currentScope.isDefinedNotImplicit(id);
+                slot = currentScope.isDefinedOrImplicit(id);
                 // A special it cannot exist without being marked as a special it.
                 if (it_id() != null) compile_error("`it` is not allowed when an ordinary parameter is defined");
 

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -430,7 +430,7 @@ public class StaticScope implements Serializable, Cloneable {
      * @param name of the variable to find
      * @return index of variable; -1 if it does not exist; -2 if is implicit.
      */
-    public int existsAndNotImplicit(String name) {
+    public int existsOrImplicit(String name) {
         int slot = findVariableName(name);
         if (slot >= 0 && isImplicitVariable(slot)) return IMPLICIT;
         return slot;
@@ -455,14 +455,25 @@ public class StaticScope implements Serializable, Cloneable {
     }
 
     /**
-     * Is this name visible to the current scope and not an implicit variable ("it", "_1", etc).
+     * Is this name visible to the current scope as either a variable or an implicit variable
+     *
+     * @param name to be looked for
+     * @return a location where the left-most 16 bits of number of scopes down it is and the
+     * right-most 16 bits represents its index in that scope
+     */
+    public int isDefinedOrImplicit(String name) {
+        return isDefinedOrImplicit(name, 0);
+    }
+
+    /**
+     * Is this name visible to the current scope and not an implicit parameter ("it", "_1", etc).
      *
      * @param name to be looked for
      * @return -1 if it is not defined; -2 if it is implicit; or a location where the left-most 16 bits of number of scopes down it is and the
      * right-most 16 bits represents its index in that scope.
      */
-    public int isDefinedNotImplicit(String name) {
-        return isDefinedNotImplicit(name, 0);
+    public int isDefinedImplicitParameter(String name) {
+        return isDefinedImplicitParameter(name, 0);
     }
 
     /**
@@ -547,7 +558,8 @@ public class StaticScope implements Serializable, Cloneable {
      * @return populated collection
      */
     public <T> T collectAllVariables(ThreadContext context, BiFunction<ThreadContext, Integer, T> collectionFactory, BiConsumer<T, String> collectionPopulator) {
-        return collectVariables(context, collectionFactory, collectionPopulator, null);
+        T collection = collectVariables(context, collectionFactory, collectionPopulator, false, true);
+        return collectVariables(context, (t, i) -> collection, collectionPopulator, true, true);
     }
 
     /**
@@ -562,7 +574,7 @@ public class StaticScope implements Serializable, Cloneable {
      * @return populated collection
      */
     public <T> T collectVariables(ThreadContext context, BiFunction<ThreadContext, Integer, T> collectionFactory, BiConsumer<T, String> collectionPopulator) {
-        return collectVariables(context, collectionFactory, collectionPopulator, false);
+        return collectVariables(context, collectionFactory, collectionPopulator, false, true);
     }
 
     /**
@@ -576,24 +588,30 @@ public class StaticScope implements Serializable, Cloneable {
      * @param <T> resulting collection type
      * @return populated collection
      */
-    public <T> T collectImplicitVariables(ThreadContext context, BiFunction<ThreadContext, Integer, T> collectionFactory, BiConsumer<T, String> collectionPopulator) {
-        return collectVariables(context, collectionFactory, collectionPopulator, true);
+    public <T> T collectImplicitParameters(ThreadContext context, BiFunction<ThreadContext, Integer, T> collectionFactory, BiConsumer<T, String> collectionPopulator) {
+        return collectVariables(context, collectionFactory, collectionPopulator, true, false);
     }
 
-    public <T> T collectVariables(ThreadContext context, BiFunction<ThreadContext, Integer, T> collectionFactory, BiConsumer<T, String> collectionPopulator, Boolean implicit) {
+    private <T> T collectVariables(ThreadContext context, BiFunction<ThreadContext, Integer, T> collectionFactory, BiConsumer<T, String> collectionPopulator, boolean implicit, boolean parents) {
         StaticScope current = this;
 
         T collection = collectionFactory.apply(context, current.variableNamesLength);
 
         HashMap<String, Object> dedup = new HashMap<>();
 
-        while (current.isBlockOrEval) {
-            addVariableNamesToCollection(current, collectionPopulator, dedup, collection, implicit);
-            current = current.enclosingScope;
-        }
-
-        // once more for method scope
         addVariableNamesToCollection(current, collectionPopulator, dedup, collection, implicit);
+
+        if (parents) {
+            current = current.enclosingScope;
+
+            while (current.isBlockOrEval) {
+                addVariableNamesToCollection(current, collectionPopulator, dedup, collection, implicit);
+                current = current.enclosingScope;
+            }
+
+            // once more for method scope
+            addVariableNamesToCollection(current, collectionPopulator, dedup, collection, implicit);
+        }
 
         return collection;
     }
@@ -632,7 +650,20 @@ public class StaticScope implements Serializable, Cloneable {
      * @return populated RubyArray
      */
     public RubyArray getLocalVariables(ThreadContext context) {
-        return collectAllVariables(
+        return collectVariables(
+                context,
+                Create::allocArray,
+                (array, id) -> appendVariableIfValid(context, array, id));
+    }
+
+    /**
+     * Get a Ruby Array of all implicit local variables.
+     *
+     * @param context the current context
+     * @return populated RubyArray
+     */
+    public RubyArray getImplicitParameters(ThreadContext context) {
+        return collectImplicitParameters(
                 context,
                 Create::allocArray,
                 (array, id) -> appendVariableIfValid(context, array, id));
@@ -654,17 +685,24 @@ public class StaticScope implements Serializable, Cloneable {
         }
     }
 
-    public int isDefinedNotImplicit(String name, int depth) {
-        int slot = existsAndNotImplicit(name);
-        if (slot == IMPLICIT) return slot;
-
+    public int isDefinedOrImplicit(String name, int depth) {
         if (isBlockOrEval) {
+            int slot = existsOrImplicit(name);
+            if (slot == IMPLICIT) return slot;
+
             if (slot >= 0) return (depth << 16) | slot;
 
-            return enclosingScope.isDefinedNotImplicit(name, depth + 1);
+            return enclosingScope.isDefinedOrImplicit(name, depth + 1);
         } else {
-            return (depth << 16) | slot;
+            return (depth << 16) | existsOrImplicit(name);
         }
+    }
+
+    public int isDefinedImplicitParameter(String name, int depth) {
+        int slot = existsOrImplicit(name);
+        if (slot == IMPLICIT) return slot;
+
+        return -1;
     }
 
     public AssignableNode addAssign(int line, RubySymbol symbolID, Node value) {


### PR DESCRIPTION
I realized I was not properly compiling jruby-prism and StaticScope.implicitOrVariable was needed.  I removed the logic changing RubyBinding but I left in RubyParserBase which might cause some problems? 