### PR TITLE
Remove Class#new from backtrace

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1018,14 +1018,14 @@ public class RubyClass extends RubyModule {
     /** rb_class_new_instance
     *
     */
-    @JRubyMethod(name = "new", keywords = true)
+    @JRubyMethod(name = "new", keywords = true, omit = true)
     public IRubyObject newInstance(ThreadContext context, Block block) {
         IRubyObject obj = allocate(context);
         getBaseCallSites()[CS_IDX_INITIALIZE].call(context, obj, obj, block);
         return obj;
     }
 
-    @JRubyMethod(name = "new", keywords = true)
+    @JRubyMethod(name = "new", keywords = true, omit = true)
     public IRubyObject newInstance(ThreadContext context, IRubyObject arg0, Block block) {
         IRubyObject obj = allocate(context);
         getBaseCallSites()[CS_IDX_INITIALIZE].call(context, obj, obj, arg0, block);
@@ -1038,21 +1038,21 @@ public class RubyClass extends RubyModule {
         return obj;
     }
 
-    @JRubyMethod(name = "new", keywords = true)
+    @JRubyMethod(name = "new", keywords = true, omit = true)
     public IRubyObject newInstance(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         IRubyObject obj = allocate(context);
         getBaseCallSites()[CS_IDX_INITIALIZE].call(context, obj, obj, arg0, arg1, block);
         return obj;
     }
 
-    @JRubyMethod(name = "new", keywords = true)
+    @JRubyMethod(name = "new", keywords = true, omit = true)
     public IRubyObject newInstance(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         IRubyObject obj = allocate(context);
         getBaseCallSites()[CS_IDX_INITIALIZE].call(context, obj, obj, arg0, arg1, arg2, block);
         return obj;
     }
 
-    @JRubyMethod(name = "new", rest = true, keywords = true)
+    @JRubyMethod(name = "new", rest = true, keywords = true, omit = true)
     public IRubyObject newInstance(ThreadContext context, IRubyObject[] args, Block block) {
         IRubyObject obj = allocate(context);
         getBaseCallSites()[CS_IDX_INITIALIZE].call(context, obj, obj, args, block);


### PR DESCRIPTION
CRuby in 4.0 optimized Class#new which removes it from the backtrace. We have had the same optimization for many years but until JIT the frame would remain in the backtrace.

Fixes #9395.