### PR TITLE
Add FreeBSD and OpenBSD runs of ruby-spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,7 @@ jobs:
             pkg install -y openjdk21
           run: |
             export JAVA_HOME="/usr/local/openjdk21"
+            export TZ="America/Chicago"
             bin/jruby spec/mspec/bin/mspec ci :${{ matrix.rubyspec-target }}
 
   spec-ruby-openbsd:
@@ -439,6 +440,7 @@ jobs:
             pkg_add jdk--%21
           run: |
             export JAVA_HOME="/usr/local/jdk-21"
+            export TZ="America/Chicago"
             bin/jruby spec/mspec/bin/mspec ci :${{ matrix.rubyspec-target }}
 
   dependency-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,70 @@ jobs:
         env:
           JRUBY_OPTS: -Xjit.threshold=0
 
+  spec-ruby-freebsd:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        rubyspec-target: ['language', 'core']
+
+    name: ${{ matrix.rubyspec-target }} specs (FreeBSD, Java 21)
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'maven'
+      - name: pre-build JRuby
+        run: |
+          ./mvnw -ntp -Pbootstrap clean package
+          bin/jruby --dev -S bundle install
+      - name: run in FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          prepare: |
+            pkg install -y openjdk21
+          run: |
+            export JAVA_HOME="/usr/local/openjdk21"
+            bin/jruby spec/mspec/bin/mspec ci :${{ matrix.rubyspec-target }}
+
+  spec-ruby-openbsd:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        rubyspec-target: ['language', 'core']
+
+    name: ${{ matrix.rubyspec-target }} specs (OpenBSD, Java 21)
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'maven'
+      - name: pre-build JRuby
+        run: |
+          ./mvnw -ntp -Pbootstrap clean package
+          bin/jruby --dev -S bundle install
+      - name: run in OpenBSD
+        uses: vmactions/openbsd-vm@v1
+        with:
+          prepare: |
+            pkg_add jdk--%21
+          run: |
+            export JAVA_HOME="/usr/local/jdk-21"
+            bin/jruby spec/mspec/bin/mspec ci :${{ matrix.rubyspec-target }}
+
   dependency-check:
     runs-on: ubuntu-latest
 

--- a/spec/ruby/core/process/constants_spec.rb
+++ b/spec/ruby/core/process/constants_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 describe "Process::Constants" do
   platform_is :darwin, :netbsd, :freebsd do
-    it "are all present on BSD-like systems" do
+    describe "on BSD-like systems" do
       %i[
           WNOHANG
           WUNTRACED
@@ -20,27 +20,31 @@ describe "Process::Constants" do
           RLIMIT_NPROC
           RLIMIT_NOFILE
       ].each do |const|
-        Process.const_defined?(const).should == true
-        Process.const_get(const).should.instance_of?(Integer)
+        it "defines #{const}" do
+          Process.const_defined?(const).should == true
+          Process.const_get(const).should.instance_of?(Integer)
+        end
       end
     end
   end
 
   platform_is :darwin do
-    it "are all present on Darwin" do
+    describe "on Darwin" do
       %i[
         RLIM_SAVED_MAX
         RLIM_SAVED_CUR
         RLIMIT_AS
       ].each do |const|
-        Process.const_defined?(const).should == true
-        Process.const_get(const).should.instance_of?(Integer)
+        it "defines #{const}" do
+          Process.const_defined?(const).should == true
+          Process.const_get(const).should.instance_of?(Integer)
+        end
       end
     end
   end
 
   platform_is :linux do
-    it "are all present on Linux" do
+    describe "on Linux" do
       %i[
         WNOHANG
         WUNTRACED
@@ -61,37 +65,43 @@ describe "Process::Constants" do
         RLIM_SAVED_MAX
         RLIM_SAVED_CUR
       ].each do |const|
-        Process.const_defined?(const).should == true
-        Process.const_get(const).should.instance_of?(Integer)
+        it "defines #{const}" do
+          Process.const_defined?(const).should == true
+          Process.const_get(const).should.instance_of?(Integer)
+        end
       end
     end
   end
 
   platform_is :netbsd, :freebsd do
-    it "are all present on NetBSD and FreeBSD" do
+    describe "on NetBSD and FreeBSD" do
       %i[
         RLIMIT_SBSIZE
         RLIMIT_AS
       ].each do |const|
