### PR TITLE
Fix original_name when two methods share a wrapper (like is_a? kind_of?)

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -196,9 +196,7 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
 
     @JRubyMethod
     public IRubyObject original_name(ThreadContext context) {
-        if (method instanceof AliasMethod alias) return asSymbol(context, alias.getOldName());
-        String source = method.getSourceName();
-        return asSymbol(context, source != null ? source : methodName);
+        return asSymbol(context, method.getOldName());
     }
 
     public IRubyObject inspect(IRubyObject receiver) {
@@ -256,11 +254,9 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
         }
         str.catString(sharp);
         str.cat(asSymbol(context, methodName).asString());
-        String displaySource = method instanceof AliasMethod alias ? alias.getOldName() : method.getSourceName();
-        if (displaySource != null && !methodName.equals(displaySource)) {
-            str.catString("(");
-            str.cat(asSymbol(context, displaySource).asString());
-            str.catString(")");
+        String displayOldName = method.getOldName();
+        if (!methodName.equals(displayOldName)) {
+            str.catString("(").cat(asSymbol(context, displayOldName).asString()).catString(")");
         }
         if (method.isNotImplemented()) {
             str.catString(" (not-implemented)");

--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -196,7 +196,9 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
 
     @JRubyMethod
     public IRubyObject original_name(ThreadContext context) {
-        return asSymbol(context, method instanceof AliasMethod alias ? alias.getOldName() : method.getName());
+        if (method instanceof AliasMethod alias) return asSymbol(context, alias.getOldName());
+        String source = method.getSourceName();
+        return asSymbol(context, source != null ? source : methodName);
     }
 
     public IRubyObject inspect(IRubyObject receiver) {
@@ -254,9 +256,10 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
         }
         str.catString(sharp);
         str.cat(asSymbol(context, methodName).asString());
-        if (!methodName.equals(method.getName())) {
+        String displaySource = method instanceof AliasMethod alias ? alias.getOldName() : method.getSourceName();
+        if (displaySource != null && !methodName.equals(displaySource)) {
             str.catString("(");
-            str.cat(asSymbol(context, method.getRealMethod().getName()).asString());
+            str.cat(asSymbol(context, displaySource).asString());
             str.catString(")");
         }
         if (method.isNotImplemented()) {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -92,6 +92,7 @@ import org.jruby.internal.runtime.methods.PartialDelegatingMethod;
 import org.jruby.internal.runtime.methods.ProcMethod;
 import org.jruby.internal.runtime.methods.RefinedMarker;
 import org.jruby.internal.runtime.methods.RefinedWrapper;
+import org.jruby.internal.runtime.methods.RenamedDynamicMethod;
 import org.jruby.internal.runtime.methods.SynchronizedDynamicMethod;
 import org.jruby.internal.runtime.methods.UndefinedMethod;
 import org.jruby.ir.IRClosure;
@@ -2991,8 +2992,7 @@ public class RubyModule extends RubyObject {
 
             checkValidBindTargetFrom(context, (RubyModule) method.owner(context), false);
 
-            newMethod = method.getMethod().dup();
-            newMethod.setSourceName(method.getMethodName());
+            newMethod = new RenamedDynamicMethod(method.getMethod().dup(), method.getMethodName());
             newMethod.setImplementationClass(this);
             newMethod.setVisibility(visibility);
         } else {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2992,6 +2992,7 @@ public class RubyModule extends RubyObject {
             checkValidBindTargetFrom(context, (RubyModule) method.owner(context), false);
 
             newMethod = method.getMethod().dup();
+            newMethod.setSourceName(method.getMethodName());
             newMethod.setImplementationClass(this);
             newMethod.setVisibility(visibility);
         } else {

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
@@ -158,7 +158,12 @@ public class AliasMethod extends DynamicMethod {
 
 
     public String getOldName() {
-        return getRealMethod().getName();
+        DynamicMethod terminal = entry.method;
+        while (terminal instanceof AliasMethod) {
+            terminal = ((AliasMethod) terminal).entry.method;
+        }
+        String source = terminal.getSourceName();
+        return source != null ? source : terminal.getName();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
@@ -157,13 +157,13 @@ public class AliasMethod extends DynamicMethod {
     }
 
 
+    @Override
     public String getOldName() {
         DynamicMethod terminal = entry.method;
-        while (terminal instanceof AliasMethod) {
-            terminal = ((AliasMethod) terminal).entry.method;
+        while (terminal instanceof AliasMethod alias) {
+            terminal = alias.entry.method;
         }
-        String source = terminal.getSourceName();
-        return source != null ? source : terminal.getName();
+        return terminal.getOldName();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DelegatingDynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DelegatingDynamicMethod.java
@@ -211,6 +211,16 @@ public abstract class DelegatingDynamicMethod extends DynamicMethod {
     public abstract DynamicMethod dup();
 
     @Override
+    public String getOldName() {
+        return delegate.getOldName();
+    }
+
+    @Override
+    public RubyModule getDefinedClass() {
+        return delegate.getDefinedClass();
+    }
+
+    @Override
     /**
      * We override equals so that for method identity checks we treat delegating wrappers the same as the original
      * methods. See e.g. RubyClass.finvokeChecked and its method_missing comparison.

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -77,6 +77,9 @@ public abstract class DynamicMethod {
     protected byte flags;
     /** The simple, base name this method was defined under. May be null.*/
     protected final String name;
+    /** The original source name when this method was bound under a different name
+     *  via define_method(name, Method/UnboundMethod); null otherwise. */
+    protected String sourceName;
     /** An arbitrarily-typed "method handle" for use by compilers and call sites */
     protected Object handle;
     /** How many times has this method been aliased. */
@@ -574,6 +577,14 @@ public abstract class DynamicMethod {
      */
     public String getName() {
         return name;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
     }
 
     /**

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -77,9 +77,6 @@ public abstract class DynamicMethod {
     protected byte flags;
     /** The simple, base name this method was defined under. May be null.*/
     protected final String name;
-    /** The original source name when this method was bound under a different name
-     *  via define_method(name, Method/UnboundMethod); null otherwise. */
-    protected String sourceName;
     /** An arbitrarily-typed "method handle" for use by compilers and call sites */
     protected Object handle;
     /** How many times has this method been aliased. */
@@ -246,6 +243,16 @@ public abstract class DynamicMethod {
     /* Arity 3, with block; calls through IRubyObject[] path */
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule klazz, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         return call(context, self, klazz, name, new IRubyObject[] {arg0, arg1, arg2}, block);
+    }
+
+    /**
+     * Get the source name for {@code Method#original_name}.
+     * Overridden by {@link AliasMethod} and {@link RenamedDynamicMethod}.
+     *
+     * @return the source name
+     */
+    public String getOldName() {
+        return name;
     }
 
     /*
@@ -579,17 +586,9 @@ public abstract class DynamicMethod {
         return name;
     }
 
-    public String getSourceName() {
-        return sourceName;
-    }
-
-    public void setSourceName(String sourceName) {
-        this.sourceName = sourceName;
-    }
-
     /**
      * Get the "handle" associated with this DynamicMethod.
-     * 
+     *
      * @return the handle
      */
     public Object getHandle() {

--- a/core/src/main/java/org/jruby/internal/runtime/methods/RenamedDynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/RenamedDynamicMethod.java
@@ -1,0 +1,41 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.internal.runtime.methods;
+
+/**
+ * Wraps a method bound under a different name via {@code define_method(name, Method)}
+ * so {@code Method#original_name} reports the source name. Per-binding wrapper, so two
+ * {@code define_method} calls over the same underlying method each record their own
+ * source name independently.
+ */
+public class RenamedDynamicMethod extends DelegatingDynamicMethod {
+    private final String sourceName;
+
+    public RenamedDynamicMethod(DynamicMethod delegate, String sourceName) {
+        super(delegate);
+        this.sourceName = sourceName;
+    }
+
+    @Override
+    public String getOldName() {
+        return sourceName;
+    }
+
+    @Override
+    public DynamicMethod dup() {
+        return new RenamedDynamicMethod(delegate.dup(), sourceName);
+    }
+}


### PR DESCRIPTION
Preserve a method's source name when methods share a single underlying wrapper, so `Method#original_name` and `#inspect` report the right name instead of whichever name happened to live on the shared wrapper. The dup'd method is wrapped in a per-binding `RenamedDynamicMethod` (a `DelegatingDynamicMethod` subclass) holding the source name in a final field. `Method#original_name` consults `DynamicMethod#getOldName`, which the wrapper overrides and `AliasMethod` walks through.

Covered by new specs in ruby/spec#1356 (https://github.com/ruby/spec/pull/1356).

Sample (the case this PR fixes):

```ruby
class A
  define_method(:my_is_a?, Kernel.instance_method(:is_a?))
  define_method(:my_kind_of?, Kernel.instance_method(:kind_of?))
end

# master:    both report the same name (last writer wins on the shared wrapper)
# this PR:
A.new.method(:my_is_a?).original_name    # => :is_a?
A.new.method(:my_kind_of?).original_name # => :kind_of?
```

Known limitation: direct lookup of multi-name `@JRubyMethod` methods still leaks the underlying name (`Class.new.method(:is_a?).inspect` still shows `(kind_of?)`). The specs in ruby/spec#1356 for the inspect case for like `Class.new.method(:id_a?)` will fail, but I think that would be better tackled in a follow-up PR. 

This PR fixes the first part of https://github.com/jruby/jruby/issues/9257.

@headius
Thanks for explaining to me how method lookup works in JRuby in https://github.com/jruby/jruby/pull/9420.