### PR TITLE
Truncate Hash#fetch KeyError message for long keys

### DIFF
--- a/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
+++ b/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
@@ -1362,7 +1362,12 @@ public class RubyHashLinkedBuckets extends RubyHash {
         if (value != null) return value;
         if (block.isGiven()) return block.yield(context, key);
 
-        throw context.runtime.newKeyError("key not found: " + key.inspect(context), this, key);
+        RubyString desc = (RubyString) key.inspect(context);
+        if (desc.size() > 65) {
+            desc = (RubyString) desc.substrEnc(context, 0, 62);
+            desc.cat("...".getBytes());
+        }
+        throw context.runtime.newKeyError("key not found: " + desc, this, key);
     }
 
     @JRubyMethod

--- a/test/mri/excludes/TestHash.rb
+++ b/test/mri/excludes/TestHash.rb
@@ -1,5 +1,4 @@
 exclude :test_AREF_fstring_key_default_proc, "Depends on MRI-specific ObjectSpace.count_objects"
 exclude :test_compare_by_identy_memory_leak, "no working assert_no_memory_leak method"
-exclude :test_fetch_error, "needs investigation"
 exclude :test_st_literal_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_update_modify_in_block, "JRuby Hash does not detect or prevent modification during iteration (https://github.com/jruby/jruby/issues/9268)"

--- a/test/mri/excludes/TestHash/TestSubHash.rb
+++ b/test/mri/excludes/TestHash/TestSubHash.rb
@@ -1,5 +1,4 @@
 exclude :test_compare_by_identy_memory_leak, "no working assert_no_memory_leak method"
-exclude :test_fetch_error, "needs investigation"
 exclude :test_inspect, "not matching special symbols requiring hashrocket vs colon"
 exclude :test_replace_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_st_literal_memory_leak, "no working assert_no_memory_leak method"

--- a/test/mri/excludes/TestHashOnly.rb
+++ b/test/mri/excludes/TestHashOnly.rb
@@ -4,7 +4,6 @@ exclude :test_any_hash_fixable, "launches many subprocesses and does not test an
 exclude :test_compare_by_id_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_compare_by_identy_memory_leak, "no working assert_no_memory_leak method"
 exclude :test_exception_in_rehash_memory_leak, "no working assert_no_memory_leak method"
-exclude :test_fetch_error, "needs investigation"
 exclude :test_integer_hash_random, "JRuby does not randomize hash calculation for integer keys, see https://bugs.ruby-lang.org/issues/13002"
 exclude :test_memory_size_after_delete, "uses ObjectSpace.memsize_of"
 exclude :test_rehash_memory_leak, "no working assert_no_memory_leak method"


### PR DESCRIPTION
Hash#fetch was including the full inspected key in its KeyError message, regardless of length. CRuby ellipsizes the key at 65 characters (62 chars + "...") via `rb_str_ellipsize` in `hash.c#rb_hash_fetch_m`. JRuby was producing arbitrarily long error messages for large keys.

Re-enables `TestHash#test_fetch_error`.

Behavior after this fix: 
```
irb(main):001> h = {}
=> {}
irb(main):002> h.fetch("hiya" * 200)
org/jruby/RubyHashLinkedBuckets.java:1370:in 'fetch': key not found: 
"hiyahiyahiyahiyahiyahiyahiyahiyahiyahiyahiyahiyahiyahiyahiyah... (KeyError)
```