### PR TITLE
Fixes #9384. Set.new(a_set) throws LocalJumpError

### DIFF
--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -258,7 +258,8 @@ public class RubySet extends RubyObject implements Set {
         } else if (enume instanceof RubySet set) {
             allocHash(context, set.size());
             for ( IRubyObject elem : set.elementsOrdered() ) {
-                invokeAdd(context, block.yield(context, elem));
+                if (block.isGiven()) elem = block.yield(context, elem);
+                invokeAdd(context, elem);
             }
             return set; // done
         } else {

--- a/spec/ruby/core/set/initialize_spec.rb
+++ b/spec/ruby/core/set/initialize_spec.rb
@@ -64,6 +64,22 @@ describe "Set#initialize" do
     s.size.should eql(0)
   end
 
+  it "should initialize with set" do
+    o = Set.new([1, 2])
+    s = Set.new(o)
+    s.size.should eql(2)
+    s.should include(1)
+    s.should include(2)
+  end
+
+  it "should initialize with set and block" do
+    o = Set.new([1, 2])
+    s = Set.new(o) { |e| e + 2 }
+    s.size.should eql(2)
+    s.should include(3)
+    s.should include(4)
+  end
+
   it "should initialize with just block" do
     s = Set.new { |x| x * x }
     s.size.should eql(0)


### PR DESCRIPTION
Simple fix.  Added some specs to catch this.  Same logic as Array case should be used by Set as well.