### PR TITLE
Improve IR and JVM AOT support

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -542,7 +542,7 @@ public abstract class IRScope implements ParseResult {
 
         boolean usesEval = usesEval();
 
-        for (IRScope child : getClosures()) {
+        for (IRScope child : getLexicalScopes()) {
             usesEval |= child.anyUsesEval();
         }
 


### PR DESCRIPTION
While exploring more AOT use cases, specifically for Project Leyden AOTCache support, I ran into several code forms that appear to be causing AOT-compiled JVM bytecode to fail at boot with a null scope. I originally suspected bad eval detection, which should be improved by the first commit in this PR, but other cases soon surfaced. This PR will eventually improve the coverage of the following scenarios:

* [ ] AOT compilation to JVM bytecode in as many scenarios as possible. Ideally all code can be AOT compiled, but for various reasons code containing eval was disabled in the past. I will work towrad full support, with fallback to IR AOT if there are cases that truly cannot work.
* [ ] AOT compilation to IR embedded in JVM bytecode, primarily from `jrubyc`. I do not know of current issues here, but recent bug #9378 is a strong candidate.
* [ ] This issue will also address #9319 and figure out why some form of AOT compilation for the JDK AOTCache is causing weird initialization problems in JavaProxy classes.