### PR TITLE
Lazily acquire singleton class for instance_eval

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -2710,25 +2710,25 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             reads = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
             writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE})
     public IRubyObject instance_eval(ThreadContext context, Block block) {
-        return specificEval(context, getInstanceEvalClass(context), block, EvalType.INSTANCE_EVAL);
+        return specificEval(context, getType(), block, EvalType.INSTANCE_EVAL);
     }
     @JRubyMethod(name = "instance_eval",
             reads = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
             writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE})
     public IRubyObject instance_eval(ThreadContext context, IRubyObject arg0, Block block) {
-        return specificEval(context, getInstanceEvalClass(context), arg0, block, EvalType.INSTANCE_EVAL);
+        return specificEval(context, getType(), arg0, block, EvalType.INSTANCE_EVAL);
     }
     @JRubyMethod(name = "instance_eval",
             reads = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
             writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE})
     public IRubyObject instance_eval(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
-        return specificEval(context, getInstanceEvalClass(context), arg0, arg1, block, EvalType.INSTANCE_EVAL);
+        return specificEval(context, getType(), arg0, arg1, block, EvalType.INSTANCE_EVAL);
     }
     @JRubyMethod(name = "instance_eval",
             reads = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
             writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE})
     public IRubyObject instance_eval(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        return specificEval(context, getInstanceEvalClass(context), arg0, arg1, arg2, block, EvalType.INSTANCE_EVAL);
+        return specificEval(context, getType(), arg0, arg1, arg2, block, EvalType.INSTANCE_EVAL);
     }
 
     // This is callable and will work but the rest = true is put so we can match the expected arity error message
@@ -2774,7 +2774,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     public IRubyObject instance_exec(ThreadContext context, IRubyObject[] args, Block block) {
         if (!block.isGiven()) throw context.runtime.newLocalJumpErrorNoBlock();
 
-        return yieldUnder(context, getInstanceEvalClass(context), args, block, EvalType.INSTANCE_EVAL);
+        return yieldUnder(context, getType(), args, block, EvalType.INSTANCE_EVAL);
     }
 
     /** rb_obj_extend

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1097,7 +1097,12 @@ public class IRRuntimeHelpers {
      * @return the instance method definition target, or the "cbase" for other purposes
      */
     public static RubyModule getCurrentClassBase(ThreadContext context, IRubyObject self) {
-        return getModuleFromScope(context, context.getCurrentStaticScope(), self);
+        StaticScope scope = context.getCurrentStaticScope();
+        RubyModule module = getModuleFromScope(context, scope, self);
+        if (scope.isSingleton()) {
+            return self.getSingletonClass();
+        }
+        return module;
     }
 
     public static RubyModule getModuleFromScope(ThreadContext context, StaticScope scope, IRubyObject arg) {

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -134,6 +134,11 @@ public class StaticScope implements Serializable, Cloneable {
 
     private BitSet keywordIndices = null;
 
+    /**
+     * Whether this scope should execute class-level changes against a singleton class.
+     */
+    private boolean singleton = false;
+
     // This is set for Prism since it knows all names for a scope right after parse but does not know which
     // ones are keywords until we are actually processing those keywords in builder.
     public void setKeywordIndices(BitSet keywordIndices) {
@@ -142,6 +147,14 @@ public class StaticScope implements Serializable, Cloneable {
 
     public BitSet getKeywordIndices() {
         return keywordIndices == null ? new BitSet() : keywordIndices;
+    }
+
+    public boolean isSingleton() {
+        return singleton;
+    }
+
+    public void setSingleton(boolean singleton) {
+        this.singleton = singleton;
     }
 
     public enum Type {

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -39,6 +39,7 @@ package org.jruby.runtime;
 import com.headius.backport9.stack.StackWalker;
 import com.headius.backport9.stack.impl.StackWalker8;
 import org.jcodings.Encoding;
+import org.jruby.EvalType;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBoolean;
@@ -1099,7 +1100,10 @@ public final class ThreadContext {
         DynamicScope scope = getCurrentScope();
         StaticScope sScope = runtime.getStaticScopeFactory().newBlockScope(scope.getStaticScope());
         sScope.setModule(executeUnderClass);
-        pushScope(DynamicScope.newDynamicScope(sScope, scope));
+        sScope.setSingleton(true);
+        DynamicScope dynScope = DynamicScope.newDynamicScope(sScope, scope);
+        dynScope.setEvalType(EvalType.INSTANCE_EVAL);
+        pushScope(dynScope);
         pushCallFrame(frame.getKlazz(), frame.getName(), executeUnderObj, block);
         getCurrentFrame().setVisibility(getPreviousFrame().getVisibility());
     }


### PR DESCRIPTION
This is based on the work done in https://github.com/ruby/ruby/pull/5146 and defers creation of the singleton class until class-level changes are necessary (method definitions, etc). We add a singleton flag to the scope that is used to acquire the singleton class as needed.

Fixes #8638