### PR TITLE
[9.4] deps(stdlib): bump erb from 2.2.3 to 4.0.4.1 to resolve CVE-2026-41316

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -41,7 +41,7 @@ default_gems = [
   ['digest', '3.1.0'],
   ['drb', '2.1.0'],
   ['english', '0.7.1'],
-  ['erb', '2.2.3'],
+  ['erb', '4.0.4.1'],
   ['error_highlight', '0.3.0'],
   # https://github.com/ruby/etc/issues/19
   # ['etc', '1.3.0'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -228,7 +228,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>erb</artifactId>
-      <version>2.2.3</version>
+      <version>4.0.4.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1106,7 +1106,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/digest-3.1.0*</include>
           <include>specifications/drb-2.1.0*</include>
           <include>specifications/english-0.7.1*</include>
-          <include>specifications/erb-2.2.3*</include>
+          <include>specifications/erb-4.0.4.1*</include>
           <include>specifications/error_highlight-0.3.0*</include>
           <include>specifications/ffi-1.16.3*</include>
           <include>specifications/fiddle-1.1.4*</include>
@@ -1186,7 +1186,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/digest-3.1.0*/**/*</include>
           <include>gems/drb-2.1.0*/**/*</include>
           <include>gems/english-0.7.1*/**/*</include>
-          <include>gems/erb-2.2.3*/**/*</include>
+          <include>gems/erb-4.0.4.1*/**/*</include>
           <include>gems/error_highlight-0.3.0*/**/*</include>
           <include>gems/ffi-1.16.3*/**/*</include>
           <include>gems/fiddle-1.1.4*/**/*</include>
@@ -1266,7 +1266,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/digest-3.1.0*</include>
           <include>cache/drb-2.1.0*</include>
           <include>cache/english-0.7.1*</include>
-          <include>cache/erb-2.2.3*</include>
+          <include>cache/erb-4.0.4.1*</include>
           <include>cache/error_highlight-0.3.0*</include>
           <include>cache/ffi-1.16.3*</include>
           <include>cache/fiddle-1.1.4*</include>

--- a/test/mri/erb/test_erb.rb
+++ b/test/mri/erb/test_erb.rb
@@ -73,12 +73,28 @@ class TestERB < Test::Unit::TestCase
     assert_equal("", ERB::Util.html_escape(""))
     assert_equal("abc", ERB::Util.html_escape("abc"))
     assert_equal("&lt;&lt;", ERB::Util.html_escape("<\<"))
+    assert_equal("&#39;&amp;&quot;&gt;&lt;", ERB::Util.html_escape("'&\"><"))
 
     assert_equal("", ERB::Util.html_escape(nil))
     assert_equal("123", ERB::Util.html_escape(123))
   end
 
+  def test_html_escape_to_s
+    object = Object.new
+    def object.to_s
+      "object"
+    end
+    assert_equal("object", ERB::Util.html_escape(object))
+  end
+
+  def test_html_escape_extension
+    assert_nil(ERB::Util.method(:html_escape).source_location)
+  end if RUBY_ENGINE == 'ruby'
+
   def test_concurrent_default_binding
+    # This test randomly fails with JRuby -- NameError: undefined local variable or method `template2'
+    pend if RUBY_ENGINE == 'jruby'
+
     template1 = 'one <%= ERB.new(template2).result %>'
 
     eval 'template2 = "two"', TOPLEVEL_BINDING
@@ -236,6 +252,8 @@ EOS
   end
 
   def test_invalid_trim_mode
+    pend if RUBY_ENGINE == 'truffleruby'
+
     assert_warning(/#{__FILE__}:#{__LINE__ + 1}/) do
       @erb.new("", trim_mode: 'abc-def')
     end
@@ -694,6 +712,45 @@ EOS
     erb.instance_variable_set(:@_init, true)
     erb = Marshal.load(Marshal.dump(erb))
     assert_raise(ArgumentError) {erb.result}
+  end
+
+  def test_prohibited_marshal_load_def_method
+    erb = ERB.allocate
+    erb.instance_variable_set(:@src, "")
+    erb.instance_variable_set(:@lineno, 1)
+    erb.instance_variable_set(:@_init, true)
+    erb = Marshal.load(Marshal.dump(erb))
+    assert_raise(ArgumentError) {erb.def_method(Class.new, 'render')}
+  end
+
+  def test_prohibited_marshal_load_def_module
+    erb = ERB.allocate
+    erb.instance_variable_set(:@src, "")
+    erb.instance_variable_set(:@lineno, 1)
+    erb.instance_variable_set(:@_init, true)
+    erb = Marshal.load(Marshal.dump(erb))
+    assert_raise(ArgumentError) {erb.def_module}
+  end
+
+  def test_prohibited_marshal_load_def_class
+    erb = ERB.allocate
+    erb.instance_variable_set(:@src, "")
+    erb.instance_variable_set(:@lineno, 1)
+    erb.instance_variable_set(:@_init, true)
+    erb = Marshal.load(Marshal.dump(erb))
+    assert_raise(ArgumentError) {erb.def_class}
+  end
+
+  def test_multi_line_comment_lineno
+    erb = ERB.new(<<~EOS)
+      <%= __LINE__ %>
+      <%#
+      %><%= __LINE__ %>
+    EOS
+    assert_equal <<~EOS, erb.result
+      1
+      3
+    EOS
   end
 end
 

--- a/test/mri/erb/test_erb_command.rb
+++ b/test/mri/erb/test_erb_command.rb
@@ -4,27 +4,17 @@ require 'test/unit'
 
 class TestErbCommand < Test::Unit::TestCase
   def test_var
-    assert_in_out_err(["-I#{File.expand_path('../../lib', __dir__)}", "-w",
+    pend if RUBY_ENGINE == 'truffleruby'
+    assert_in_out_err(["-I#{File.expand_path('../../lib', __dir__)}",
                        File.expand_path("../../libexec/erb", __dir__),
                        "var=hoge"],
                       "<%=var%>", ["hoge"])
   end
 
   def test_template_file_encoding
-    assert_in_out_err(["-I#{File.expand_path('../../lib', __dir__)}", "-w",
+    pend if RUBY_ENGINE == 'truffleruby'
+    assert_in_out_err(["-I#{File.expand_path('../../lib', __dir__)}",
                        File.expand_path("../../libexec/erb", __dir__)],
                       "<%=''.encoding.to_s%>", ["UTF-8"])
-  end
-
-  # These interfaces will be removed at Ruby 2.7.
-  def test_deprecated_option
-    warnings = [
-      "warning: -S option of erb command is deprecated. Please do not use this.",
-      /\n.+\/libexec\/erb:\d+: warning: Passing safe_level with the 2nd argument of ERB\.new is deprecated\. Do not use it, and specify other arguments as keyword arguments\.\n/,
-    ]
-    assert_in_out_err(["-I#{File.expand_path('../../lib', __dir__)}", "-w",
-                       File.expand_path("../../libexec/erb", __dir__),
-                       "-S", "0"],
-                      "hoge", ["hoge"], warnings)
   end
 end


### PR DESCRIPTION
2.2.3 is EOL from CRuby perspective, so they will not backport the fix to a maintained gem (I [asked](https://github.com/ruby/erb/pull/114#issuecomment-4293182677)).

This thus deviates from the CRuby 3.1 stdlib version and bumps to 4.0.4.1 (as bundled with Ruby 3.4.x, maintained at https://github.com/ruby/erb/tree/ruby-3.4).

This still has Ruby 2.7 compatibility and the two relevant "breaking" changes seem innocuous: https://github.com/ruby/erb/blob/ruby-3.4/NEWS.md (Drop deprecated -S option from command / Bump `required-ruby_version` to Ruby 2.7+)

My only open question with this is whether the gem extension stub introduced in erb `4.0.x` is a problem, since this did not exist with `2.2.3`. Is something like https://github.com/jruby/jruby/pull/9289 needed for `9.4` - even though it's not there currently?