### PR TITLE
[deps] bump jruby-openssl default gem to 0.15.7

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -52,7 +52,7 @@ default_gems = [
   ['irb', '1.14.3'],
   ['jar-dependencies', '0.5.4'],
   ['jruby-readline', '1.3.7'],
-  ['jruby-openssl', '0.15.6'],
+  ['jruby-openssl', '0.15.7'],
   ['json', '2.16.0'],
   ['logger', '1.6.4'],
   ['net-http', '0.6.0'],


### PR DESCRIPTION
Bump jruby-openssl from 0.15.6 to 0.15.7.

Release notes: https://github.com/jruby/jruby-openssl/releases/tag/v0.15.7