### PR TITLE
Ensure core exceptions get raised with $! as cause

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4243,6 +4243,9 @@ public final class Ruby implements Constantizable {
         IRubyObject msg = new RubyNameError.RubyNameErrorMessage(this, message, recv, nameStr);
         RubyException err = RubyNoMethodError.newNoMethodError(getNoMethodError(), msg, nameStr, args, privateCall);
 
+        // set cause since we are preparing to raise
+        err.setCause(getCurrentContext().getErrorInfo());
+
         return err.toThrowable();
     }
 

--- a/spec/mspec/lib/mspec/matchers/raise_error.rb
+++ b/spec/mspec/lib/mspec/matchers/raise_error.rb
@@ -1,11 +1,18 @@
 class RaiseErrorMatcher
   FAILURE_MESSAGE_FOR_EXCEPTION = {}.compare_by_identity
+  UNDEF_CAUSE = Object.new
 
   attr_writer :block
 
-  def initialize(exception, message, &block)
+  def initialize(exception, message = nil, options = nil, &block)
+    if message.is_a? Hash
+      @message = nil
+      options = message
+    else
+      @message = message
+    end
+    @cause = options ? options.fetch(:cause, UNDEF_CAUSE) : UNDEF_CAUSE
     @exception = exception
-    @message = message
     @block = block
     @actual = nil
   end
@@ -45,24 +52,45 @@ class RaiseErrorMatcher
     end
   end
 
-  def matching_exception?(exc)
-    matching_class?(exc) and matching_message?(exc)
-  end
-
-  def exception_class_and_message(exception_class, message)
-    if message
-      "#{exception_class} (#{message})"
+  def matching_cause?(exc)
+    case @cause
+    when UNDEF_CAUSE
+      true
     else
-      "#{exception_class}"
+      @cause == exc.cause
     end
   end
 
+  def matching_exception?(exc)
+    matching_class?(exc) and matching_message?(exc) and matching_cause?(exc)
+  end
+
+  def exception_class_and_message_and_cause(exception_class, message, cause)
+    string = "#{exception_class}"
+    prefixed = false
+    prefix = -> { prefixed ? ", " : prefixed = "(" }
+
+    if message != nil
+      string << "#{prefix.()}#{message.inspect}"
+    end
+
+    if cause != UNDEF_CAUSE
+      string << "#{prefix.()}cause: #{cause.inspect}"
+    end
+
+    string << ")" if prefixed
+
+    string
+  end
+
   def format_expected_exception
-    exception_class_and_message(@exception, @message)
+    exception_class_and_message_and_cause(@exception, @message, @cause)
   end
 
   def format_exception(exception)
-    exception_class_and_message(exception.class, exception.message)
+    exception_class_and_message_and_cause(exception.class,
+                                          @message == nil ? nil : exception.message,
+                                          @cause == UNDEF_CAUSE ? UNDEF_CAUSE : exception.cause)
   end
 
   def failure_message
@@ -87,18 +115,18 @@ class RaiseErrorMatcher
 end
 
 module MSpecMatchers
-  private def raise_error(exception = Exception, message = nil, &block)
-    RaiseErrorMatcher.new(exception, message, &block)
+  private def raise_error(exception = Exception, message = nil, options = nil, &block)
+    RaiseErrorMatcher.new(exception, message, options, &block)
   end
 
   # CRuby < 4.1 has inconsistent coercion errors:
   # https://bugs.ruby-lang.org/issues/21864
   # This matcher ignores the message on CRuby < 4.1
   # and checks the message for all other cases, including other Rubies
-  private def raise_consistent_error(exception = Exception, message = nil, &block)
+  private def raise_consistent_error(exception = Exception, message = nil, options = nil, &block)
     if RUBY_ENGINE == "ruby" and ruby_version_is ""..."4.1"
       message = nil
     end
-    RaiseErrorMatcher.new(exception, message, &block)
+    RaiseErrorMatcher.new(exception, message, options, &block)
   end
 end

