### PR TITLE
Deprecate all public RubyString constructors

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -419,14 +419,17 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (!getEncoding().isAsciiCompatible()) throw getRuntime().newEncodingCompatibilityError("ASCII incompatible encoding: " + getEncoding());
     }
 
+    @Deprecated(since = "10.1.0.0", forRemoval = true)
     public RubyString(Ruby runtime, RubyClass rubyClass) {
         this(runtime, rubyClass, ByteList.NULL_ARRAY);
     }
 
+    @Deprecated(since = "10.1.0.0", forRemoval = true)
     public RubyString(Ruby runtime, RubyClass rubyClass, CharSequence value) {
         this(runtime, rubyClass, value, UTF8);
     }
 
+    @Deprecated(since = "10.1.0.0", forRemoval = true)
     public RubyString(Ruby runtime, RubyClass rubyClass, CharSequence value, Encoding enc) {
         super(runtime, rubyClass);
         assert value != null;
@@ -451,24 +454,28 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         this.value = encodeBytelist(value, enc);
     }
 
+    @Deprecated(since = "10.1.0.0", forRemoval = true)
     public RubyString(Ruby runtime, RubyClass rubyClass, byte[] value) {
         super(runtime, rubyClass);
         assert value != null;
         this.value = new ByteList(value);
     }
 
+    @Deprecated(since = "10.1.0.0", forRemoval = true)
     public RubyString(Ruby runtime, RubyClass rubyClass, ByteList value) {
         super(runtime, rubyClass);
         assert value != null;
         this.value = value;
     }
 
+    @Deprecated(since = "10.1.0.0", forRemoval = true)
     public RubyString(Ruby runtime, RubyClass rubyClass, ByteList value, boolean objectSpace) {
         super(runtime, rubyClass, objectSpace);
         assert value != null;
         this.value = value;
     }
 
+    @Deprecated(since = "10.1.0.0", forRemoval = true)
     public RubyString(Ruby runtime, RubyClass rubyClass, ByteList value, Encoding encoding, boolean objectSpace) {
         this(runtime, rubyClass, value, objectSpace);
         value.setEncoding(encoding);


### PR DESCRIPTION
We would like to make RubyString abstract, so it can be represented more efficiently when containing a single character or a Java String. In order to do so, we need users to stop using the public constructors.

This patch deprecates all of the constructors for removal. They will not prevent compilation, but they should show up a bit more boldly and most Java editing tools will highlight them as errors.

See jruby/jruby#9369 for the attempt to abstract RubyString. This effort will be put on hold for now due to the many exposed constructors.

See jruby/jruby-openssl#355 for an example of an external library that was using these constructors directly.