### PR TITLE
Fix Enumerator#each(*args) inheriting parent size

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -356,7 +356,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         ArraySupport.copy(args, newArgs, mlen, args.length);
 
         return new RubyEnumerator(context.runtime, getType(), object, asSymbol(context, method), newArgs,
-                size, sizeFn, methodArgsHasKeywords).each(context, block);
+                null, null, methodArgsHasKeywords).each(context, block);
     }
 
     @JRubyMethod(name = "inspect")

--- a/test/mri/excludes/TestEnumerator.rb
+++ b/test/mri/excludes/TestEnumerator.rb
@@ -1,4 +1,3 @@
-exclude :test_each_arg, "unfinished in initial 2.6 work, #6161"
 exclude :test_generator, "missing FrozenError"
 exclude :test_initialize_copy, "missing TypeError"
 exclude :test_inspect, "unfinished in initial 2.6 work, #6161"


### PR DESCRIPTION
`Enumerator#each(*args)` returns a new `Enumerator` with the args bound to the underlying iteration. CRuby drops the parent's size block on this new `Enumerator` because the parameterization may change iteration shape. JRuby was passing the parent's `size` and `sizeFn` through to the new `Enumerator`, causing `#size` to lie about parameterized iteration.

Fix: pass `null` for `size` and `sizeFn` when constructing the new `Enumerator` in `RubyEnumerator#each(IRubyObject[], Block)`.

Reproducer:

```ruby
class Repeater
  def each(times = 1)
    times.times { yield }
  end
end

e = Repeater.new.to_enum { 1 }
e.size                # => 1
e.each(5).size        # CRuby: nil   JRuby before fix: 1
e.each(5).to_a.size   # both runtimes: 5
```

CRuby side:
https://github.com/ruby/ruby/blob/db26919bd033dde6a07d18572c621c6959de300f/enumerator.c#L640
```c
e->size = Qnil;
e->size_fn = 0;

```
Re-enables `TestEnumerator#test_each_arg`.