-        Process.const_defined?(const).should == true
-        Process.const_get(const).should.instance_of?(Integer)
+        it "defines #{const}" do
+          Process.const_defined?(const).should == true
+          Process.const_get(const).should.instance_of?(Integer)
+        end
       end
     end
   end
 
   platform_is :freebsd do
-    it "are all present on FreeBSD" do
+    describe "on FreeBSD" do
       %i[
         RLIMIT_NPTS
       ].each do |const|
-        Process.const_defined?(const).should == true
-        Process.const_get(const).should.instance_of?(Integer)
+        it "defines #{const}" do
+          Process.const_defined?(const).should == true
+          Process.const_get(const).should.instance_of?(Integer)
+        end
       end
     end
   end
 
   platform_is :windows do
-    it "does not define RLIMIT constants" do
+    describe "on Windows" do
       %i[
           RLIMIT_CPU
           RLIMIT_FSIZE
@@ -107,7 +117,9 @@ describe "Process::Constants" do
           RLIM_SAVED_MAX
           RLIM_SAVED_CUR
       ].each do |const|
-        Process.const_defined?(const).should == false
+        it "does not define #{const}" do
+          Process.const_defined?(const).should == false
+        end
       end
     end
   end

--- a/spec/tags/ruby/core/dir/chroot_tags.txt
+++ b/spec/tags/ruby/core/dir/chroot_tags.txt
@@ -1,3 +1,8 @@
-fails:Dir.chroot as regular user raises an Errno::EPERM exception if the directory exists
-fails:Dir.chroot as regular user raises a SystemCallError if the directory doesn't exist
-fails:Dir.chroot as regular user calls #to_path on non-String argument
+fails(unsupported):Dir.chroot as regular user raises an Errno::EPERM exception if the directory exists
+fails(unsupported):Dir.chroot as regular user raises a SystemCallError if the directory doesn't exist
+fails(unsupported):Dir.chroot as regular user calls #to_path on non-String argument
+fails(unsupported):Dir.chroot as root can be used to change the process' root directory
+fails(unsupported):Dir.chroot as root returns 0 if successful
+fails(unsupported):Dir.chroot as root raises an Errno::ENOENT exception if the directory doesn't exist
+fails(unsupported):Dir.chroot as root can be escaped from with ../
+fails(unsupported):Dir.chroot as root calls #to_path on non-String argument

--- a/spec/tags/ruby/core/file/lchmod_tags.txt
+++ b/spec/tags/ruby/core/file/lchmod_tags.txt
@@ -1,2 +1,3 @@
 fails(linux/openbsd, not supposed to impl):File.lchmod returns false from #respond_to?
 fails(linux/openbsd, not supposed to impl):File.lchmod raises a NotImplementedError when called
