### PR TITLE
[10.0] [deps] bump jruby-openssl to 0.16.0

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -52,7 +52,7 @@ default_gems = [
   ['irb', '1.14.3'],
   ['jar-dependencies', '0.5.4'],
   ['jruby-readline', '1.3.7'],
-  ['jruby-openssl', '0.15.6'],
+  ['jruby-openssl', '0.16.0'],
   ['json', '2.16.0'],
   ['logger', '1.6.4'],
   ['net-http', '0.6.0'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -320,7 +320,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.15.6</version>
+      <version>0.16.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1166,7 +1166,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/irb-1.14.3*</include>
           <include>specifications/jar-dependencies-0.5.4*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
-          <include>specifications/jruby-openssl-0.15.6*</include>
+          <include>specifications/jruby-openssl-0.16.0*</include>
           <include>specifications/json-2.16.0*</include>
           <include>specifications/logger-1.6.4*</include>
           <include>specifications/net-http-0.6.0*</include>
@@ -1250,7 +1250,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/irb-1.14.3*/**/*</include>
           <include>gems/jar-dependencies-0.5.4*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
-          <include>gems/jruby-openssl-0.15.6*/**/*</include>
+          <include>gems/jruby-openssl-0.16.0*/**/*</include>
           <include>gems/json-2.16.0*/**/*</include>
           <include>gems/logger-1.6.4*/**/*</include>
           <include>gems/net-http-0.6.0*/**/*</include>
@@ -1334,7 +1334,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/irb-1.14.3*</include>
           <include>cache/jar-dependencies-0.5.4*</include>
           <include>cache/jruby-readline-1.3.7*</include>
-          <include>cache/jruby-openssl-0.15.6*</include>
+          <include>cache/jruby-openssl-0.16.0*</include>
           <include>cache/json-2.16.0*</include>
           <include>cache/logger-1.6.4*</include>
           <include>cache/net-http-0.6.0*</include>
@@ -1418,7 +1418,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>extensions/universal-java/3.4.0/irb-1.14.3/*</include>
           <include>extensions/universal-java/3.4.0/jar-dependencies-0.5.4/*</include>
           <include>extensions/universal-java/3.4.0/jruby-readline-1.3.7/*</include>
-          <include>extensions/universal-java/3.4.0/jruby-openssl-0.15.6/*</include>
+          <include>extensions/universal-java/3.4.0/jruby-openssl-0.16.0/*</include>
           <include>extensions/universal-java/3.4.0/json-2.16.0/*</include>
           <include>extensions/universal-java/3.4.0/logger-1.6.4/*</include>
           <include>extensions/universal-java/3.4.0/net-http-0.6.0/*</include>


### PR DESCRIPTION
Backport/cherry-pick of https://github.com/jruby/jruby/pull/9386 ; mainly to get security fixes from https://github.com/jruby/jruby-openssl/pull/360 