### PR TITLE
prevent UNDEF from leaking through constant resolution

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -5441,8 +5441,13 @@ public class RubyModule extends RubyObject {
                     mod.getConstantWithAutoload(context, name, null, true) :
                     mod.fetchConstant(context, name, true);
 
-            // if it's UNDEF and we're not loading and there's no autoload set up, consider it undefined
-            if (value == UNDEF && !loadConstant && mod.getAutoloadMap().get(name) == null) return null;
+            if (value == UNDEF && !loadConstant) {
+                final Autoload autoload = mod.getAutoloadMap().get(name);
+                // stale marker, or this thread is resolving the autoload before assigning the constant
+                if (autoload == null || (autoload.isSelf(context) && autoload.getValue() == null)) {
+                    return null;
+                }
+            }
             if (value != null) return value;
 
             if (!inherit) break;


### PR DESCRIPTION
`iterateConstantNoConstMissing` with `loadConstant=false`, the `getConstantSkipAutoload` call path (used by `InheritanceSearchConst`), could return `UNDEF` instead of` null` when an autoload entry existed for the constant;

could than lead to a method call receiver causing a NPE in CacheEntry.typeOk (due null meta-class for the UNDEF)

---

had this around for a while, was looking at potential issues with AI tooling when looking at #9296 it's hard to tell whether that is the issue (`autoload` usage ended up unconfirmed) but regardless the fix here seems legit, as there indeed was a way to leak-out `UNDEF` used as a marked for autoloads...
