### PR TITLE
Marshal load perf

### DIFF
--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
@@ -84,8 +84,8 @@ import static org.jruby.util.RubyStringBuilder.str;
  * Unmarshals objects from strings or streams in Ruby's marshal format.
  */
 public class MarshalLoader {
-    private final List<IRubyObject> links = new ArrayList<>();
-    private final List<RubySymbol> symbols = new ArrayList<>();
+    private List<IRubyObject> links;
+    private List<RubySymbol> symbols;
     private final Map<IRubyObject, IRubyObject> partials;
     private final IRubyObject proc;
     private final boolean hasProc;
@@ -759,6 +759,7 @@ public class MarshalLoader {
 
     private IRubyObject readSymbolLink(ThreadContext context, RubyInputStream in, MarshalLoader input) {
         try {
+            assert symbols != null : "symbols were found but symbols list was uninitialized";
             return symbols.get(input.unmarshalInt(context, in));
         } catch (IndexOutOfBoundsException e) {
             throw typeError(context,"bad symbol");
@@ -768,6 +769,7 @@ public class MarshalLoader {
     private IRubyObject readDataLink(ThreadContext context, RubyInputStream in, MarshalLoader input) {
         int index = input.unmarshalInt(context, in);
         try {
+            assert links != null : "links were found but links list was uninitialized";
             return links.get(index);
         } catch (IndexOutOfBoundsException e) {
             throw argumentError(context, "dump format error (unlinked, index: " + index + ")");
@@ -775,10 +777,12 @@ public class MarshalLoader {
     }
 
     private void registerDataLink(IRubyObject value) {
+        if (links == null) links = new ArrayList<>(4);
         links.add(value);
     }
 
     private void registerSymbolLink(RubySymbol value) {
+        if (symbols == null) symbols = new ArrayList<>(4);
         symbols.add(value);
     }
 }

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
@@ -209,21 +209,31 @@ public class MarshalLoader {
         if (!partial) {
             noLongerPartial(value);
             if (freeze) {
-                RubyClass metaClass = value.getMetaClass();
-                if (metaClass == stringClass(context)) {
-                    IRubyObject original = value;
-                    // FIXME: We need to modify original to be frozen but we also need it to be part of the deduped table.
-                    value = context.runtime.freezeAndDedupString((RubyString) value);
-                    if (value != original) {
-                        original.setFrozen(value.isFrozen());
-                    }
-                } else if (!value.isModule() && !value.isClass()) {
-                    value.setFrozen(true);
-                }
+                value = freezeObject(context, value);
             }
             value = postProc(context, value);
         }
 
+        return value;
+    }
+
+    private static IRubyObject freezeObject(ThreadContext context, IRubyObject value) {
+        RubyClass metaClass = value.getMetaClass();
+        if (metaClass == stringClass(context)) {
+            value = freezeString(context, value);
+        } else if (!value.isModule() && !value.isClass()) {
+            value.setFrozen(true);
+        }
+        return value;
+    }
+
+    private static IRubyObject freezeString(ThreadContext context, IRubyObject value) {
+        IRubyObject original = value;
+        // FIXME: We need to modify original to be frozen but we also need it to be part of the deduped table.
+        value = context.runtime.freezeAndDedupString((RubyString) value);
+        if (value != original) {
+            original.setFrozen(value.isFrozen());
+        }
         return value;
     }
 

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
@@ -86,8 +86,9 @@ import static org.jruby.util.RubyStringBuilder.str;
 public class MarshalLoader {
     private final List<IRubyObject> links = new ArrayList<>();
     private final List<RubySymbol> symbols = new ArrayList<>();
-    private final Map<IRubyObject, IRubyObject> partials = new IdentityHashMap<>();
+    private final Map<IRubyObject, IRubyObject> partials;
     private final IRubyObject proc;
+    private final boolean hasProc;
     private final boolean freeze;
 
     public MarshalLoader(ThreadContext context, IRubyObject proc) {
@@ -99,6 +100,8 @@ public class MarshalLoader {
         if (proc == null) proc = context.nil;
         
         this.proc = proc;
+        this.hasProc = !(proc == null || proc.isNil());
+        this.partials = hasProc ? new IdentityHashMap<>() : null;
         this.freeze = freeze;
     }
 
@@ -153,7 +156,7 @@ public class MarshalLoader {
     }
 
     private IRubyObject doCallProcForObj(ThreadContext context, IRubyObject result) {
-        if (proc == null || proc.isNil()) return result;
+        if (!hasProc) return result;
 
         return Helpers.invoke(context, proc, "call", result);
     }
@@ -733,15 +736,15 @@ public class MarshalLoader {
     }
 
     private boolean isPartialObject(IRubyObject value) {
-        return partials.containsKey(value);
+        return hasProc && partials.containsKey(value);
     }
 
     private void markAsPartialObject(IRubyObject value) {
-        partials.put(value, value);
+        if (hasProc) partials.put(value, value);
     }
 
     private void noLongerPartial(IRubyObject value) {
-        partials.remove(value);
+        if (hasProc) partials.remove(value);
     }
 
     private IRubyObject readSymbolLink(ThreadContext context, RubyInputStream in, MarshalLoader input) {

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalLoader.java
@@ -366,19 +366,19 @@ public class MarshalLoader {
     }
 
     private IRubyObject objectForFixnum(ThreadContext context, RubyInputStream in) {
-        return leave(context, RubyFixnum.unmarshalFrom(context, in, this), false);
+        return postProc(context, RubyFixnum.unmarshalFrom(context, in, this));
     }
 
     private IRubyObject objectForFalse(ThreadContext context) {
-        return leave(context, context.fals, false);
+        return postProc(context, context.fals);
     }
 
     private IRubyObject objectForTrue(ThreadContext context) {
-        return leave(context, context.tru, false);
+        return postProc(context, context.tru);
     }
 
     private IRubyObject objectForNil(ThreadContext context) {
-        return leave(context, context.nil, false);
+        return postProc(context, context.nil);
     }
 
     private IRubyObject objectForUClass(ThreadContext context, RubyInputStream in, boolean partial, List<RubyModule> extendedModules) {


### PR DESCRIPTION
Several performance improvements for Marshal.load based on the benchmark and results in jruby/jruby#9136:

* Don't perform link handling for values that don't link, like low integers.
* Avoid constructing the partials map when no proc was given.
* Simplify post-load object-freezing logic.
* Avoid allocating symbol and object links collections until needed.