### PR TITLE
deps(stdlib): bump erb from 6.0.1 to 6.0.1.1 to resolve CVE-2026-41316

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -31,7 +31,7 @@ default_gems = [
   ['digest', '3.2.1'],
   ['english', '0.8.1'],
   # Ongoing discussion about the -java gem, since it just omits the ext: https://github.com/ruby/erb/issues/52
-  ['erb', '6.0.1'],
+  ['erb', '6.0.1.1'],
   ['error_highlight', '0.7.1'],
   # https://github.com/ruby/etc/issues/19
   # ['etc', '1.4.6'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -125,7 +125,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>erb</artifactId>
-      <version>6.0.1</version>
+      <version>6.0.1.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1151,7 +1151,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/did_you_mean-2.0.0*</include>
           <include>specifications/digest-3.2.1*</include>
           <include>specifications/english-0.8.1*</include>
-          <include>specifications/erb-6.0.1*</include>
+          <include>specifications/erb-6.0.1.1*</include>
           <include>specifications/error_highlight-0.7.1*</include>
           <include>specifications/ffi-1.17.0*</include>
           <include>specifications/fiddle-1.1.8*</include>
@@ -1235,7 +1235,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/did_you_mean-2.0.0*/**/*</include>
           <include>gems/digest-3.2.1*/**/*</include>
           <include>gems/english-0.8.1*/**/*</include>
-          <include>gems/erb-6.0.1*/**/*</include>
+          <include>gems/erb-6.0.1.1*/**/*</include>
           <include>gems/error_highlight-0.7.1*/**/*</include>
           <include>gems/ffi-1.17.0*/**/*</include>
           <include>gems/fiddle-1.1.8*/**/*</include>
@@ -1319,7 +1319,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/did_you_mean-2.0.0*</include>
           <include>cache/digest-3.2.1*</include>
           <include>cache/english-0.8.1*</include>
-          <include>cache/erb-6.0.1*</include>
+          <include>cache/erb-6.0.1.1*</include>
           <include>cache/error_highlight-0.7.1*</include>
           <include>cache/ffi-1.17.0*</include>
           <include>cache/fiddle-1.1.8*</include>
@@ -1403,7 +1403,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>extensions/universal-java/4.0.0/did_you_mean-2.0.0/*</include>
           <include>extensions/universal-java/4.0.0/digest-3.2.1/*</include>
           <include>extensions/universal-java/4.0.0/english-0.8.1/*</include>
-          <include>extensions/universal-java/4.0.0/erb-6.0.1/*</include>
+          <include>extensions/universal-java/4.0.0/erb-6.0.1.1/*</include>
           <include>extensions/universal-java/4.0.0/error_highlight-0.7.1/*</include>
           <include>extensions/universal-java/4.0.0/ffi-1.17.0/*</include>
           <include>extensions/universal-java/4.0.0/fiddle-1.1.8/*</include>

--- a/test/mri/erb/test_erb.rb
+++ b/test/mri/erb/test_erb.rb
@@ -664,6 +664,33 @@ EOS
     assert_raise(ArgumentError) {erb.result}
   end
 
+  def test_prohibited_marshal_load_def_method
+    erb = ERB.allocate
+    erb.instance_variable_set(:@src, "")
+    erb.instance_variable_set(:@lineno, 1)
+    erb.instance_variable_set(:@_init, true)
+    erb = Marshal.load(Marshal.dump(erb))
+    assert_raise(ArgumentError) {erb.def_method(Class.new, 'render')}
+  end
+
+  def test_prohibited_marshal_load_def_module
+    erb = ERB.allocate
+    erb.instance_variable_set(:@src, "")
+    erb.instance_variable_set(:@lineno, 1)
+    erb.instance_variable_set(:@_init, true)
+    erb = Marshal.load(Marshal.dump(erb))
+    assert_raise(ArgumentError) {erb.def_module}
+  end
+
+  def test_prohibited_marshal_load_def_class
+    erb = ERB.allocate
+    erb.instance_variable_set(:@src, "")
+    erb.instance_variable_set(:@lineno, 1)
+    erb.instance_variable_set(:@_init, true)
+    erb = Marshal.load(Marshal.dump(erb))
+    assert_raise(ArgumentError) {erb.def_class}
+  end
+
   def test_multi_line_comment_lineno
     erb = ERB.new(<<~EOS)
       <%= __LINE__ %>


### PR DESCRIPTION
MRI tests synced as at https://github.com/ruby/erb/commit/93450765b5319cfb552a3d9719df137e8fbb75e9