### PR TITLE
Fix missing warn call from parser

### DIFF
--- a/spec/tags/ruby/core/warning/warn_tags.txt
+++ b/spec/tags/ruby/core/warning/warn_tags.txt
@@ -5,4 +5,3 @@ fails:Warning.warn doesn't print message when category is :strict_unused_block b
 windows:Warning.warn does not add a newline
 windows:Warning.warn returns nil
 windows:Warning.warn can be overridden
-fails:Warning.warn is called by parser warnings


### PR DESCRIPTION
This spec was tagged for the 10.1.0.0 release because it's not particularly important. This PR will restore the missing Warning.warn call from the parser after release when we have time to look into it further.

Initially based on wasm_prism branch but should be rebased to master after #9374 has been merged.