### PR TITLE
[9.4] [deps] bump jruby-openssl to 0.16.0

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -62,7 +62,7 @@ default_gems = [
   ['irb', '1.4.2'],
   ['jar-dependencies', '0.5.4'],
   ['jruby-readline', '1.3.7'],
-  ['jruby-openssl', '0.15.5'],
+  ['jruby-openssl', '0.16.0'],
   ['json', '2.7.1'],
   ['logger', '1.5.1'],
   ['mutex_m', '0.1.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -410,7 +410,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.15.5</version>
+      <version>0.16.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1120,7 +1120,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/irb-1.4.2*</include>
           <include>specifications/jar-dependencies-0.5.4*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
-          <include>specifications/jruby-openssl-0.15.5*</include>
+          <include>specifications/jruby-openssl-0.16.0*</include>
           <include>specifications/json-2.7.1*</include>
           <include>specifications/logger-1.5.1*</include>
           <include>specifications/mutex_m-0.1.1*</include>
@@ -1200,7 +1200,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/irb-1.4.2*/**/*</include>
           <include>gems/jar-dependencies-0.5.4*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
-          <include>gems/jruby-openssl-0.15.5*/**/*</include>
+          <include>gems/jruby-openssl-0.16.0*/**/*</include>
           <include>gems/json-2.7.1*/**/*</include>
           <include>gems/logger-1.5.1*/**/*</include>
           <include>gems/mutex_m-0.1.1*/**/*</include>
@@ -1280,7 +1280,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/irb-1.4.2*</include>
           <include>cache/jar-dependencies-0.5.4*</include>
           <include>cache/jruby-readline-1.3.7*</include>
-          <include>cache/jruby-openssl-0.15.5*</include>
+          <include>cache/jruby-openssl-0.16.0*</include>
           <include>cache/json-2.7.1*</include>
           <include>cache/logger-1.5.1*</include>
           <include>cache/mutex_m-0.1.1*</include>


### PR DESCRIPTION
Backport/cherry-pick of https://github.com/jruby/jruby/pull/9386 ; mainly to get security fixes from https://github.com/jruby/jruby-openssl/pull/360 