### PR TITLE
Fix Hash#inspect of Symbol keys with non-ASCII encoding

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -491,8 +491,15 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         ByteList bytes = fstring.getByteList();
         Encoding enc = bytes.getEncoding();
 
+        boolean nameInvalid;
+        if (str.isAsciiOnly()) {
+            nameInvalid = !isSymbolName(symbol);
+        } else {
+            nameInvalid = this.type == SymbolNameType.OTHER;
+        }
+
         if ((resenc != enc && !str.isAsciiOnly()) /*|| len != (long)strlen(ptr)*/ ||
-                !isSymbolName(symbol) || !isPrintable(context)) {
+                nameInvalid || !isPrintable(context)) {
             return false;
         }
         return true;

--- a/spec/tags/ruby/core/hash/inspect_tags.txt
+++ b/spec/tags/ruby/core/hash/inspect_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash#inspect can be evaled when Encoding.default_external is changed

--- a/test/mri/excludes/TestHash.rb
+++ b/test/mri/excludes/TestHash.rb
@@ -1,6 +1,5 @@
 exclude :test_AREF_fstring_key_default_proc, "Depends on MRI-specific ObjectSpace.count_objects"
 exclude :test_compare_by_identy_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_fetch_error, "needs investigation"
-exclude :test_inspect, "not matching special symbols requiring hashrocket vs colon"
 exclude :test_st_literal_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_update_modify_in_block, "JRuby Hash does not detect or prevent modification during iteration (https://github.com/jruby/jruby/issues/9268)"

--- a/test/mri/excludes/TestHashOnly.rb
+++ b/test/mri/excludes/TestHashOnly.rb
@@ -5,7 +5,6 @@ exclude :test_compare_by_id_memory_leak, "no working assert_no_memory_leak metho
 exclude :test_compare_by_identy_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_exception_in_rehash_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_fetch_error, "needs investigation"
-exclude :test_inspect, "not matching special symbols requiring hashrocket vs colon"
 exclude :test_integer_hash_random, "JRuby does not randomize hash calculation for integer keys, see https://bugs.ruby-lang.org/issues/13002"
 exclude :test_memory_size_after_delete, "uses ObjectSpace.memsize_of"
 exclude :test_rehash_memory_leak, "no working assert_no_memory_leak method"


### PR DESCRIPTION
isSymbolName was classifying names via a Java String built by RubyEncoding.decodeRaw (byte-as-Latin-1), losing multi-byte character grouping. Use the encoding-aware SymbolNameType when the string is not ASCII instead.

Re-enables TestHash#test_inspect; also drops a stale no-op exclude in TestHashOnly (no test_inspect method exists in that class).