### PR TITLE
[fix] TCPServer#initialize: close channel on bind/init failure

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
@@ -102,10 +102,13 @@ public class RubyTCPServer extends RubyTCPSocket {
 
         int port = SocketUtils.getPortFrom(context, _port);
 
+        ServerSocketChannel ssc = null;
+        boolean success = false;
+
         try {
             InetAddress addr = InetAddress.getByName(host);
 
-            ServerSocketChannel ssc = ServerSocketChannel.open();
+            ssc = ServerSocketChannel.open();
             ssc.socket().setReuseAddress(true);
 
             InetSocketAddress socket_address = new InetSocketAddress(addr, port);
@@ -113,20 +116,26 @@ public class RubyTCPServer extends RubyTCPSocket {
             ssc.socket().bind(socket_address);
 
             initSocket(newChannelFD(runtime, ssc));
-        } catch(UnknownHostException e) {
+
+            success = true;
+        } catch (UnknownHostException e) {
             throw SocketUtils.sockerr(runtime, "initialize: name or service not known");
-        } catch(BindException e) {
+        } catch (BindException e) {
             throw runtime.newErrnoFromBindException(e, bindContextMessage(context, _host, port));
-        } catch(SocketException e) {
+        } catch (SocketException e) {
             String msg = e.getMessage();
 
             throw msg.contains("Permission denied") ?
                     runtime.newErrnoEACCESError("bind(2)") :
                     SocketUtils.sockerr(runtime, "initialize: name or service not known");
-        } catch(IOException e) {
+        } catch (IOException e) {
             throw runtime.newIOErrorFromException(e);
         } catch (IllegalArgumentException iae) {
             throw SocketUtils.sockerr(runtime, iae.getMessage());
+        } finally {
+            if (!success && ssc != null) {
+                try { ssc.close(); } catch (IOException ioe) {}
+            }
         }
 
         return this;


### PR DESCRIPTION
noticed during some (heavy JOSSL) `TCPServer` testing that the native channel wasn't being always closed.