### PR TITLE
Fix Method/UnboundMethod#original_name deep alias chains

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -299,11 +299,6 @@ public class RubyMethod extends AbstractRubyMethod {
         return super_method(context, receiver, superClass);
     }
 
-    @JRubyMethod
-    public IRubyObject original_name(ThreadContext context) {
-        return method instanceof AliasMethod ? asSymbol(context, ((AliasMethod)method).getOldName()) : name(context);
-    }
-
     public IRubyObject getReceiver() {
         return receiver;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
@@ -158,9 +158,9 @@ public class AliasMethod extends DynamicMethod {
 
 
     public String getOldName() {
-        return entry.method.getName();
+        return getRealMethod().getName();
     }
-    
+
     @Override
     public DynamicMethod getRealMethod() {
         return entry.method.getRealMethod();


### PR DESCRIPTION
Use getRealMethod() instead of entry.method, which only unwrapped one level. Fixes Method#/UnboundMethod#original_name for chains 3+ deep. Also drops the stale RubyMethod#original_name override left over from when the implementation moved to AbstractRubyMethod. 

Fixes the first part of https://github.com/jruby/jruby/issues/9257. (except for the usage of `is_a?`)

I added tests here: https://github.com/ruby/spec/pull/1353 and here: https://github.com/ruby/spec/pull/1354. 

With this the sample from the example in the issue becomes the same as MRI. I'm not sure about the breaking up of `kind_of?` and `is_a?` to different Java methods, but this seems to be the way things are done for methods like `map`/`collect`. 

Sample code: 

```ruby
class Test
  def hello = "hello"
  alias hallo hello
  alias moi hallo
  alias tere moi
  alias hej tere
end

Test.new.method(:hej).original_name
=> :hello # MRI
=> :moi # JRuby 10.1.0.0
=> :hello # JRuby on this branch
```


