### PR TITLE
Ensure the initial string has correct size

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/indy/BuildDynamicStringSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/BuildDynamicStringSite.java
@@ -504,10 +504,12 @@ public class BuildDynamicStringSite extends MutableCallSite {
         int firstStringCR = firstString.cr;
 
         // copy element bytes into a buffer initialSize wide, zeroing out the begin offset
-        byte[] bufferArray = Arrays.copyOfRange(firstStringByteList.unsafeBytes(), firstStringByteList.begin(), initialSize);
+        int firstSize = firstStringByteList.realSize();
+        byte[] bufferArray = new byte[firstSize + initialSize];
+        System.arraycopy(firstStringByteList.unsafeBytes(), firstStringByteList.begin(), bufferArray, 0, firstSize);
 
         // use element realSize for starting buffer realSize
-        ByteList bufferByteList = new ByteList(bufferArray, 0, firstStringByteList.realSize(), firstStringByteList.getEncoding(), false);
+        ByteList bufferByteList = new ByteList(bufferArray, 0, firstSize, firstStringByteList.getEncoding(), false);
 
         buffer = RubyString.newString(context.runtime, bufferByteList, firstStringCR);
         return buffer;


### PR DESCRIPTION
The initial string here was created using the size estimate from the IR, but that number does not appear to include the first string used to start the buffer. The logic then incorrectly allocated an array of initial size but used the first string's real size as the size for the ByteList. In the case reported, this resulted in the buffer ByteList containing a shorter array than the size it claimed, eventually leading to an ArrayIndexOutOfBounds error.

The change here fixes the incorrect use of the first string's real size with the buffer as well as always ensuring the buffer has enough room for that initial string plus the estimate. We will want to review how these estimates are being calculated, since it seems there's some confusion as to what is included.

Fixes #9372

See also #9046