### PR TITLE
Make fixnum packing configurable and disable ints

### DIFF
--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -303,61 +303,239 @@ public abstract class RubyFixnum extends RubyInteger implements Constantizable, 
     private static final boolean USE_SHORT_FIXNUMS = Options.USE_SHORT_FIXNUMS.load();
     private static final boolean USE_BYTE_FIXNUMS = Options.USE_BYTE_FIXNUMS.load();
 
-    public static RubyFixnum newFixnum(Ruby runtime, long value) {
-        if (!USE_COMPACT_FIXNUMS || !USE_INT_FIXNUMS || value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
-            // long is never in cache range
+    private static final FixnumFactory FIXNUM_FACTORY;
+    static {
+        if (USE_INT_FIXNUMS || USE_BYTE_FIXNUMS) {
+            // fallback handles all configurations at runtime
+            FIXNUM_FACTORY = new FallbackFixnumFactory();
+        } else if (USE_COMPACT_FIXNUMS && USE_SHORT_FIXNUMS) {
+            if (USE_CACHE) {
+                FIXNUM_FACTORY = new LongShortCachedFixnumFactory();
+            } else {
+                FIXNUM_FACTORY = new LongShortUncachedFixnumFactory();
+            }
+        } else {
+            if (USE_CACHE) {
+                FIXNUM_FACTORY = new LongCachedFixnumFactory();
+            } else {
+                FIXNUM_FACTORY = new LongUncachedFixnumFactory();
+            }
+        }
+    }
+
+    private interface FixnumFactory {
+        RubyFixnum newFixnum(Ruby runtime, long value);
+        RubyFixnum newFixnum(Ruby runtime, int value);
+        RubyFixnum newFixnum(Ruby runtime, short value);
+        RubyFixnum newFixnum(Ruby runtime, byte value);
+        RubyFixnum newFixnumForCache(RubyClass fixnum, int value);
+    }
+
+    private static final class LongCachedFixnumFactory implements FixnumFactory {
+        public RubyFixnum newFixnum(Ruby runtime, long value) {
+            if (isInCacheRange(value)) {
+                return cachedFixnum(runtime, value);
+            }
             return new LongFixnum(runtime.getInteger(), value);
         }
-        return newFixnum(runtime, (int) value);
-    }
 
-    public static RubyFixnum newFixnum(Ruby runtime, int value) {
-        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
-        if (!USE_SHORT_FIXNUMS || value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
-            // integer is never in cache range
-            // disabled to avoid polymorphism and because it doesn't save size (https://github.com/jruby/jruby/pull/9379)
-            // return new IntFixnum(runtime.getInteger(), value);
+        public RubyFixnum newFixnum(Ruby runtime, int value) {
+            if (isInCacheRange(value)) {
+                return cachedFixnum(runtime, value);
+            }
             return new LongFixnum(runtime.getInteger(), value);
         }
-        return newFixnum(runtime, (short) value);
-    }
 
-    public static RubyFixnum newFixnum(Ruby runtime, short value) {
-        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
-        if (!USE_BYTE_FIXNUMS || value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
-            return USE_CACHE && isInCacheRange(value) ? cachedFixnum(runtime, value) : new ShortFixnum(runtime.getInteger(), value);
+        public RubyFixnum newFixnum(Ruby runtime, short value) {
+            if (isInCacheRange(value)) {
+                return cachedFixnum(runtime, value);
+            }
+            return new LongFixnum(runtime.getInteger(), value);
         }
-        return newFixnum(runtime, (byte) value);
+
+        public RubyFixnum newFixnum(Ruby runtime, byte value) {
+            if (isInCacheRange(value)) {
+                return cachedFixnum(runtime, value);
+            }
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnumForCache(RubyClass fixnum, int value) {
+            return new LongFixnum(fixnum, value);
+        }
     }
 
-    public static RubyFixnum newFixnum(Ruby runtime, byte value) {
-        if (USE_CACHE && isInCacheRange(value)) return cachedFixnum(runtime, value);
+    private static final class LongUncachedFixnumFactory implements FixnumFactory {
+        public RubyFixnum newFixnum(Ruby runtime, long value) {
+            return new LongFixnum(runtime.getInteger(), value);
+        }
 
-        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
-        if (!USE_BYTE_FIXNUMS) {
+        public RubyFixnum newFixnum(Ruby runtime, int value) {
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, short value) {
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, byte value) {
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnumForCache(RubyClass fixnum, int value) {
+            return new LongFixnum(fixnum, value);
+        }
+    }
+    
+    private static final class LongShortCachedFixnumFactory implements FixnumFactory {
+        public RubyFixnum newFixnum(Ruby runtime, long value) {
+            short shortValue = (short) value;
+            if (shortValue == value) {
+                if (isInCacheRange(shortValue)) {
+                    return cachedFixnum(runtime, shortValue);
+                }
+                return new ShortFixnum(runtime.getInteger(), shortValue);
+            }
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, int value) {
+            short shortValue = (short) value;
+            if (shortValue == value) {
+                if (isInCacheRange(shortValue)) {
+                    return cachedFixnum(runtime, shortValue);
+                }
+                return new ShortFixnum(runtime.getInteger(), shortValue);
+            }
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, short value) {
+            if (isInCacheRange(value)) {
+                return cachedFixnum(runtime, value);
+            }
             return new ShortFixnum(runtime.getInteger(), value);
         }
 
-        return new ByteFixnum(runtime.getInteger(), value);
+        public RubyFixnum newFixnum(Ruby runtime, byte value) {
+            if (isInCacheRange(value)) {
+                return cachedFixnum(runtime, value);
+            }
+            return new ShortFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnumForCache(RubyClass fixnum, int value) {
+            return new ShortFixnum(fixnum, (short) value);
+        }
+    }
+
+    private static final class LongShortUncachedFixnumFactory implements FixnumFactory {
+        public RubyFixnum newFixnum(Ruby runtime, long value) {
+            short shortValue = (short) value;
+            if (shortValue == value) {
+                return newFixnum(runtime, shortValue);
+            }
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, int value) {
+            short shortValue = (short) value;
+            if (shortValue == value) {
+                return newFixnum(runtime, shortValue);
+            }
+            return new LongFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, short value) {
+            return new ShortFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, byte value) {
+            return new ShortFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnumForCache(RubyClass fixnum, int value) {
+            return new ShortFixnum(fixnum, (short) value);
+        }
+    }
+    
+    private static final class FallbackFixnumFactory implements FixnumFactory {
+        public RubyFixnum newFixnum(Ruby runtime, long value) {
+            if (!USE_COMPACT_FIXNUMS || !USE_INT_FIXNUMS || value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
+                // long is never in cache range
+                return new LongFixnum(runtime.getInteger(), value);
+            }
+            return newFixnum(runtime, (int) value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, int value) {
+            if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
+            if (!USE_SHORT_FIXNUMS || value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
+                // integer is never in cache range
+                // disabled to avoid polymorphism and because it doesn't save size (https://github.com/jruby/jruby/pull/9379)
+                // return new IntFixnum(runtime.getInteger(), value);
+                return new LongFixnum(runtime.getInteger(), value);
+            }
+            return newFixnum(runtime, (short) value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, short value) {
+            if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
+            if (!USE_BYTE_FIXNUMS || value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
+                return USE_CACHE && isInCacheRange(value) ? cachedFixnum(runtime, value) : new ShortFixnum(runtime.getInteger(), value);
+            }
+            return newFixnum(runtime, (byte) value);
+        }
+
+        public RubyFixnum newFixnum(Ruby runtime, byte value) {
+            if (USE_CACHE && isInCacheRange(value)) return cachedFixnum(runtime, value);
+
+            if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
+            if (!USE_BYTE_FIXNUMS) {
+                return new ShortFixnum(runtime.getInteger(), value);
+            }
+
+            return new ByteFixnum(runtime.getInteger(), value);
+        }
+
+        public RubyFixnum newFixnumForCache(RubyClass fixnum, int value) {
+            if (!USE_COMPACT_FIXNUMS) return new LongFixnum(fixnum, value);
+            if (!USE_SHORT_FIXNUMS || value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
+                return new IntFixnum(fixnum, value);
+            } else if (!USE_BYTE_FIXNUMS || value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
+                return new ShortFixnum(fixnum, (short) value);
+            }
+            return new ByteFixnum(fixnum, (byte) value);
+        }
+    }
+
+    public static RubyFixnum newFixnum(Ruby runtime, long value) {
+        return FIXNUM_FACTORY.newFixnum(runtime, value);
+    }
+
+    public static RubyFixnum newFixnum(Ruby runtime, int value) {
+        return FIXNUM_FACTORY.newFixnum(runtime, value);
+    }
+
+    public static RubyFixnum newFixnum(Ruby runtime, short value) {
+        return FIXNUM_FACTORY.newFixnum(runtime, value);
+    }
+
+    public static RubyFixnum newFixnum(Ruby runtime, byte value) {
+        return FIXNUM_FACTORY.newFixnum(runtime, value);
     }
 
     private static RubyFixnum newFixnumForCache(RubyClass fixnum, int value) {
-        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(fixnum, value);
-        if (!USE_SHORT_FIXNUMS || value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
-            return new IntFixnum(fixnum, value);
-        } else if (!USE_BYTE_FIXNUMS || value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
-            return new ShortFixnum(fixnum, (short) value);
-        }
-        return new ByteFixnum(fixnum, (byte) value);
+        return FIXNUM_FACTORY.newFixnumForCache(fixnum, value);
     }
 
-    private static boolean isInCacheRange(int value) {
+    private static boolean isInCacheRange(long value) {
         return value <= CACHE_OFFSET - 1 && value >= -CACHE_OFFSET;
     }
 
-    private static RubyFixnum cachedFixnum(Ruby runtime, int value) {
+    private static RubyFixnum cachedFixnum(Ruby runtime, long value) {
         // This truncates to int but we determine above that it's in cache range
-        return runtime.fixnumCache[value + CACHE_OFFSET];
+        return runtime.fixnumCache[(int) value + CACHE_OFFSET];
     }
 
     public static RubyFixnum zero(Ruby runtime) {

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -298,8 +298,13 @@ public abstract class RubyFixnum extends RubyInteger implements Constantizable, 
         return negate(context, getValue());
     }
 
+    private static final boolean USE_COMPACT_FIXNUMS = Options.USE_COMPACT_FIXNUMS.load();
+    private static final boolean USE_INT_FIXNUMS = Options.USE_INT_FIXNUMS.load();
+    private static final boolean USE_SHORT_FIXNUMS = Options.USE_SHORT_FIXNUMS.load();
+    private static final boolean USE_BYTE_FIXNUMS = Options.USE_BYTE_FIXNUMS.load();
+
     public static RubyFixnum newFixnum(Ruby runtime, long value) {
-        if (value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
+        if (!USE_COMPACT_FIXNUMS || !USE_INT_FIXNUMS || value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
             // long is never in cache range
             return new LongFixnum(runtime.getInteger(), value);
         }
@@ -307,7 +312,8 @@ public abstract class RubyFixnum extends RubyInteger implements Constantizable, 
     }
 
     public static RubyFixnum newFixnum(Ruby runtime, int value) {
-        if (value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
+        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
+        if (!USE_SHORT_FIXNUMS || value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
             // integer is never in cache range
             // disabled to avoid polymorphism and because it doesn't save size (https://github.com/jruby/jruby/pull/9379)
             // return new IntFixnum(runtime.getInteger(), value);
@@ -317,27 +323,32 @@ public abstract class RubyFixnum extends RubyInteger implements Constantizable, 
     }
 
     public static RubyFixnum newFixnum(Ruby runtime, short value) {
-        if (value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
+        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
+        if (!USE_BYTE_FIXNUMS || value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
             return USE_CACHE && isInCacheRange(value) ? cachedFixnum(runtime, value) : new ShortFixnum(runtime.getInteger(), value);
         }
         return newFixnum(runtime, (byte) value);
     }
 
     public static RubyFixnum newFixnum(Ruby runtime, byte value) {
-        // using ShortFixnum until there's value in using ByteFixnum
-        return USE_CACHE && isInCacheRange(value) ? cachedFixnum(runtime, value) : new ShortFixnum(runtime.getInteger(), value);
+        if (USE_CACHE && isInCacheRange(value)) return cachedFixnum(runtime, value);
+
+        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(runtime.getInteger(), value);
+        if (!USE_BYTE_FIXNUMS) {
+            return new ShortFixnum(runtime.getInteger(), value);
+        }
+
+        return new ByteFixnum(runtime.getInteger(), value);
     }
 
     private static RubyFixnum newFixnumForCache(RubyClass fixnum, int value) {
-        if (value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
-            // disabled to avoid polymorphism and because it doesn't save size (https://github.com/jruby/jruby/pull/9379)
-            //return new IntFixnum(fixnum, value);
-            return new LongFixnum(fixnum, value);
-        } else if (value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
+        if (!USE_COMPACT_FIXNUMS) return new LongFixnum(fixnum, value);
+        if (!USE_SHORT_FIXNUMS || value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
+            return new IntFixnum(fixnum, value);
+        } else if (!USE_BYTE_FIXNUMS || value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
             return new ShortFixnum(fixnum, (short) value);
         }
-        // using ShortFixnum until there's value in using ByteFixnum
-        return new ShortFixnum(fixnum, (byte) value);
+        return new ByteFixnum(fixnum, (byte) value);
     }
 
     private static boolean isInCacheRange(int value) {

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -193,6 +193,13 @@ public class Options {
     public static final Option<String> GEM_HOME = string(MISCELLANEOUS, "gem.home", "The home dir where Ruby gems will be installed.");
     public static final Option<String> GEM_PATH = string(MISCELLANEOUS, "gem.path", "The path containing all dirs to search for installed Ruby gems.");
 
+    public static final Option<Boolean> USE_COMPACT_FIXNUMS = bool(MISCELLANEOUS, "fixnum.compact", true, "Allocate fixnums compactly.");
+    // int fixnums don't pack any tighter than long with current JVMs
+    public static final Option<Boolean> USE_INT_FIXNUMS = bool(MISCELLANEOUS, "fixnum.int", false, "Allocate int-range fixnums compactly.");
+    public static final Option<Boolean> USE_SHORT_FIXNUMS = bool(MISCELLANEOUS, "fixnum.short", true, "Allocate short-range fixnums compactly.");
+    // byte fixnums don't pack any tighter than short with current JVMs
+    public static final Option<Boolean> USE_BYTE_FIXNUMS = bool(MISCELLANEOUS, "fixnum.byte", false, "Allocate byte-range fixnums compactly.");
+
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");
     public static final Option<Boolean> DEBUG_LAUNCH = bool(DEBUG, "debug.launch", false, "Log externally-launched processes.");


### PR DESCRIPTION
During benchmarking I realized two things about the split fixnums:

* IntFixnum and LongFixnum are the same size, due to object alignment (i.e. having Int gains us nothing)
* Having all three types (Short, Int, and Long) can lead to wide-ranging Integer code becoming tri-morphic, which may interefere with JVM optimizations.

I created this patch to allow enabling and disabling all *four* widths of fixnum for experimentation, but having only short and long enabled by default.

I this is a WIP and I don't like how it conditionally enables the different widths. The code is far too complex. A better option would be to have fully specialized paths for each combination (possibly generated) and choose one at boot that will never again check a condition.

will land a separate patch for 10.1.0.0 that just hard disables IntFixnum to keep it minimal.