--- a/spec/mspec/spec/matchers/raise_error_spec.rb
+++ b/spec/mspec/spec/matchers/raise_error_spec.rb
@@ -84,10 +84,10 @@ RSpec.describe RaiseErrorMatcher do
       matcher.matches?(Proc.new { raise exc })
     rescue UnexpectedException => e
       expect(matcher.failure_message).to eq(
-        ["Expected ExpectedException (message)", "but got: UnexpectedException (message)"]
+        ['Expected ExpectedException("message")', 'but got: UnexpectedException("message")']
       )
       expect(ExceptionState.new(nil, nil, e).message).to eq(
-        "Expected ExpectedException (message)\nbut got: UnexpectedException (message)"
+        "Expected ExpectedException(\"message\")\nbut got: UnexpectedException(\"message\")"
       )
     else
       raise "no exception"
@@ -103,10 +103,10 @@ RSpec.describe RaiseErrorMatcher do
       matcher.matches?(Proc.new { raise exc })
     rescue ExpectedException => e
       expect(matcher.failure_message).to eq(
-        ["Expected ExpectedException (expected)", "but got: ExpectedException (unexpected)"]
+        ['Expected ExpectedException("expected")', 'but got: ExpectedException("unexpected")']
       )
       expect(ExceptionState.new(nil, nil, e).message).to eq(
-        "Expected ExpectedException (expected)\nbut got: ExpectedException (unexpected)"
+        "Expected ExpectedException(\"expected\")\nbut got: ExpectedException(\"unexpected\")"
       )
     else
       raise "no exception"
@@ -122,10 +122,10 @@ RSpec.describe RaiseErrorMatcher do
       matcher.matches?(Proc.new { raise exc })
     rescue UnexpectedException => e
       expect(matcher.failure_message).to eq(
-          ["Expected ExpectedException (expected)", "but got: UnexpectedException (unexpected)"]
+          ['Expected ExpectedException("expected")', 'but got: UnexpectedException("unexpected")']
       )
       expect(ExceptionState.new(nil, nil, e).message).to eq(
-          "Expected ExpectedException (expected)\nbut got: UnexpectedException (unexpected)"
+          "Expected ExpectedException(\"expected\")\nbut got: UnexpectedException(\"unexpected\")"
       )
     else
       raise "no exception"
@@ -137,7 +137,7 @@ RSpec.describe RaiseErrorMatcher do
     matcher = RaiseErrorMatcher.new(ExpectedException, "expected")
     matcher.matches?(proc)
     expect(matcher.failure_message).to eq(
-      ["Expected ExpectedException (expected)", "but no exception was raised (120 was returned)"]
+      ['Expected ExpectedException("expected")', "but no exception was raised (120 was returned)"]
     )
   end
 
@@ -146,7 +146,7 @@ RSpec.describe RaiseErrorMatcher do
     matcher = RaiseErrorMatcher.new(ExpectedException, "expected")
     matcher.matches?(proc)
     expect(matcher.failure_message).to eq(
-      ["Expected ExpectedException (expected)", "but no exception was raised (nil was returned)"]
+      ['Expected ExpectedException("expected")', "but no exception was raised (nil was returned)"]
     )
   end
 
@@ -159,7 +159,7 @@ RSpec.describe RaiseErrorMatcher do
     matcher = RaiseErrorMatcher.new(ExpectedException, "expected")
     matcher.matches?(proc)
     expect(matcher.failure_message).to eq(
-      ["Expected ExpectedException (expected)", "but no exception was raised (#<Object>(#pretty_inspect raised #<ArgumentError: bad>) was returned)"]
+      ['Expected ExpectedException("expected")', 'but no exception was raised (#<Object>(#pretty_inspect raised #<ArgumentError: bad>) was returned)']
     )
   end
 
@@ -168,7 +168,7 @@ RSpec.describe RaiseErrorMatcher do
     matcher = RaiseErrorMatcher.new(ExpectedException, "expected")
     matcher.matches?(proc)
     expect(matcher.negative_failure_message).to eq(
-      ["Expected to not get ExpectedException (expected)", ""]
+      ['Expected to not get ExpectedException("expected")', ""]
     )
   end
 
