### PR TITLE
Shrink RubyHashLinkedBuckets

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -351,16 +351,10 @@ public class RubyHash extends RubyObject implements Map {
         public Object getKey() {
             return key;
         }
-        public Object getJavaifiedKey(){
-            return key.toJava(Object.class);
-        }
 
         @Override
         public Object getValue() {
             return value;
-        }
-        public Object getJavaifiedValue() {
-            return value.toJava(Object.class);
         }
 
         @Override
@@ -386,6 +380,16 @@ public class RubyHash extends RubyObject implements Map {
         @Override
         public int hashCode(){
             return key.hashCode() ^ value.hashCode();
+        }
+
+        @Deprecated(since = "10.1.1.0")
+        public Object getJavaifiedKey(){
+            return key.toJava(Object.class);
+        }
+
+        @Deprecated(since = "10.1.1.0")
+        public Object getJavaifiedValue() {
+            return value.toJava(Object.class);
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -63,7 +63,6 @@ import static org.jruby.api.Access.hashClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
-import static org.jruby.runtime.ThreadContext.hasKeywords;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 // Design overview:
@@ -286,28 +285,56 @@ public class RubyHash extends RubyObject implements Map {
         this.state = state;
     }
 
-    public static final class RubyHashEntry implements Map.Entry {
-        final IRubyObject key;
-        IRubyObject value;
-        RubyHashEntry next;
-        RubyHashEntry prevAdded;
-        RubyHashEntry nextAdded;
-        final int hash;
+    public static class RubyHashEntryLink {
+        RubyHash.RubyHashEntryLink prevAdded;
+        RubyHash.RubyHashEntryLink nextAdded;
+
+        int hash() {
+            // should never be called
+            throw new RuntimeException("hash() should never be called on RubyHashEntryLink");
+        }
+
+        public IRubyObject key() {
+            // should never be called
+            throw new RuntimeException("key() should never be called on RubyHashEntryLink");
+        }
+
+        IRubyObject value() {
+            // should never be called
+            throw new RuntimeException("value() should never be called on RubyHashEntryLink");
+        }
+
+        IRubyObject value(IRubyObject value) {
+            // should never be called
+            throw new RuntimeException("value(IRubyObject) should never be called on RubyHashEntryLink");
+        }
+
+        public boolean isLive() {
+            // should never be called
+            throw new RuntimeException("value() should never be called on RubyHashEntryLink");
+        }
+    }
+
+    public static final class RubyHashEntry extends RubyHashEntryLink implements Map.Entry {
+        private final IRubyObject key;
+        private IRubyObject value;
+        private RubyHashEntry next;
+        private final int hash;
 
         RubyHashEntry() {
             key = NEVER;
             hash = -1;
         }
 
-        public RubyHashEntry(int h, IRubyObject k, IRubyObject v, RubyHashEntry e, RubyHashEntry head) {
+        public RubyHashEntry(int h, IRubyObject k, IRubyObject v, RubyHashEntry e, RubyHashEntryLink head) {
             key = k;
-            value = v;
-            next = e;
+            value(v);
+            next(e);
             hash = h;
 
             if (head != null) {
-                RubyHashEntry prevAdded = head.prevAdded;
-                RubyHashEntry nextAdded = head;
+                RubyHashEntryLink prevAdded = head.prevAdded;
+                RubyHashEntryLink nextAdded = head;
 
                 this.prevAdded = prevAdded;
                 prevAdded.nextAdded = this;
@@ -319,16 +346,16 @@ public class RubyHash extends RubyObject implements Map {
 
         public RubyHashEntry(RubyHashEntry oldEntry, int newHash) {
             this.hash = newHash;
-            this.key = oldEntry.key;
-            this.value = oldEntry.value;
-            this.next = oldEntry.next;
+            this.key = oldEntry.key();
+            this.value(oldEntry.value());
+            this.next(oldEntry.next());
 
             // prevAdded is never null
-            RubyHashEntry prevAdded = oldEntry.prevAdded;
+            RubyHashEntryLink prevAdded = oldEntry.prevAdded;
             this.prevAdded = prevAdded;
             prevAdded.nextAdded = this;
 
-            RubyHashEntry nextAdded = oldEntry.nextAdded;
+            RubyHashEntryLink nextAdded = oldEntry.nextAdded;
             if (nextAdded != null) {
                 this.nextAdded = nextAdded;
                 nextAdded.prevAdded = this;
@@ -349,19 +376,19 @@ public class RubyHash extends RubyObject implements Map {
 
         @Override
         public Object getKey() {
-            return key;
+            return key();
         }
 
         @Override
         public Object getValue() {
-            return value;
+            return value();
         }
 
         @Override
         public Object setValue(Object value) {
-            IRubyObject oldValue = this.value;
+            IRubyObject oldValue = this.value();
             if (value instanceof IRubyObject) {
-                this.value = (IRubyObject)value;
+                this.value((IRubyObject)value);
             } else {
                 throw new UnsupportedOperationException("directEntrySet() doesn't support setValue for non IRubyObject instance entries, convert them manually or use entrySet() instead");
             }
@@ -373,13 +400,39 @@ public class RubyHash extends RubyObject implements Map {
             if(!(other instanceof RubyHashEntry)) return false;
             RubyHashEntry otherEntry = (RubyHashEntry)other;
 
-            return (key == otherEntry.key || key.eql(otherEntry.key)) &&
-                    (value == otherEntry.value || value.equals(otherEntry.value));
+            return (key() == otherEntry.key() || key().eql(otherEntry.key())) &&
+                    (value() == otherEntry.value() || value().equals(otherEntry.value()));
         }
 
         @Override
         public int hashCode(){
-            return key.hashCode() ^ value.hashCode();
+            return key().hashCode() ^ value().hashCode();
+        }
+
+        public IRubyObject key() {
+            return key;
+        }
+
+        IRubyObject value() {
+            return value;
+        }
+
+        IRubyObject value(IRubyObject value) {
+            IRubyObject oldValue = this.value;
+            this.value = value;
+            return oldValue;
+        }
+
+        RubyHashEntry next() {
+            return next;
+        }
+
+        void next(RubyHashEntry next) {
+            this.next = next;
+        }
+
+        int hash() {
+            return hash;
         }
 
         @Deprecated(since = "10.1.1.0")

--- a/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
+++ b/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
@@ -80,7 +80,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static org.jruby.RubyEnumerator.SizeFn;
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
@@ -141,7 +140,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     private byte hashFlags;
     private IRubyObject ifNone;
 
-    private final RubyHashLinkedBuckets.RubyHashEntry head = new RubyHashLinkedBuckets.RubyHashEntry();
+    private final RubyHashLinkedBuckets.RubyHashEntryLink head = new RubyHashLinkedBuckets.RubyHashEntryLink();
 
     @SuppressWarnings("unused")
     private volatile short iteratorCount;
@@ -313,9 +312,9 @@ public class RubyHashLinkedBuckets extends RubyHash {
             oldTable[j] = null;
 
             while (entry != null) {
-                RubyHashEntry next = entry.next;
-                int i = bucketIndex(entry.hash, newCapacity);
-                entry.next = newTable[i];
+                RubyHashEntry next = entry.next();
+                int i = bucketIndex(entry.hash(), newCapacity);
+                entry.next(newTable[i]);
                 newTable[i] = entry;
                 entry = next;
             }
@@ -386,10 +385,10 @@ public class RubyHashLinkedBuckets extends RubyHash {
         final int i = bucketIndex(hash, table.length);
 
         if (checkForExisting) {
-            for (RubyHashEntry entry = table[i]; entry != null; entry = entry.next) {
-                if (internalKeyExist(entry.hash, entry.key, hash, key)) {
-                    IRubyObject existing = entry.value;
-                    entry.value = value;
+            for (RubyHashEntry entry = table[i]; entry != null; entry = entry.next()) {
+                if (internalKeyExist(entry.hash(), entry.key(), hash, key)) {
+                    IRubyObject existing = entry.value();
+                    entry.value(value);
 
                     return existing;
                 }
@@ -408,7 +407,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     // get implementation
 
     protected IRubyObject internalGet(IRubyObject key) { // specialized for value
-        return internalGetEntry(key).value;
+        return internalGetEntry(key).value();
     }
 
     protected RubyHashEntry internalGetEntry(IRubyObject key) {
@@ -417,8 +416,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
         final int hash = hashValue(key);
         final RubyHashEntry[] table = this.getTable();
 
-        for (RubyHashEntry entry = table[bucketIndex(hash, table.length)]; entry != null; entry = entry.next) {
-            if (internalKeyExist(entry.hash, entry.key, hash, key)) {
+        for (RubyHashEntry entry = table[bucketIndex(hash, table.length)]; entry != null; entry = entry.next()) {
+            if (internalKeyExist(entry.hash(), entry.key(), hash, key)) {
                 return entry;
             }
         }
@@ -447,21 +446,21 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     protected RubyHashEntry internalDeleteEntry(final RubyHashEntry entry) {
         // n.b. we need to recompute the hash in case the key object was modified
-        return internalDelete(hashValue(entry.key), MATCH_ENTRY, entry);
+        return internalDelete(hashValue(entry.key()), MATCH_ENTRY, entry);
     }
 
-    private final RubyHashEntry internalDelete(final int hash, final EntryMatchType matchType, final Object obj) {
+    private RubyHashEntry internalDelete(final int hash, final EntryMatchType matchType, final Object obj) {
         final int i = bucketIndex(hash, getTable().length);
 
         RubyHashEntry entry = getTable()[i];
         if (entry != null) {
             RubyHashEntry prior = null;
-            for (; entry != null; prior = entry, entry = entry.next) {
-                if (entry.hash == hash && matchType.matches(entry, obj)) {
+            for (; entry != null; prior = entry, entry = entry.next()) {
+                if (entry.hash() == hash && matchType.matches(entry, obj)) {
                     if (prior != null) {
-                        prior.next = entry.next;
+                        prior.next(entry.next());
                     } else {
-                        getTable()[i] = entry.next;
+                        getTable()[i] = entry.next();
                     }
                     entry.detach();
                     size--;
@@ -488,7 +487,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     private static final EntryMatchType MATCH_KEY = new EntryMatchType() {
         @Override
         public boolean matches(final RubyHashEntry entry, final Object obj) {
-            final IRubyObject key = entry.key;
+            final IRubyObject key = entry.key();
             return obj == key || (((IRubyObject)obj).eql(key));
         }
     };
@@ -500,12 +499,12 @@ public class RubyHashLinkedBuckets extends RubyHash {
         }
     };
 
-    private final RubyHashEntry[] internalCopyTable(RubyHashEntry destHead) {
+    private final RubyHashEntry[] internalCopyTable(RubyHashEntryLink destHead) {
          RubyHashEntry[]newTable = new RubyHashEntry[getTable().length];
 
-         for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-             int i = bucketIndex(entry.hash, getTable().length);
-             newTable[i] = new RubyHashEntry(entry.hash, entry.key, entry.value, newTable[i], destHead);
+         for (RubyHashEntryLink entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+             int i = bucketIndex(entry.hash(), getTable().length);
+             newTable[i] = new RubyHashEntry(entry.hash(), entry.key(), entry.value(), newTable[i], destHead);
          }
          return newTable;
     }
@@ -514,9 +513,9 @@ public class RubyHashLinkedBuckets extends RubyHash {
         long count = size;
         int index = 0;
         // visit not more than size entries
-        for (RubyHashEntry entry = head.nextAdded; entry != head && count != 0; entry = entry.nextAdded) {
+        for (RubyHashEntryLink entry = head.nextAdded; entry != head && count != 0; entry = entry.nextAdded) {
             if (entry != null && entry.isLive()) {
-                visitor.visit(context, this, entry.key, entry.value, index++);
+                visitor.visit(context, this, entry.key(), entry.value(), index++);
                 count--;
             }
         }
@@ -535,9 +534,9 @@ public class RubyHashLinkedBuckets extends RubyHash {
         long count = size;
         int index = 0;
         // visit not more than size entries
-        for (RubyHashEntry entry = head.nextAdded; entry != head && count != 0; entry = entry.nextAdded) {
+        for (RubyHashEntryLink entry = head.nextAdded; entry != head && count != 0; entry = entry.nextAdded) {
             if (entry != null && entry.isLive()) {
-                visitor.visit(context, this, entry.key, entry.value, index++, state);
+                visitor.visit(context, this, entry.key(), entry.value(), index++, state);
                 count--;
             }
         }
@@ -549,10 +548,10 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     public <T> boolean allSymbols() {
         // visit not more than size entries
-        RubyHashEntry head = this.head;
-        for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+        RubyHashEntryLink head = this.head;
+        for (RubyHashEntryLink entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
             if (entry != null && entry.isLive()) {
-                if (!(entry.key instanceof RubySymbol)) return false;
+                if (!(entry.key() instanceof RubySymbol)) return false;
             }
         }
         return true;
@@ -889,17 +888,17 @@ public class RubyHashLinkedBuckets extends RubyHash {
             RubyHashEntry entry = oldTable[j];
             oldTable[j] = null;
             while (entry != null) {
-                RubyHashEntry next = entry.next;
-                int oldHash = entry.hash;
-                IRubyObject key = entry.key;
+                RubyHashEntry next = entry.next();
+                int oldHash = entry.hash();
+                IRubyObject key = entry.key();
                 int newHash = hashValue(key);
 
                 int i = bucketIndex(newHash, newTable.length);
 
                 RubyHashEntry newEntry = newTable[i];
-                if (newEntry != null && internalKeyExist(newEntry.hash, newEntry.key, newHash, key)) {
-                    RubyHashEntry tmpNext = entry.nextAdded;
-                    RubyHashEntry tmpPrev = entry.prevAdded;
+                if (newEntry != null && internalKeyExist(newEntry.hash(), newEntry.key(), newHash, key)) {
+                    RubyHashEntryLink tmpNext = entry.nextAdded;
+                    RubyHashEntryLink tmpPrev = entry.prevAdded;
                     tmpPrev.nextAdded = tmpNext;
                     tmpNext.prevAdded = tmpPrev;
                     size--;
@@ -911,7 +910,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
                         rehashedIndexes.add(newHash);
                     }
 
-                    entry.next = newEntry;
+                    entry.next(newEntry);
                     newTable[i] = entry;
                 }
                 entry = next;
@@ -924,20 +923,20 @@ public class RubyHashLinkedBuckets extends RubyHash {
         for (int hash : rehashedIndexes) {
             RubyHashEntry entry = getTable()[bucketIndex(hash, newTable.length)];
             while (entry != null) {
-                if (entry.hash == hash) {
-                    RubyHashEntry nextEntry = entry.next;
+                if (entry.hash() == hash) {
+                    RubyHashEntry nextEntry = entry.next();
                     while (nextEntry != null) {
-                        if (internalKeyExist(entry.hash, entry.key, nextEntry.hash, nextEntry.key)) {
-                            RubyHashEntry tmpNext = entry.nextAdded;
-                            RubyHashEntry tmpPrev = entry.prevAdded;
+                        if (internalKeyExist(entry.hash(), entry.key(), nextEntry.hash(), nextEntry.key())) {
+                            RubyHashEntryLink tmpNext = entry.nextAdded;
+                            RubyHashEntryLink tmpPrev = entry.prevAdded;
                             tmpPrev.nextAdded = tmpNext;
                             tmpNext.prevAdded = tmpPrev;
                             size--;
                         }
-                        nextEntry = nextEntry.next;
+                        nextEntry = nextEntry.next();
                     }
                 }
-                entry = entry.next;
+                entry = entry.next();
             }
         }
         return this;
@@ -1059,7 +1058,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     protected void op_asetForString(Ruby runtime, RubyString key, IRubyObject value) {
         final RubyHashEntry entry = internalGetEntry(key);
         if (entry != NULL_ENTRY) {
-            entry.value = value;
+            entry.value(value);
         } else {
             checkIterating();
 
@@ -1072,7 +1071,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     protected void op_asetSmallForString(Ruby runtime, RubyString key, IRubyObject value) {
         final RubyHashEntry entry = internalGetEntry(key);
         if (entry != NULL_ENTRY) {
-            entry.value = value;
+            entry.value(value);
         } else {
             checkIterating();
 
@@ -1735,10 +1734,10 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
         if (isEmpty()) return context.nil;
 
-        RubyHashEntry entry = head.nextAdded;
+        RubyHashEntryLink entry = head.nextAdded;
         if (entry != head) {
-            var result = newArray(context, entry.key, entry.value);
-            internalDeleteEntry(entry);
+            var result = newArray(context, entry.key(), entry.value());
+            internalDeleteEntry((RubyHashEntry) entry);
             return result;
         }
 
@@ -1773,7 +1772,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
      */
     public IRubyObject delete(IRubyObject key) {
         RubyHashEntry entry = internalDelete(key);
-        return entry != NULL_ENTRY ? entry.value : null;
+        return entry != NULL_ENTRY ? entry.value() : null;
     }
 
     public IRubyObject delete(ThreadContext context, IRubyObject key) {
@@ -2088,9 +2087,9 @@ public class RubyHashLinkedBuckets extends RubyHash {
       modify();
       iteratorEntry();
       try {
-        for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-          if (entry.value == context.nil) {
-            internalDelete(entry.key);
+        for (RubyHashEntryLink entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+          if (entry.value() == context.nil) {
+            internalDelete(entry.key());
             changed = true;
           }
         }
@@ -2152,8 +2151,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
     protected IRubyObject any_p_i(ThreadContext context, Block block) {
         iteratorEntry();
         try {
-            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-                IRubyObject newAssoc = newArray(context, entry.key, entry.value);
+            for (RubyHashEntryLink entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                IRubyObject newAssoc = newArray(context, entry.key(), entry.value());
                 if (block.yield(context, newAssoc).isTrue())
                     return context.tru;
             }
@@ -2166,8 +2165,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
     protected IRubyObject any_p_i_fast(ThreadContext context, Block block) {
         iteratorEntry();
         try {
-            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-                if (block.yieldArray(context, newArray(context, entry.key, entry.value), null).isTrue()) return context.tru;
+            for (RubyHashEntryLink entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                if (block.yieldArray(context, newArray(context, entry.key(), entry.value()), null).isTrue()) return context.tru;
             }
             return context.fals;
         } finally {
@@ -2178,8 +2177,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
     protected IRubyObject any_p_p(ThreadContext context, IRubyObject pattern) {
         iteratorEntry();
         try {
-            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-                IRubyObject newAssoc = newArray(context, entry.key, entry.value);
+            for (RubyHashEntryLink entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                IRubyObject newAssoc = newArray(context, entry.key(), entry.value());
                 if (pattern.callMethod(context, "===", newAssoc).isTrue()) return context.tru;
             }
             return context.fals;
@@ -2363,7 +2362,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     @Override
     public Object remove(Object key) {
         IRubyObject rubyKey = JavaUtil.convertJavaToUsableRubyObject(metaClass.runtime, key);
-        return internalDelete(rubyKey).value;
+        return internalDelete(rubyKey).value();
     }
 
     @Override
@@ -2518,7 +2517,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     private class BaseIterator implements Iterator {
         final private EntryView view;
-        private RubyHashEntry entry;
+        private RubyHashEntryLink entry;
         private boolean peeking;
         private int startGeneration;
 
@@ -2559,20 +2558,20 @@ public class RubyHashLinkedBuckets extends RubyHash {
             if (entry == head) {
                 throw new IllegalStateException("Iterator out of range");
             }
-            internalDeleteEntry(entry);
+            internalDeleteEntry((RubyHashEntry) entry);
         }
     }
 
     private static abstract class EntryView {
-        public abstract Object convertEntry(Ruby runtime, RubyHashEntry value);
+        public abstract Object convertEntry(Ruby runtime, RubyHashEntryLink value);
         public abstract boolean contains(RubyHashLinkedBuckets hash, Object o);
         public abstract boolean remove(RubyHashLinkedBuckets hash, Object o);
     }
 
     private static final EntryView DIRECT_KEY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
-            return entry.key;
+        public Object convertEntry(Ruby runtime, RubyHashEntryLink entry) {
+            return entry.key();
         }
         @Override
         public boolean contains(RubyHashLinkedBuckets hash, Object o) {
@@ -2588,8 +2587,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     private static final EntryView KEY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
-            return entry.key.toJava(Object.class);
+        public Object convertEntry(Ruby runtime, RubyHashEntryLink entry) {
+            return entry.key().toJava(Object.class);
         }
         @Override
         public boolean contains(RubyHashLinkedBuckets hash, Object o) {
@@ -2603,8 +2602,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     private static final EntryView DIRECT_VALUE_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
-            return entry.value;
+        public Object convertEntry(Ruby runtime, RubyHashEntryLink entry) {
+            return entry.value();
         }
         @Override
         public boolean contains(RubyHashLinkedBuckets hash, Object o) {
@@ -2624,8 +2623,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     private static final EntryView VALUE_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
-            return entry.value.toJava(Object.class);
+        public Object convertEntry(Ruby runtime, RubyHashEntryLink entry) {
+            return entry.value().toJava(Object.class);
         }
         @Override
         public boolean contains(RubyHashLinkedBuckets hash, Object o) {
@@ -2643,14 +2642,14 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     private static final EntryView DIRECT_ENTRY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+        public Object convertEntry(Ruby runtime, RubyHashEntryLink entry) {
             return entry;
         }
         @Override
         public boolean contains(RubyHashLinkedBuckets hash, Object o) {
             if (!(o instanceof RubyHashEntry)) return false;
             RubyHashEntry entry = (RubyHashEntry)o;
-            RubyHashEntry candidate = hash.internalGetEntry(entry.key);
+            RubyHashEntry candidate = hash.internalGetEntry(entry.key());
             return candidate != NULL_ENTRY && entry.equals(candidate);
         }
         @Override
@@ -2662,44 +2661,44 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     private static final EntryView ENTRY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+        public Object convertEntry(Ruby runtime, RubyHashEntryLink entry) {
             return new ConvertingEntry(runtime, entry);
         }
         @Override
         public boolean contains(RubyHashLinkedBuckets hash, Object o) {
             if (!(o instanceof ConvertingEntry)) return false;
             ConvertingEntry entry = (ConvertingEntry)o;
-            RubyHashEntry candidate = hash.internalGetEntry(entry.entry.key);
+            RubyHashEntry candidate = hash.internalGetEntry(entry.entry.key());
             return candidate != NULL_ENTRY && entry.entry.equals(candidate);
         }
         @Override
         public boolean remove(RubyHashLinkedBuckets hash, Object o) {
             if (!(o instanceof ConvertingEntry)) return false;
             ConvertingEntry entry = (ConvertingEntry)o;
-            return hash.internalDeleteEntry(entry.entry) != NULL_ENTRY;
+            return hash.internalDeleteEntry((RubyHashEntry) entry.entry) != NULL_ENTRY;
         }
     };
 
     private static class ConvertingEntry implements Entry {
-        private final RubyHashEntry entry;
+        private final RubyHashEntryLink entry;
         private final Ruby runtime;
 
-        public ConvertingEntry(Ruby runtime, RubyHashEntry entry) {
+        public ConvertingEntry(Ruby runtime, RubyHashEntryLink entry) {
             this.entry = entry;
             this.runtime = runtime;
         }
 
         @Override
         public Object getKey() {
-            return entry.key.toJava(Object.class);
+            return entry.key().toJava(Object.class);
         }
         @Override
         public Object getValue() {
-            return entry.value.toJava(Object.class);
+            return entry.value().toJava(Object.class);
         }
         @Override
         public Object setValue(Object o) {
-            return entry.setValue(JavaUtil.convertJavaToUsableRubyObject(runtime, o));
+            return entry.value(JavaUtil.convertJavaToUsableRubyObject(runtime, o));
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
+++ b/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
@@ -68,6 +68,8 @@ import org.jruby.util.io.RubyInputStream;
 import org.jruby.util.io.RubyOutputStream;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
@@ -140,6 +142,20 @@ public class RubyHashLinkedBuckets extends RubyHash {
     private IRubyObject ifNone;
 
     private final RubyHashLinkedBuckets.RubyHashEntry head = new RubyHashLinkedBuckets.RubyHashEntry();
+
+    @SuppressWarnings("unused")
+    private volatile short iteratorCount;
+
+    private static final VarHandle ITERATOR_UPDATER;
+    static {
+        VarHandle iterUp;
+        try {
+            iterUp = MethodHandles.lookup().findVarHandle(RubyHashLinkedBuckets.class, "iteratorCount", short.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        ITERATOR_UPDATER = iterUp;
+    }
 
     RubyHashLinkedBuckets(Ruby runtime, RubyClass klass, RubyHash other) {
         super(runtime, klass, true, 0);
@@ -1380,41 +1396,12 @@ public class RubyHashLinkedBuckets extends RubyHash {
         return asBoolean(context, hasValue(context, expected));
     }
 
-    private volatile int iteratorCount;
-
-    private static final AtomicIntegerFieldUpdater<RubyHashLinkedBuckets> ITERATOR_UPDATER;
-    static {
-        AtomicIntegerFieldUpdater<RubyHashLinkedBuckets> iterUp = null;
-        try {
-            iterUp = AtomicIntegerFieldUpdater.newUpdater(RubyHashLinkedBuckets.class, "iteratorCount");
-        } catch (Exception e) {
-            // ignore, leave null
-        }
-        ITERATOR_UPDATER = iterUp;
-    }
-
     private void iteratorEntry() {
-        if (ITERATOR_UPDATER == null) {
-            iteratorEntrySync();
-            return;
-        }
-        ITERATOR_UPDATER.incrementAndGet(this);
+        ITERATOR_UPDATER.getAndAdd(this, (short) 1);
     }
 
     private void iteratorExit() {
-        if (ITERATOR_UPDATER == null) {
-            iteratorExitSync();
-            return;
-        }
-        ITERATOR_UPDATER.decrementAndGet(this);
-    }
-
-    private synchronized void iteratorEntrySync() {
-        ++iteratorCount;
-    }
-
-    private synchronized void iteratorExitSync() {
-        --iteratorCount;
+        ITERATOR_UPDATER.getAndAdd(this, (short) -1);
     }
 
     private void iteratorVisitAll(ThreadContext context, VisitorWithStateI visitor) {

--- a/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
+++ b/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
@@ -92,7 +92,6 @@ import static org.jruby.api.Error.runtimeError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ThreadContext.hasKeywords;
-import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.Inspector.EMPTY_HASH_BL;
 import static org.jruby.util.Inspector.RECURSIVE_HASH_BL;
@@ -135,8 +134,7 @@ import static org.jruby.util.Inspector.RECURSIVE_HASH_BL;
  */
 @JRubyClass(name = "Hash", include="Enumerable")
 public class RubyHashLinkedBuckets extends RubyHash {
-    protected int size = 0;
-    private int threshold;
+    protected int size;
 
     private byte hashFlags;
     private IRubyObject ifNone;
@@ -183,7 +181,6 @@ public class RubyHashLinkedBuckets extends RubyHash {
     protected RubyHashLinkedBuckets(Ruby runtime, RubyClass metaClass, IRubyObject defaultValue, RubyHashEntry[] initialTable, int threshold) {
         super(runtime, metaClass, true, 0);
         this.ifNone = defaultValue;
-        this.threshold = threshold;
         this.setTable(initialTable);
     }
 
@@ -214,7 +211,6 @@ public class RubyHashLinkedBuckets extends RubyHash {
 
     private static void copyFrom(RubyHashLinkedBuckets self, RubyHash other, boolean identity) {
         if (other instanceof RubyHashLinkedBuckets lbOther) {
-            self.threshold = lbOther.threshold;
             self.setTable(lbOther.internalCopyTable(self.head));
             self.size = other.size();
         }
@@ -254,18 +250,16 @@ public class RubyHashLinkedBuckets extends RubyHash {
         return (hashFlags & flag) != 0;
     }
 
-    private final void allocFirst() {
-        threshold = INITIAL_THRESHOLD;
-        setTable(new RubyHashEntry[MRI_HASH_RESIZE ? MRI_INITIAL_CAPACITY : JAVASOFT_INITIAL_CAPACITY]);
+    private void allocFirst() {
+        setTable(new RubyHashEntry[MRI_INITIAL_CAPACITY]);
     }
 
-    private final void allocFirst(int buckets) {
+    private void allocFirst(int buckets) {
         if (buckets <= 0) throw new ArrayIndexOutOfBoundsException("invalid bucket size: " + buckets);
-        threshold = INITIAL_THRESHOLD;
         setTable(new RubyHashEntry[buckets]);
     }
 
-    private final void alloc() {
+    private void alloc() {
         head.prevAdded = head.nextAdded = head;
         allocFirst();
     }
@@ -283,33 +277,18 @@ public class RubyHashLinkedBuckets extends RubyHash {
         134217728 + 29, 268435456 + 3, 536870912 + 11, 1073741824 + 85, 0
     };
 
-    private static final int JAVASOFT_INITIAL_CAPACITY = 8; // 16 ?
     private static final int MRI_INITIAL_CAPACITY = MRI_PRIMES[0];
 
-    private static final int INITIAL_THRESHOLD = JAVASOFT_INITIAL_CAPACITY - (JAVASOFT_INITIAL_CAPACITY >> 2);
-    private static final int MAXIMUM_CAPACITY = 1 << 30;
 
     { head.prevAdded = head.nextAdded = head; }
-
-    private static int JavaSoftHashValue(int h) {
-        h ^= (h >>> 20) ^ (h >>> 12);
-        return h ^ (h >>> 7) ^ (h >>> 4);
-    }
-
-    private static int JavaSoftBucketIndex(final int h, final int length) {
-        return h & (length - 1);
-    }
 
     private static int MRIHashValue(int h) {
         return h & HASH_SIGN_BIT_MASK;
     }
 
     private static final int HASH_SIGN_BIT_MASK = ~(1 << 31);
-    private static int MRIBucketIndex(final int h, final int length) {
-        return ((h & HASH_SIGN_BIT_MASK) % length);
-    }
 
-    private final synchronized void resize(int newCapacity) {
+    private synchronized void resize(int newCapacity) {
         final RubyHashEntry[] oldTable = getTable();
         final RubyHashEntry[] newTable = new RubyHashEntry[newCapacity];
 
@@ -329,30 +308,19 @@ public class RubyHashLinkedBuckets extends RubyHash {
         setTable(newTable);
     }
 
-    private final void JavaSoftCheckResize() {
-        if (overThreshold()) {
-            RubyHashEntry[] tbl = getTable();
-            if (tbl.length == MAXIMUM_CAPACITY) {
-                threshold = Integer.MAX_VALUE;
-                return;
-            }
-            resizeAndAdjustThreshold(getTable());
-        }
-    }
-
-    private boolean overThreshold() {
-        return size > threshold;
-    }
-
-    private void resizeAndAdjustThreshold(RubyHashEntry[] oldTable) {
-        int newCapacity = oldTable.length << 1;
-        resize(newCapacity);
-        threshold = newCapacity - (newCapacity >> 2);
-    }
-
     private static final int MIN_CAPA = 8;
     private static final int ST_DEFAULT_MAX_DENSITY = 2;
-    private final void MRICheckResize() {
+
+    protected final int hashValue(final IRubyObject key) {
+        final int h = isComparedByIdentity() ? System.identityHashCode(key) : key.hashCode();
+        return MRIHashValue(h);
+    }
+
+    private static int bucketIndex(final int h, final int length) {
+        return ((h & HASH_SIGN_BIT_MASK) % length);
+    }
+
+    private void checkResize() {
         if (size / getTable().length > ST_DEFAULT_MAX_DENSITY) {
             int forSize = getTable().length + 1; // size + 1;
             for (int i=0, newCapacity = MIN_CAPA; i < MRI_PRIMES.length; i++, newCapacity <<= 1) {
@@ -361,24 +329,8 @@ public class RubyHashLinkedBuckets extends RubyHash {
                     return;
                 }
             }
-            return; // suboptimal for large hashes (> 1073741824 + 85 entries) not very likely to happen
+            // suboptimal for large hashes (> 1073741824 + 85 entries) not very likely to happen
         }
-    }
-    // ------------------------------
-    private static final boolean MRI_HASH = true;
-    private static final boolean MRI_HASH_RESIZE = true;
-
-    protected final int hashValue(final IRubyObject key) {
-        final int h = isComparedByIdentity() ? System.identityHashCode(key) : key.hashCode();
-        return MRI_HASH ? MRIHashValue(h) : JavaSoftHashValue(h);
-    }
-
-    private static int bucketIndex(final int h, final int length) {
-        return MRI_HASH ? MRIBucketIndex(h, length) : JavaSoftBucketIndex(h, length);
-    }
-
-    private void checkResize() {
-        if (MRI_HASH_RESIZE) MRICheckResize(); else JavaSoftCheckResize();
     }
 
     protected final void checkIterating() {

--- a/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
+++ b/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
@@ -141,7 +141,6 @@ public class RubyHashLinkedBuckets extends RubyHash {
     private byte hashFlags;
     private IRubyObject ifNone;
 
-    private int generation = 0; // generation count for O(1) clears
     private final RubyHashLinkedBuckets.RubyHashEntry head = new RubyHashLinkedBuckets.RubyHashEntry();
 
     RubyHashLinkedBuckets(Ruby runtime, RubyClass klass, RubyHash other) {
@@ -267,7 +266,6 @@ public class RubyHashLinkedBuckets extends RubyHash {
     }
 
     private final void alloc() {
-        generation++;
         head.prevAdded = head.nextAdded = head;
         allocFirst();
     }
@@ -545,16 +543,10 @@ public class RubyHashLinkedBuckets extends RubyHash {
     }
 
     public <T> void visitAll(ThreadContext context, VisitorWithStateI visitor) {
-        int startGeneration = generation;
         long count = size;
         int index = 0;
         // visit not more than size entries
         for (RubyHashEntry entry = head.nextAdded; entry != head && count != 0; entry = entry.nextAdded) {
-            if (startGeneration != generation) {
-                startGeneration = generation;
-                entry = head.nextAdded;
-                if (entry == head) break;
-            }
             if (entry != null && entry.isLive()) {
                 visitor.visit(context, this, entry.key, entry.value, index++);
                 count--;
@@ -572,16 +564,10 @@ public class RubyHashLinkedBuckets extends RubyHash {
     }
 
     protected <T> void visitLimited(ThreadContext context, VisitorWithState visitor, long size, T state) {
-        int startGeneration = generation;
         long count = size;
         int index = 0;
         // visit not more than size entries
         for (RubyHashEntry entry = head.nextAdded; entry != head && count != 0; entry = entry.nextAdded) {
-            if (startGeneration != generation) {
-                startGeneration = generation;
-                entry = head.nextAdded;
-                if (entry == head) break;
-            }
             if (entry != null && entry.isLive()) {
                 visitor.visit(context, this, entry.key, entry.value, index++, state);
                 count--;
@@ -594,15 +580,9 @@ public class RubyHashLinkedBuckets extends RubyHash {
     }
 
     public <T> boolean allSymbols() {
-        int startGeneration = generation;
         // visit not more than size entries
         RubyHashEntry head = this.head;
         for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-            if (startGeneration != generation) {
-                startGeneration = generation;
-                entry = head.nextAdded;
-                if (entry == head) break;
-            }
             if (entry != null && entry.isLive()) {
                 if (!(entry.key instanceof RubySymbol)) return false;
             }
@@ -2606,16 +2586,11 @@ public class RubyHashLinkedBuckets extends RubyHash {
         public BaseIterator(EntryView view) {
             this.view = view;
             this.entry = head;
-            this.startGeneration = generation;
         }
 
         private void advance(boolean consume) {
             if (!peeking) {
                 do {
-                    if (startGeneration != generation) {
-                        startGeneration = generation;
-                        entry = head;
-                    }
                     entry = entry.nextAdded;
                 } while (entry != head && !entry.isLive());
             }

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -52,7 +52,6 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.TypeError;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.Block;
 import org.jruby.runtime.Builtins;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.Helpers;
@@ -60,7 +59,6 @@ import org.jruby.runtime.JavaSites.TimeSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.util.ByteList;
 import org.jruby.util.RubyDateFormatter;
 import org.jruby.util.RubyTimeParser;
@@ -102,7 +100,6 @@ import static org.jruby.runtime.ThreadContext.hasKeywords;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.invokedynamic.MethodNames.OP_CMP;
 import static org.jruby.util.RubyStringBuilder.str;
-import static org.jruby.util.TypeConverter.typeAsString;
 
 /** The Time class.
  *
@@ -166,11 +163,11 @@ public class RubyTime extends RubyObject {
         }
         
         RubyHash.RubyHashEntry entry = context.runtime.getENV().getEntry(tz);
-        if (entry.key == null || entry.key == NEVER) return null; // NO_ENTRY
+        if (entry.key() == null || entry.key() == NEVER) return null; // NO_ENTRY
 
-        if (entry.key != tz) context.runtime.tzVar = (RubyString) entry.key;
+        if (entry.key() != tz) context.runtime.tzVar = (RubyString) entry.key();
 
-        return (entry.value instanceof RubyString) ? entry.value.asJavaString() : null;
+        return (entry.value() instanceof RubyString) ? entry.value().asJavaString() : null;
     }
 
     @Deprecated(since = "10.0.0.0")


### PR DESCRIPTION
This started out as an experiment to remove the "generation" count that appeared to only be used for some rehashing heuristics, and expanded to an overall reduction of Hash size (based on the RubyHashLinkedBuckets implementation).

Changes
---------

* generation count (4 bytes) is removed, as it did not appear to be doing anything useful that other fields didn't handle. See previous discussion below.
* threshold (4 bytes) was removed, as it was only used by the "Javasoft" hash strategy that has been disabled forever.
* iteratorCount (4 bytes) is reduced to 2 bytes, as there's no reason to be able to accommodate 2^32 concurrent iterators.
* The "head" entry is reduced by 32 bytes by introducing a base entry link type, since it only needed to track next and previous added entries.

These changes reduce the retained size of an empty hash from 160 bytes (in 10.1.0.0) to 136 bytes.

On generation count
---------------------

This generation count did not appear to actually be doing anything useful, only being incremented on rehash and only used to follow a slightly different path for clearing the Hash instance. Removing it does not appear to affect functionality, and it was a 32-bit integer increasing the size of every linked-bucket Hash object in the system.

It is a relic of old ported code from CRuby and I'm not sure we need it now (or perhaps ever needed it).