### PR TITLE
Warn on class/const assign in condition

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -973,13 +973,13 @@ public abstract class RubyParserBase {
      * assign_in_cond
 	 **/
     private boolean checkAssignmentInCondition(Node node) {
-        if (node instanceof MultipleAsgnNode || node instanceof LocalAsgnNode || node instanceof DAsgnNode || node instanceof GlobalAsgnNode || node instanceof InstAsgnNode) {
+        if (node instanceof MultipleAsgnNode || node instanceof LocalAsgnNode || node instanceof DAsgnNode || node instanceof GlobalAsgnNode || node instanceof InstAsgnNode || node instanceof ClassVarAsgnNode || node instanceof ConstDeclNode) {
             Node valueNode = ((AssignableNode) node).getValueNode();
             if (isStaticContent(valueNode)) {
                 warning(ID.ASSIGNMENT_IN_CONDITIONAL, lexer.getFile(), valueNode.getLine(), "found '= literal' in conditional, should be ==");
             }
             return true;
-        } 
+        }
 
         return false;
     }

--- a/test/mri/excludes/TestParse.rb
+++ b/test/mri/excludes/TestParse.rb
@@ -1,4 +1,3 @@
-exclude :test_assign_in_conditional, "needs investigation"
 exclude :test_call_command, "does not parse (https://github.com/jruby/jruby/issues/9270)"
 exclude :test_define_singleton_error, "work in progress"
 exclude :test_dynamic_constant_assignment, "needs investigation"


### PR DESCRIPTION
Extend checkAssignmentInCondition to treat ClassVarAsgnNode and ConstDeclNode as assignable nodes so assignments like class vars or constant declarations in conditionals will trigger the existing "assignment in conditional" warning. Also re-enable the test_assign_in_conditional test by removing its exclude in test/mri/excludes/TestParse.rb.

So code like following:
```ruby
if @@hello = true
  pp "hello"
end
```

and

```ruby
if BASE_HELLO = true
  pp "hello"
end
```

will now have the `found '= literal' in conditional, should be ==` warning. 

Sorry about the Copilot review, I have now disabled it so it will no longer auto review my PRs from now on. 