@@ -177,7 +177,58 @@ RSpec.describe RaiseErrorMatcher do
     matcher = RaiseErrorMatcher.new(Exception, nil)
     matcher.matches?(proc)
     expect(matcher.negative_failure_message).to eq(
-      ["Expected to not get Exception", "but got: UnexpectedException (unexpected)"]
+      ['Expected to not get Exception', 'but got: UnexpectedException']
     )
+  end
+
+  it "matches cause if given" do
+    cause = RuntimeError.new("foo")
+    proc = -> do
+      raise cause
+    rescue
+      raise "bar"
+    end
+
+    matcher = RaiseErrorMatcher.new(RuntimeError, cause:)
+    expect(matcher.matches?(proc)).to eq(true)
+  end
+
+  it "matches message and cause if given" do
+    cause = RuntimeError.new("foo")
+    proc = -> do
+      raise cause
+    rescue
+      raise "bar"
+    end
+
+    matcher = RaiseErrorMatcher.new(RuntimeError, "bar", cause:)
+    expect(matcher.matches?(proc)).to eq(true)
+  end
+
+  it "provides useful negative failure message when cause does not match" do
+    cause = RuntimeError.new("bar")
+    proc = -> do
+      raise "foo"
+    end
+
+    matcher = RaiseErrorMatcher.new(RuntimeError, cause:)
+
+    begin
+      matcher.matches?(proc)
+    rescue RuntimeError
+      expect(matcher.failure_message).to eq(
+        ['Expected RuntimeError(cause: #<RuntimeError: bar>)', 'but got: RuntimeError(cause: nil)']
+      )
+    end
+
+    matcher = RaiseErrorMatcher.new(RuntimeError, "foo", cause:)
+
+    begin
+      matcher.matches?(proc)
+    rescue RuntimeError
+      expect(matcher.failure_message).to eq(
+        ['Expected RuntimeError("foo", cause: #<RuntimeError: bar>)', 'but got: RuntimeError("foo", cause: nil)']
+      )
+    end
   end
 end

--- a/spec/ruby/core/exception/cause_spec.rb
+++ b/spec/ruby/core/exception/cause_spec.rb
@@ -4,53 +4,35 @@ describe "Exception#cause" do
   it "returns the active exception when an exception is raised" do
     begin
       raise Exception, "the cause"
-    rescue Exception
-      begin
+    rescue Exception => cause
+      -> {
         raise RuntimeError, "the consequence"
-      rescue RuntimeError => e
-        e.should be_an_instance_of(RuntimeError)
-        e.message.should == "the consequence"
-
-        e.cause.should be_an_instance_of(Exception)
-        e.cause.message.should == "the cause"
-      end
+      }.should raise_error(RuntimeError, "the consequence", cause:)
     end
   end
 
   it "is set for user errors caused by internal errors" do
-    -> {
-      begin
-        1 / 0
-      rescue
-        raise "foo"
-      end
-    }.should raise_error(RuntimeError) { |e|
-      e.cause.should be_kind_of(ZeroDivisionError)
-    }
+    begin
+      1 / 0
+    rescue => cause
+      -> { raise "foo" }.should raise_error(RuntimeError, cause:)
+    end
   end
 
   it "is set for internal errors caused by user errors" do
     cause = RuntimeError.new "cause"
-    -> {
-      begin
-        raise cause
-      rescue
-        1 / 0
-      end
-    }.should raise_error(ZeroDivisionError) { |e|
-      e.cause.should equal(cause)
-    }
+    begin
+      raise cause
+    rescue
+      -> { 1 / 0 }.should raise_error(ZeroDivisionError, cause:)
+    end
   end
 
   it "is not set to the exception itself when it is re-raised" do
-    -> {
-      begin
-        raise RuntimeError
-      rescue RuntimeError => e
-        raise e
-      end
-    }.should raise_error(RuntimeError) { |e|
-      e.cause.should == nil
-    }
+    begin
+      raise RuntimeError
+    rescue RuntimeError => e
+      -> { raise e }.should raise_error(RuntimeError, cause: nil)
+    end
   end
 end

