### PR TITLE
Allow bytecode version to be open-ended

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -55,6 +55,7 @@ import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
 import org.objectweb.asm.Opcodes;
 
 import java.io.*;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1812,31 +1813,12 @@ public class RubyInstanceConfig {
         }
 
         int version = Integer.parseInt(specVersion);
-        switch (version) {
-            case 8 :
-                return Opcodes.V1_8; // 52
-            case 9 :
-                return Opcodes.V9;
-            case 10 :
-                return Opcodes.V10;
-            case 11 :
-                return Opcodes.V11;
-            case 12 :
-                return Opcodes.V12;
-            case 13 :
-                return Opcodes.V13;
-            case 14 :
-                return Opcodes.V14;
-            case 15 :
-                return Opcodes.V15;
-            case 16 :
-                return Opcodes.V16;
-            case 17 :
-                return Opcodes.V17;
-            case 18 :
-            default :
-                return Opcodes.V18;
-        }
+		try {
+			Field versionField = Opcodes.class.getField("V" + version);
+			return (Integer) versionField.get(null);
+		} catch (Exception e) {
+			return Opcodes.V21;
+		}
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1803,22 +1803,26 @@ public class RubyInstanceConfig {
 
     private static int initJavaBytecodeVersion() {
         final String specVersion = Options.BYTECODE_VERSION.load();
+        return calculateBytecodeVersion(specVersion);
+    }
+
+    public static int calculateBytecodeVersion(String specVersion) {
         if (specVersion.indexOf('.') != -1) {
             switch (specVersion) {
                 default:
-                    System.err.println("unsupported Java version, using 1.8: " + specVersion);
+                    System.err.println("unsupported Java version " + specVersion + ", using 1.8");
                 case "1.8":
                     return Opcodes.V1_8;
             }
         }
 
         int version = Integer.parseInt(specVersion);
-		try {
-			Field versionField = Opcodes.class.getField("V" + version);
-			return (Integer) versionField.get(null);
-		} catch (Exception e) {
-			return Opcodes.V21;
-		}
+        try {
+            Field versionField = Opcodes.class.getField("V" + version);
+            return (Integer) versionField.get(null);
+        } catch (Exception e) {
+            return Opcodes.V21;
+        }
     }
 
     @Deprecated

--- a/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
+++ b/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
@@ -30,7 +30,9 @@
 package org.jruby.test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.util.Locale;
 
 import org.jruby.exceptions.MainExitException;
@@ -38,6 +40,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.load.LoadService;
+import org.objectweb.asm.Opcodes;
 
 /**
  * This should be filled up with more tests for RubyInstanceConfig later
@@ -145,5 +148,21 @@ public class TestRubyInstanceConfig extends Base {
         return "/dev/fd/0";
       }
       return "/dev/stdin";
+    }
+
+    public void testBytecodeVersion() throws Exception {
+        assertEquals("it uses Opcodes.V1_8 for '1.8'", Opcodes.V1_8, RubyInstanceConfig.calculateBytecodeVersion("1.8"));
+        assertEquals("it uses Opcodes.V9 for '9'", Opcodes.V9, RubyInstanceConfig.calculateBytecodeVersion("9"));
+        assertEquals("it uses Opcodes.V21 for '21'", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("21"));
+        assertEquals("it uses Opcodes.V21 for '21'", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("21"));
+        assertEquals("it falls back on Opcodes.V21 for high unsupported versions", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("99"));
+        PrintStream err = System.err;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); PrintStream ps = new PrintStream(baos)) {
+            System.setErr(ps);
+            assertEquals("it falls back on Opcodes.V1_8 for low unsupported versions", Opcodes.V1_8, RubyInstanceConfig.calculateBytecodeVersion("1.7"));
+            assertEquals("it outputs an error message for low unsupported versions", "unsupported Java version 1.7, using 1.8", new String(baos.toByteArray()).replaceAll("[\\n\\r]", ""));
+        } finally {
+            System.setErr(err);
+        }
     }
 }


### PR DESCRIPTION
The ASM library hard codes a set of known bytecode versions, which frequently forces us to select an earlier version than the JVM we are running on. This change makes that byte code version open-ended, decoupling us from the ASM supported bytecode versions.

This is somewhat experimental, since we do not know how ASM will react if the JDK version is much newer than it's known byte code versions. If this patch does not work, we will fall back on updating ASM to latest and dealing with and updating our version calculation in the future.

Fixes #9443 

Update: as suspected, ASM will not permit us to use bytecode versions newer than it supports, so I have made an additional change to limit the open-endedness of this to just the values the current ASM version supports.