### PR TITLE
Enable new Method and UnboundMethod#original_name specs

### DIFF
--- a/spec/tags/ruby/core/method/original_name_tags.txt
+++ b/spec/tags/ruby/core/method/original_name_tags.txt
@@ -1,3 +1,0 @@
-fails:Method#original_name returns the original name even when aliased thrice
-fails:Method#original_name returns the source UnboundMethod's name (not the name given to define_method)
-fails:Method#original_name preserves the source method's name through define_method and alias

--- a/spec/tags/ruby/core/unboundmethod/original_name_tags.txt
+++ b/spec/tags/ruby/core/unboundmethod/original_name_tags.txt
@@ -1,1 +1,0 @@
-fails:UnboundMethod#original_name returns the original name even when aliased thrice


### PR DESCRIPTION
After the merge of https://github.com/jruby/jruby/pull/9420 these should now pass. 