### PR TITLE
Fix metaclass dispatch missing meta-metaclass methods

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -538,7 +538,9 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         MetaClass klass = new MetaClass(context.runtime, superClass, this); // rb_class_boot
         setMetaClass(klass);
 
-        klass.setMetaClass(superClass.getRealClass().metaClass);
+        // MRI: SET_METACLASS_OF(metaclass, ENSURE_EIGENCLASS(tmp))
+        RubyClass effectiveSuper = superClass.isIncluded() ? superClass.getRealClass() : superClass;
+        klass.setMetaClass(effectiveSuper.singletonClass(context));
 
         return klass;
     }

--- a/spec/tags/ruby/language/metaclass_tags.txt
+++ b/spec/tags/ruby/language/metaclass_tags.txt
@@ -1,1 +1,0 @@
-fails:calling methods on the metaclass calls a method defined on the metaclass of the metaclass


### PR DESCRIPTION
The sample code from https://github.com/jruby/jruby/issues/287 still errors on JRuby master: 

```ruby
class Foo
  class << self
    class << self
      def foo; end
    end
  end
end
class Bar < Foo; end
Bar.singleton_class.foo
(irb):11:in 'evaluate': undefined method 'foo' for class #<Class:Bar> (NoMethodError)
```

This is because currently in master the code is stripping away singleton classes and not creating a singleton class in case one is missing. 

So skip the wrapper with `isIncluded()` and use `singletonClass(context)` to get the correct eigenclass. 
This lets us drop `spec/tags/ruby/language/metaclass_tags.txt`, but the MRI tests are still failing since they go one step further (meta-meta-meta tier, blows up on line 160), and with meta-meta classes there is still an issue there with how they are handled (see MetaClass.java:109, can't just fix it as it leads to a stack overflow with the same shape of fix as I did on line 542)