--- a/spec/ruby/core/exception/dup_spec.rb
+++ b/spec/ruby/core/exception/dup_spec.rb
@@ -61,10 +61,10 @@ describe "Exception#dup" do
 
   it "does copy the cause" do
     begin
-      raise StandardError, "the cause"
+      raise StandardError
     rescue StandardError => cause
       begin
-        raise RuntimeError, "the consequence"
+        raise RuntimeError
       rescue RuntimeError => e
         e.cause.should equal(cause)
         e.dup.cause.should equal(cause)

--- a/spec/ruby/core/kernel/method_spec.rb
+++ b/spec/ruby/core/kernel/method_spec.rb
@@ -75,6 +75,14 @@ describe "Kernel#method" do
       name = mock("method-name")
       name.should_receive(:to_str).and_raise(NoMethodError)
       -> { Object.method(name) }.should raise_error(NoMethodError)
+
+      name = mock("method-name")
+      name.should_receive(:to_str).and_raise(NoMethodError)
+      begin
+        raise RuntimeError.new
+      rescue => cause
+        -> { Object.method(name) }.should raise_error(NoMethodError, cause:)
+      end
     end
   end
 end

--- a/spec/ruby/language/send_spec.rb
+++ b/spec/ruby/language/send_spec.rb
@@ -212,17 +212,38 @@ describe "Invoking a method" do
       o.args.should == [1,2]
     end
 
-    it "raises NameError if invoked as a vcall" do
-      -> { no_such_method }.should raise_error NameError
+    describe "if invoked as a vcall" do
+      it "raises NameError" do
+        -> { no_such_method }.should raise_error NameError
+      end
+
+      it "raises NameError with $! as a cause" do
+        begin
+          raise RuntimeError.new
+        rescue => cause
+          -> { no_such_method }.should raise_error(NameError, cause:)
+        end
+      end
     end
 
     it "should omit the method_missing call from the backtrace for NameError" do
       -> { no_such_method }.should raise_error { |e| e.backtrace.first.should_not include("method_missing") }
     end
 
-    it "raises NoMethodError if invoked as an unambiguous method call" do
-      -> { no_such_method() }.should raise_error NoMethodError
-      -> { no_such_method(1,2,3) }.should raise_error NoMethodError
+    describe "if invoked as an unambiguous method call" do
+      it "raises NoMethodError" do
+        -> { no_such_method() }.should raise_error NoMethodError
+        -> { no_such_method(1,2,3) }.should raise_error NoMethodError
+      end
+
+      it "raises NoMethodError with $! as a cause" do
+        begin
+          raise
+        rescue => cause
+          -> { no_such_method() }.should raise_error(NoMethodError, cause:)
+          -> { no_such_method(1,2,3) }.should raise_error(NoMethodError, cause:)
+        end
+      end
     end
 
     it "should omit the method_missing call from the backtrace for NoMethodError" do

--- a/spec/ruby/shared/kernel/raise.rb
+++ b/spec/ruby/shared/kernel/raise.rb
@@ -147,21 +147,14 @@ describe :kernel_raise_with_cause, shared: true do
     it "sets cause to nil when there is no previous exception" do
       -> do
         @object.raise("error without a cause")
-      end.should raise_error(RuntimeError, "error without a cause") do |error|
-        error.cause.should == nil
-      end
+      end.should raise_error(RuntimeError, "error without a cause", cause: nil)
     end
 
     it "supports automatic cause chaining from a previous exception" do
-      -> do
-        begin
-          raise StandardError,"first error"
-        rescue
-          @object.raise("second error")
-        end
-      end.should raise_error(RuntimeError, "second error") do |error|
-        error.cause.should be_kind_of(StandardError)
-        error.cause.message.should == "first error"
+      begin
+        raise StandardError,"first error"
+      rescue => cause
+        -> { @object.raise("second error") }.should raise_error(RuntimeError, "second error", cause:)
       end
     end
   end
