### PR TITLE
Fix Set marshal object link registration

### DIFF
--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -109,6 +109,8 @@ public class RubySet extends RubyObject implements Set {
         public void marshalTo(ThreadContext context, RubyOutputStream out, Object obj, RubyClass type, MarshalDumper marshalStream) {
             RubySet set = (RubySet) obj;
 
+            marshalStream.registerObject(set);
+
             // create dummy object with extra @hash ivar and dump variables from that
             RubyObject dummy = new RubyObject(context.runtime, type);
             dummy.setInstanceVariable("@hash", set.hash);
@@ -128,8 +130,10 @@ public class RubySet extends RubyObject implements Set {
         public Object unmarshalFrom(ThreadContext context, RubyInputStream in, RubyClass type, MarshalLoader loader) {
             RubySet set = new RubySet(context.runtime, type, false);
 
+            loader.entry(set);
+
             // unmarshal as dummy object and extra @hash ivar
-            RubyObject dummy = (RubyObject) loader.entry(new RubyObject(context.runtime, type));
+            RubyObject dummy = new RubyObject(context.runtime, type);
             loader.ivar(context, in, null, dummy, null);
 
             set.hash = (RubyHash) dummy.getInstanceVariables().removeInstanceVariable("@hash");

--- a/test/jruby/test_set.rb
+++ b/test/jruby/test_set.rb
@@ -39,6 +39,20 @@ class TestSet < Test::Unit::TestCase
     assert_equal Set.new([1, 2]), set
   end
 
+  def test_marshal_object_links
+    shared = 'good'
+    loaded = Marshal.load Marshal.dump([Set.new, ['bad', shared], shared])
+
+    assert_equal 'good', loaded[2]
+    assert_same loaded[1][1], loaded[2]
+
+    set = Set.new
+    loaded = Marshal.load Marshal.dump([set, set])
+
+    assert_same Set, loaded[0].class
+    assert_same loaded[0], loaded[1]
+  end
+
   def test_yaml_dump; require 'yaml'
     str = YAML.dump(Set.new)
     assert_equal "--- !ruby/object:Set\nhash: {}\n", str


### PR DESCRIPTION
**Note that this PR is agent generated and I don't really understand the logic behind it. I'm publishing it just to help you handle the issue.**

JRuby's Set custom marshal compatibility path serialized the Set through a dummy Ruby object containing the legacy @hash instance variable, but it never registered the real Set object with the marshal object link table. On load, the dummy object was registered instead of the Set that was returned to Ruby code. That shifted later object links and could make a subsequent repeated object reference resolve to the wrong earlier object.

Register the real Set with both MarshalDumper and MarshalLoader while keeping the dummy object only as the compatibility carrier for the legacy @hash payload. This preserves the old wire shape for Set marshaling while keeping marshal links aligned with the objects that are actually dumped and returned.

Fixes: https://github.com/jruby/jruby/issues/9405
Assisted-by: gpt-5.5