### PR TITLE
[refactor] remove duplicate fallback in CallableSelector

### DIFF
--- a/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
+++ b/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
@@ -360,10 +360,7 @@ public class CallableSelector {
             if (method == null) {
                 method = findCallable(methods, AssignableOrDuckable, args);
                 if (method == null) {
-                    method = findCallable(methods, AssignableOrDuckable, args);
-                    if (method == null) {
-                        method = findCallable(methods, AssignableAndPrimitivableWithVarargs, args);
-                    }
+                    method = findCallable(methods, AssignableAndPrimitivableWithVarargs, args);
                 }
             }
         }


### PR DESCRIPTION
tried AssignableOrDuckable twice in a row before falling through