@@ -171,10 +164,8 @@ describe :kernel_raise_with_cause, shared: true do
       cause = StandardError.new("original error")
 
       -> do
-        @object.raise("new error", cause: cause)
-      end.should raise_error(RuntimeError, "new error") do |error|
-        error.cause.should == cause
-      end
+        @object.raise("new error", cause:)
+      end.should raise_error(RuntimeError, "new error", cause:)
     end
 
     it "allows setting cause to nil" do
@@ -188,7 +179,7 @@ describe :kernel_raise_with_cause, shared: true do
     it "raises an ArgumentError when only cause is given" do
       cause = StandardError.new("cause")
       -> do
-        @object.raise(cause: cause)
+        @object.raise(cause:)
       end.should raise_error(ArgumentError, "only cause is given with no arguments")
     end
 
@@ -201,7 +192,7 @@ describe :kernel_raise_with_cause, shared: true do
     it "raises a TypeError when given cause is not an instance of Exception or nil" do
       cause = Object.new
       -> do
-        @object.raise("message", cause: cause)
+        @object.raise("message", cause:)
       end.should raise_error(TypeError, "exception object expected")
     end
 
@@ -209,11 +200,8 @@ describe :kernel_raise_with_cause, shared: true do
       cause = StandardError.new("cause")
 
       -> do
-        @object.raise(cause, cause: cause)
-      end.should raise_error(StandardError, "cause") do |error|
-        error.should == cause
-        error.cause.should == nil
-      end
+        @object.raise(cause, cause:)
+      end.should raise_error(StandardError, "cause", cause: nil)
     end
 
     it "raises ArgumentError when cause creates a circular reference" do
@@ -238,12 +226,8 @@ describe :kernel_raise_with_cause, shared: true do
       cause = StandardError.new("cause message")
 
       -> do
-        @object.raise(ArgumentError, "argument error message", cause: cause)
-      end.should raise_error(ArgumentError, "argument error message") do |error|
-        error.should be_kind_of(ArgumentError)
-        error.message.should == "argument error message"
-        error.cause.should == cause
-      end
+        @object.raise(ArgumentError, "argument error message", cause:)
+      end.should raise_error(ArgumentError, "argument error message", cause:)
     end
 
     it "supports exception class with message, backtrace and cause" do
@@ -251,11 +235,8 @@ describe :kernel_raise_with_cause, shared: true do
       backtrace = ["line1", "line2"]
 
       -> do
-        @object.raise(ArgumentError, "argument error message", backtrace, cause: cause)
-      end.should raise_error(ArgumentError, "argument error message") do |error|
-        error.should be_kind_of(ArgumentError)
-        error.message.should == "argument error message"
-        error.cause.should == cause
+        @object.raise(ArgumentError, "argument error message", backtrace, cause:)
+      end.should raise_error(ArgumentError, "argument error message", cause:) do |error|
         error.backtrace.should == backtrace
       end
     end
@@ -268,10 +249,7 @@ describe :kernel_raise_with_cause, shared: true do
         rescue
           @object.raise("second error", cause: custom_error)
         end
-      end.should raise_error(RuntimeError, "second error") do |error|
-        error.cause.should be_kind_of(StandardError)
-        error.cause.message.should == "custom error"
-      end
+      end.should raise_error(RuntimeError, "second error", cause: custom_error)
     end
 
     it "supports cause: nil, discarding previous exception" do
@@ -282,9 +260,7 @@ describe :kernel_raise_with_cause, shared: true do
           # Explicit nil prevents chaining:
           @object.raise("second error", cause: nil)
         end
-      end.should raise_error(RuntimeError, "second error") do |error|
-        error.cause.should == nil
-      end
+      end.should raise_error(RuntimeError, "second error", cause: nil)
     end
   end
 end


### PR DESCRIPTION
Many places where we raise exceptions from JRuby core code, we do not attach $! as a cause. This leads to several issues, including part of the issue reported in #9398. This PR adds specs and fixes known cases.