### PR TITLE
Fix missing frozen check in 1 and 2-element Array sort!/reverse!

### DIFF
--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -190,6 +190,7 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
     @Override
     public IRubyObject reverse_bang(ThreadContext context) {
         if (!packed()) return super.reverse_bang(context);
+        modifyCheck(context);
         return this;
     }
 

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -224,7 +224,7 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
     @Override
     public IRubyObject reverse_bang(ThreadContext context) {
         if (!packed()) return super.reverse_bang(context);
-
+        modifyCheck(context);
         IRubyObject tmp = car;
         car = cdr;
         cdr = tmp;
@@ -247,7 +247,7 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
         IRubyObject cdr = this.cdr;
 
         IRubyObject ret = block.yieldArray(context, Create.newArray(context, car, cdr), null);
-        //TODO: ary_sort_check should be done here
+        modifyCheck(context);
         int compare = RubyComparable.cmpint(context, ret, car, cdr);
         if (compare > 0) reverse_bang(context);
         return this;
@@ -272,6 +272,7 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
             compare = ((RubyString) o1).op_cmp((RubyString) o2);
         } else {
             compare = compareOthers(context, o1, o2);
+            modifyCheck(context);
         }
 
         if (compare > 0) reverse_bang(context);

--- a/test/jruby/test_array.rb
+++ b/test/jruby/test_array.rb
@@ -183,4 +183,22 @@ class TestArray < Test::Unit::TestCase
     assert_equal([], rules)
   end
 
+  # 2-element arrays use the RubyArrayTwoObject specialization.
+  def test_reverse_bang_two_element_frozen
+    assert_raise(FrozenError) { [1, 2].freeze.reverse! }
+  end
+
+  def test_sort_bang_two_element_freeze_in_block
+    array = [1, 2]
+    assert_raise(FrozenError) do
+      array.sort! { |_a, _b| array.freeze; -1 }
+    end
+  end
+
+  def test_sort_bang_two_element_freeze_in_cmp
+    o1, o2 = Object.new, Object.new
+    array = [o1, o2]
+    o1.define_singleton_method(:<=>) { |_| array.freeze; -1 }
+    assert_raise(FrozenError) { array.sort! }
+  end
 end

--- a/test/jruby/test_array.rb
+++ b/test/jruby/test_array.rb
@@ -183,8 +183,9 @@ class TestArray < Test::Unit::TestCase
     assert_equal([], rules)
   end
 
-  # 2-element arrays use the RubyArrayTwoObject specialization.
+  # 1- and 2-element arrays use the RubyArrayOneObject and RubyArrayTwoObject specializations.
   def test_reverse_bang_two_element_frozen
+    assert_raise(FrozenError) { [1].freeze.reverse! }
     assert_raise(FrozenError) { [1, 2].freeze.reverse! }
   end
 


### PR DESCRIPTION
Call modifyCheck(context) in RubyArrayTwoObject to enforce frozen/modify checks during in-place operations. Added checks in reverse_bang and in the sort/compare paths (after block yield and inside compareOthers) so attempts to freeze or modify the array during reverse! or sort! will raise FrozenError. Also added unit tests to exercise the two-element specialization: reverse! on a frozen array, freezing the array inside a sort! block, and freezing during <=> comparator.

JRuby 10.1.0.0:
```ruby
[1, 2].freeze.reverse!
=> [2, 1]
```

This branch: 
```ruby
[1, 2].freeze.reverse!
org/jruby/specialized/RubyArrayTwoObject.java:229:in 'reverse!': can't modify frozen Array: [1, 2] (FrozenError)
        from (irb):1:in 'evaluate'
        from org/jruby/RubyKernel.java:1448:in 'eval'
        from org/jruby/RubyKernel.java:1850:in 'loop'
        from org/jruby/RubyKernel.java:1587:in 'catch'
        from /Users/sampokuokkanen/jruby/lib/ruby/gems/shared/gems/irb-1.16.0/exe/irb:9:in '<main>'
        from org/jruby/RubyKernel.java:1402:in 'load'
        from ./bin/irb:25:in '<main>'
```

The reason why I noticed this is I was looking into https://github.com/jruby/jruby/blob/master/test/mri/ruby/test_array.rb#L1827 and when playing around with it I noticed that the third test case failed, but it was masked by the `(count += 1) == 6` check failing. 

I also created a PR agains MRI:
https://github.com/ruby/ruby/pull/16885
If they accept this PR we can enable `test_freeze_inside_sort!`. 

RubyArrayOneObject was also missing the check in `.reverse!` Added a test case and confirmed that `[1].freeze.reverse!` will raise a FrozenError. 