### PR TITLE
[fix] escape shell metachars in chdir: to prevent injection

### DIFF
--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -158,17 +158,15 @@ public class PopenExecutor {
         RubyString prog = eargp.use_shell ? eargp.command_name : eargp.command_name;
         ExecArg sarg = new ExecArg();
 
-        if (eargp.chdirGiven) {
-            // we can'd do chdir with posix_spawn, so we should be set to use_shell and now
-            // just need to add chdir to the cmd
-            String script = "cd '" + eargp.chdir_dir + "'; ";
+        String progString;
 
-            // use exec to eliminate extra sh process if we do not need to run command as a shell script
-            if (!searchForMetaChars(prog)) script = script + "exec ";
+        if (eargp.chdirGiven) { // posix_spawn cannot chdir; run a guarded shell command instead
+            progString = chdirShellCommand(eargp.chdir_dir, prog, !searchForMetaChars(prog));
 
-            prog = (RubyString) dupString(context, prog).prepend(context, newString(context, script));
             eargp.chdir_dir = null;
             eargp.chdirGiven = false;
+        } else {
+            progString = prog.toString();
         }
 
         if (execargRunOptions(context, eargp, sarg, errmsg) < 0) return -1;
@@ -181,8 +179,8 @@ public class PopenExecutor {
 //            }
         }
         long pid = eargp.use_shell ?
-                procSpawnSh(context, prog.toString(), eargp) :
-                procSpawnCmd(context, eargp.argv_str.argv, prog.toString(), eargp);
+                procSpawnSh(context, progString, eargp) :
+                procSpawnCmd(context, eargp.argv_str.argv, progString, eargp);
 
         if (pid == -1) {
             Ruby runtime = context.runtime;
@@ -565,9 +563,8 @@ public class PopenExecutor {
         if (prog != null) cmd = checkEmbeddedNulls(context, prog).toString();
 
         if (eargp.chdirGiven) {
-            // we can'd do chdir with posix_spawn, so we should be set to use_shell and now
-            // just need to add chdir to the cmd
-            cmd = "cd '" + eargp.chdir_dir + "'; " + cmd;
+            // posix_spawn cannot chdir; run a guarded shell command instead.
+            cmd = chdirShellCommand(eargp.chdir_dir, cmd, false);
             eargp.chdir_dir = null;
             eargp.chdirGiven = false;
         }
@@ -1854,6 +1851,15 @@ public class PopenExecutor {
             }
             eargp.argv_str = argv_str;
         }
+    }
+
+    private static String chdirShellCommand(String dir, CharSequence command, boolean exec) {
+        final String script = "cd -- " + quotePosixShellWord(dir) + " && ";
+        return exec ? (script + "exec " + command) : (script + "eval " + quotePosixShellWord(command.toString()));
+    }
+
+    private static String quotePosixShellWord(String str) {
+        return '\'' + str.replace("'", "'\\''") + '\'';
     }
 
     /**

--- a/test/jruby/test_process.rb
+++ b/test/jruby/test_process.rb
@@ -1,6 +1,9 @@
 require 'test/unit'
 require 'test/jruby/test_helper'
+require 'fileutils'
 require 'rbconfig'
+require 'shellwords'
+require 'tmpdir'
 
 class TestProcess < Test::Unit::TestCase
   include TestHelper
@@ -114,5 +117,47 @@ class TestProcess < Test::Unit::TestCase
     assert_raise(NotImplementedError) { Process.waitpid2 }
     assert_raise(NotImplementedError) { Process.waitall }
   end if WINDOWS
+
+  def test_chdir_option_does_not_allow_shell_injection
+    omit 'requires POSIX shell' if WINDOWS
+
+    Dir.mktmpdir('jruby_chdir_test') do |tmpdir|
+      marker = File.join(tmpdir, 'injected_marker')
+      malicious_dir = "missing' ; touch #{Shellwords.escape(marker)} #"
+
+      system('echo safe', chdir: malicious_dir, out: File::NULL, err: File::NULL)
+
+      assert_false File.exist?(marker), 'command injection via chdir: path executed'
+    end
+  end
+
+  def test_chdir_option_does_not_run_command_when_chdir_fails
+    omit 'requires POSIX shell' if WINDOWS
+
+    Dir.mktmpdir('jruby_chdir_test') do |tmpdir|
+      marker = File.join(tmpdir, 'failed_chdir_marker')
+      missing_dir = File.join(tmpdir, 'missing')
+
+      system("echo safe; touch #{Shellwords.escape(marker)}", chdir: missing_dir, out: File::NULL, err: File::NULL)
+
+      assert_false File.exist?(marker), 'command ran even though chdir: target was missing'
+    end
+  end
+
+  def test_chdir_option_handles_shell_special_characters_in_path
+    omit 'requires POSIX shell' if WINDOWS
+
+    Dir.mktmpdir('jruby_chdir_test') do |tmpdir|
+      ["dir with ' quote $dollar ; semicolon", '-P'].each do |name|
+        dir = File.join(tmpdir, name)
+        FileUtils.mkdir_p(dir)
+
+        assert system('true', chdir: dir, out: File::NULL, err: File::NULL)
+
+        output = IO.popen('pwd', chdir: dir, &:read).strip
+        assert_equal File.realpath(dir), File.realpath(output)
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
`PopenExecutor` constructs a `cd '<dir>'; ...` for the `chdir:` option in spawn/system/IO.popen; 

directory path was embedded in single quotes without escaping, allowing single-quote breakout command injection:
```
  system('echo hello', chdir: "x'; touch /tmp/pwned; echo '")
```
p.s. MRI uses the POSIX chdir syscall directly and is not affected