### PR TITLE
Fix destructuring of block argument with default value

### DIFF
--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -227,7 +227,9 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
     // This should be the only argument massaging in yield.  This handles all argument conversion logic except
     // for the generic Block#yield(IRubyObject value).
     private static IRubyObject[] maybeSpreadArgs(ThreadContext context, IRubyObject[] args, Block block) {
-        return block.type != Type.LAMBDA && args.length == 1 && block.getSignature().isSpreadable() ?
+        Signature sig = block.getSignature();
+        return block.type != Type.LAMBDA && args.length == 1 && sig.isSpreadable()
+                && !(sig.opt() + sig.required() == 1 && !sig.hasRest()) ?
                 IRRuntimeHelpers.toAry(context, args) :
                 args;
     }

--- a/spec/ruby/core/basicobject/instance_exec_spec.rb
+++ b/spec/ruby/core/basicobject/instance_exec_spec.rb
@@ -36,6 +36,12 @@ describe "BasicObject#instance_exec" do
     Object.new.instance_exec(1,2) {|one, two| one + two}.should == 3
   end
 
+  describe "with optional argument" do
+    it "does not destructure a single array argument" do
+      Object.new.instance_exec([1, 2, 3]) { |a = 99| a }.should == [1, 2, 3]
+    end
+  end
+
   it "only binds the exec to the receiver" do
     f = Object.new
     f.instance_exec do

--- a/spec/ruby/core/module/shared/class_exec.rb
+++ b/spec/ruby/core/module/shared/class_exec.rb
@@ -26,4 +26,10 @@ describe :module_class_exec, shared: true do
     a = ModuleSpecs::Subclass
     a.send(@method, 1) { |b| b }.should equal(1)
   end
+
+  describe "with optional argument" do
+    it "does not destructure a single array argument" do
+      ModuleSpecs::Subclass.send(@method, [1, 2, 3]) { |a = 99| a }.should == [1, 2, 3]
+    end
+  end
 end


### PR DESCRIPTION
It fixes #9375 - incorrect behaviour found in `instance_exec`, `module_exec` and `class_exec`:

```
Object.new.instance_exec([1, 2]) { |x = :unset| x } 
=> 1
```

The fix is similar to #9211 

The alternative I considered is to maybe put that logic (`sig.opt() + sig.required() == 1 && !sig.hasRest()`) but I'm not sure it would be correct. Sounds like it, but it's not how the fix was applied in the other PR. Will be happy to change.