+fails(FreeBSD:https://github.com/jruby/jruby/issues/9433):File.lchmod changes the file mode of the link and not of the file

--- a/spec/tags/ruby/core/file/lutime_tags.txt
+++ b/spec/tags/ruby/core/file/lutime_tags.txt
@@ -1,1 +1,11 @@
 fails:File.lutime allows Time instances in the far future to set mtime and atime (but some filesystems limit it up to 2446-05-10 or 2038-01-19 or 2486-07-02)
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime sets the access and modification time of each file
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime uses the current times if two nil values are passed
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime accepts an object that has a #to_path method
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime accepts an object that has a #to_path method
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime accepts numeric atime and mtime arguments
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime may set nanosecond precision
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime returns the number of filenames in the arguments
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime sets the access and modification time for a regular file
+fails(OpenBSD, may be broken native access, https://github.com/jruby/jruby/issues/9438):File.lutime sets the access and modification time for a symlink
+

--- a/spec/tags/ruby/core/file/open_tags.txt
+++ b/spec/tags/ruby/core/file/open_tags.txt
@@ -2,3 +2,9 @@ windows:File.open opens directories
 windows:File.open does not open a file that does no exists when using File::TRUNC mode
 windows:File.open can't write in a block when call open with File::TRUNC mode
 windows:File.open raises an Errno::EEXIST if the file exists when open with File::RDONLY|File::TRUNC
+fails(OpenBSD, possibly broken IO flags or native access, https://github.com/jruby/jruby/issues/9438):File.open opens a file that no exists when use File::TRUNC mode
+fails(OpenBSD, possibly broken IO flags or native access, https://github.com/jruby/jruby/issues/9438):File.open truncates the file when passed File::TRUNC mode
+fails(OpenBSD, possibly broken IO flags or native access, https://github.com/jruby/jruby/issues/9438):File.open can't read in a block when call open with File::TRUNC mode
+fails(OpenBSD, possibly broken IO flags or native access, https://github.com/jruby/jruby/issues/9438):File.open can't write in a block when call open with File::TRUNC mode
+fails(OpenBSD, possibly broken IO flags or native access, https://github.com/jruby/jruby/issues/9438):File.open raises an Errno::EEXIST if the file exists when open with File::RDONLY|File::TRUNC
+

--- a/spec/tags/ruby/core/file/stat/inspect_tags.txt
+++ b/spec/tags/ruby/core/file/stat/inspect_tags.txt
@@ -1,1 +1,2 @@
 windows:File::Stat#inspect produces a nicely formatted description of a File::Stat object
+fails(FreeBSD:https://github.com/jruby/jruby/issues/9433):File::Stat#inspect produces a nicely formatted description of a File::Stat object

--- a/spec/tags/ruby/core/file/stat/nlink_tags.txt
+++ b/spec/tags/ruby/core/file/stat/nlink_tags.txt
@@ -1,0 +1,1 @@
+fails(FreeBSD:https://github.com/jruby/jruby/issues/9433):File::Stat#nlink returns the number of links to a file

--- a/spec/tags/ruby/core/file/stat/sticky_tags.txt
+++ b/spec/tags/ruby/core/file/stat/sticky_tags.txt
@@ -1,0 +1,2 @@
+fails(OpenBSD, possibly broken native access, https://github.com/jruby/jruby/issues/9438):File::Stat#sticky? returns true if the named file has the sticky bit, otherwise false
+

--- a/spec/tags/ruby/core/file/sticky_tags.txt
+++ b/spec/tags/ruby/core/file/sticky_tags.txt
@@ -1,0 +1,2 @@
+fails(OpenBSD, possibly broken native access, https://github.com/jruby/jruby/issues/9438):File.sticky? returns true if the named file has the sticky bit, otherwise false
+

--- a/spec/tags/ruby/core/filetest/sticky_tags.txt
+++ b/spec/tags/ruby/core/filetest/sticky_tags.txt
@@ -1,0 +1,2 @@
+fails(OpenBSD, possibly broken native access, https://github.com/jruby/jruby/issues/9438):FileTest.sticky? returns true if the named file has the sticky bit, otherwise false
+

--- a/spec/tags/ruby/core/process/clock_gettime_tags.txt
+++ b/spec/tags/ruby/core/process/clock_gettime_tags.txt
@@ -3,10 +3,10 @@ fails:Process.clock_gettime supports the platform clocks mentioned in the docume
 fails:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_RAW
 fails:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_RAW_APPROX
 fails:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME_RAW and CLOCK_UPTIME_RAW_APPROX
-fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_VIRTUAL
-fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_PROF
-fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME
-fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_SECOND
-fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_REALTIME_FAST and CLOCK_REALTIME_PRECISE
-fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_FAST and CLOCK_MONOTONIC_PRECISE
-fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME_FAST and CLOCK_UPTIME_PRECISE
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9430):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_VIRTUAL
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9430):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_PROF
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9430):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9430):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_SECOND
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9430):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_REALTIME_FAST and CLOCK_REALTIME_PRECISE
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9430):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_FAST and CLOCK_MONOTONIC_PRECISE
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9430):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME_FAST and CLOCK_UPTIME_PRECISE

--- a/spec/tags/ruby/core/process/clock_gettime_tags.txt
+++ b/spec/tags/ruby/core/process/clock_gettime_tags.txt
@@ -3,3 +3,10 @@ fails:Process.clock_gettime supports the platform clocks mentioned in the docume
 fails:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_RAW
 fails:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_RAW_APPROX
 fails:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME_RAW and CLOCK_UPTIME_RAW_APPROX
+fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_VIRTUAL
+fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_PROF
+fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME
+fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_SECOND
+fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_REALTIME_FAST and CLOCK_REALTIME_PRECISE
+fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_FAST and CLOCK_MONOTONIC_PRECISE
+fails(FreeBSD):Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME_FAST and CLOCK_UPTIME_PRECISE

--- a/spec/tags/ruby/core/process/constants_tags.txt
+++ b/spec/tags/ruby/core/process/constants_tags.txt
@@ -1,3 +1,0 @@
-fails(JRUBY-3655):Process::Constants has the correct constant values on Linux
-fails(JRUBY-3655):Process::Constants has the correct constant values on BSD-like systems
-fails(JRUBY-3655):Process::Constants has the correct constant values on Darwin

--- a/spec/tags/ruby/core/process/constants_tags.txt
+++ b/spec/tags/ruby/core/process/constants_tags.txt
@@ -1,0 +1,2 @@
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9431):Process::Constants on NetBSD and FreeBSD defines RLIMIT_SBSIZE
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9431):Process::Constants on FreeBSD defines RLIMIT_NPTS

--- a/spec/tags/ruby/core/process/groups_tags.txt
+++ b/spec/tags/ruby/core/process/groups_tags.txt
@@ -1,3 +1,4 @@
 fails:Process.groups sets the list of gids of groups in the supplemental group access list
 fails:Process.groups= raises Errno::EPERM
 fails(missing one group on MacOS, unsure if it is important):Process.groups gets an Array of the gids of groups in the supplemental group access list
+fails(superuser):Process.groups= sets the list of gids of groups in the supplemental group access list

--- a/spec/tags/ruby/core/process/setrlimit_tags.txt
+++ b/spec/tags/ruby/core/process/setrlimit_tags.txt
@@ -1,0 +1,2 @@
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9431):Process.setrlimit when passed a Symbol coerces :SBSIZE into RLIMIT_SBSIZE
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9431):Process.setrlimit when passed a String coerces 'SBSIZE' into RLIMIT_SBSIZE

--- a/spec/tags/ruby/core/process/setrlimit_tags.txt
+++ b/spec/tags/ruby/core/process/setrlimit_tags.txt
@@ -1,2 +1,5 @@
 fails(FreeBSD,https://github.com/jruby/jruby/issues/9431):Process.setrlimit when passed a Symbol coerces :SBSIZE into RLIMIT_SBSIZE
 fails(FreeBSD,https://github.com/jruby/jruby/issues/9431):Process.setrlimit when passed a String coerces 'SBSIZE' into RLIMIT_SBSIZE
+fails(OpenBSD,https://github.com/jruby/jruby/issues/9431):Process.setrlimit when passed a Symbol coerces :AS into RLIMIT_AS
+fails(OpenBSD,https://github.com/jruby/jruby/issues/9431):Process.setrlimit when passed a String coerces 'AS' into RLIMIT_AS
+

--- a/spec/tags/ruby/core/string/crypt_tags.txt
+++ b/spec/tags/ruby/core/string/crypt_tags.txt
@@ -1,3 +1,6 @@
 fails:String#crypt raises an ArgumentError when the string contains NUL character
 windows:String#crypt returns a cryptographic hash of self by applying the UNIX crypt algorithm with the specified salt
 windows:String#crypt calls #to_str to converts the salt arg to a String
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9432):String#crypt returns a cryptographic hash of self by applying the UNIX crypt algorithm with the specified salt
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9432):String#crypt calls #to_str to converts the salt arg to a String
+fails(FreeBSD,https://github.com/jruby/jruby/issues/9432):String#crypt doesn't return subclass instances


### PR DESCRIPTION
This is an attempt to add FreeBSD and OpenBSD runs of ruby/spec to JRuby CI.

These use QEMU-based VM actions:

* FreeBSD: https://github.com/vmactions/freebsd-vm
* OpenBSD https://github.com/vmactions/openbsd-vm

Current status:

* The OpenBSD image used by the action claims to be 7.8 but appears to be connected to an older set of ports. The newest JDK offered is 17. I attempted to point it at a different ports location but still failed to find JDK 21.
* Core specs fail on FreeBSD with various OS-level and time-related failures. These specs may never have been tested on FreeBSD, so it might not indicate a problem with JRuby.

cc @jeremyevans for assistance figuring out OpenBSD JDK 21 and which of these spec failure are expected.

cc @eregon for any interest in getting ruby/spec running on *BSD. It is trivial to do with JRuby but running on other Ruby implementations will require being able to build or install them on these platforms.