### PR TITLE
attempt at a proper fix for the BiVariableMap memory leak

### DIFF
--- a/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
@@ -29,67 +29,71 @@
  */
 package org.jruby.embed.internal;
 
+import java.util.Map;
+
 import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.embed.LocalVariableBehavior;
 
 public abstract class AbstractLocalContextProvider implements LocalContextProvider {
+	protected final RubyInstanceConfig config;
+	protected final LocalVariableBehavior behavior;
+	protected boolean lazy = true;
 
-    protected final RubyInstanceConfig config;
-    protected final LocalVariableBehavior behavior;
-    protected boolean lazy = true;
+	protected AbstractLocalContextProvider() {
+		this(new RubyInstanceConfig());
+	}
 
-    protected AbstractLocalContextProvider() {
-        this( new RubyInstanceConfig() );
-    }
+	protected AbstractLocalContextProvider(RubyInstanceConfig config) {
+		this.config = config;
+		this.behavior = LocalVariableBehavior.TRANSIENT;
+	}
 
-    protected AbstractLocalContextProvider(RubyInstanceConfig config) {
-        this.config = config; this.behavior = LocalVariableBehavior.TRANSIENT;
-    }
+	protected AbstractLocalContextProvider(RubyInstanceConfig config, LocalVariableBehavior behavior) {
+		this.config = config;
+		this.behavior = behavior;
+	}
 
-    protected AbstractLocalContextProvider(RubyInstanceConfig config, LocalVariableBehavior behavior) {
-        this.config = config; this.behavior = behavior;
-    }
+	protected AbstractLocalContextProvider(LocalVariableBehavior behavior) {
+		this.config = new RubyInstanceConfig();
+		this.behavior = behavior;
+	}
 
-    protected AbstractLocalContextProvider(LocalVariableBehavior behavior) {
-        this.config = new RubyInstanceConfig(); this.behavior = behavior;
-    }
+	protected abstract LocalContext getLocalContext();
 
-    protected LocalContext getInstance() {
-        return new LocalContext(config, behavior, lazy);
-    }
+	@Override
+	public RubyInstanceConfig getRubyInstanceConfig() {
+		return getLocalContext().getRubyInstanceConfig();
+	}
 
-    @Override
-    public RubyInstanceConfig getRubyInstanceConfig() {
-        return config;
-    }
+	@Override
+	public Ruby getRuntime() {
+		return getLocalContext().getRuntime();
+	}
 
-    @Override
-    public LocalVariableBehavior getLocalVariableBehavior() {
-        return behavior;
-    }
+	@Override
+	public BiVariableMap getVarMap() {
+		return getLocalContext().getVarMap(this);
+	}
 
-    boolean isGlobalRuntimeReady() { return Ruby.isGlobalRuntimeReady(); }
+	@Override
+	public Map getAttributeMap() {
+		return getLocalContext().getAttributeMap();
+	}
 
-    Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
-        if ( isGlobalRuntimeReady() ) {
-            return Ruby.getGlobalRuntime();
-        }
-        return Ruby.newInstance(provider.config);
-    }
+	@Override
+	public boolean isRuntimeInitialized() {
+		return getLocalContext().isInitialized();
+	}
 
-    RubyInstanceConfig getGlobalRuntimeConfig(AbstractLocalContextProvider provider) {
-        // make sure we do not yet initialize the runtime here
-        if ( isGlobalRuntimeReady() ) {
-            return getGlobalRuntime(provider).getInstanceConfig();
-        }
-        return provider.config;
-    }
+	@Override
+	public LocalVariableBehavior getLocalVariableBehavior() {
+		return behavior;
+	}
 
-    static RubyInstanceConfig getGlobalRuntimeConfigOrNew() {
-        return Ruby.isGlobalRuntimeReady() ?
-                Ruby.getGlobalRuntime().getInstanceConfig() :
-                    new RubyInstanceConfig();
-    }
-
+	static RubyInstanceConfig getGlobalRuntimeConfigOrNew() {
+		if (Ruby.isGlobalRuntimeReady())
+			return Ruby.getGlobalRuntime().getInstanceConfig();
+		return new RubyInstanceConfig();
+	}
 }

--- a/core/src/main/java/org/jruby/embed/internal/ArgvAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/ArgvAccessor.java
@@ -1,0 +1,81 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2011 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.jruby.RubyArray;
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ *
+ * @author yoko
+ */
+class ArgvAccessor extends VariableAccessor {
+	private static final String NAME = "ARGV";
+
+	public ArgvAccessor() {
+		super(NAME, false, Type.Argv);
+	}
+
+	@Override
+	Set<String> keySet(BiVariableMap map, IRubyObject receiver) {
+		return Set.of(NAME);
+	}
+
+	@Override
+	IRubyObject retrieve(BiVariableMap map, IRubyObject receiver, String name) {
+		return map.getRuntime().getTopSelf().getMetaClass().getConstant(NAME);
+	}
+
+	@Override
+	void inject(BiVariableMap map, IRubyObject receiver, String name, IRubyObject value) {
+		// FIXME cast string[] and lists to RubyArray
+		// FIXME probably simply need to reject non-arrays here
+		if (value instanceof RubyArray)
+			map.getRuntime().getTopSelf().getMetaClass().storeConstant(NAME, value);
+		/*
+		 * FIXME straight-forward except for weird casting of the java object: it gets
+		 * converted to an array if possible... or just ignored if not. more precisely:
+		 * Collection and String[] are converted to a ruby array (of string for
+		 * String[], and of potentially weird things for Collection). everything else is
+		 * silently turned into an empty array, no warnings or anything :/
+		 */
+		map.getRuntime().getConstantInvalidator(NAME).invalidate();
+	}
+
+	@Override
+	void remove(BiVariableMap map, IRubyObject receiver, String name) {
+		// cannot remove ARGV, so we just set it to an empty list instead
+		inject(map, receiver, name, RubyArray.newArray(map.getRuntime()));
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
+++ b/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
@@ -29,6 +29,8 @@
  */
 package org.jruby.embed.internal;
 
+import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -46,8 +48,6 @@ import org.jruby.embed.variable.BiVariable;
 import org.jruby.embed.variable.VariableInterceptor;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.scope.ManyVarsDynamicScope;
-import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
 
 /**
  * Ruby-Java bi-directional variable map implementation. Keys of this map
@@ -71,7 +71,7 @@ import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
  */
 public class BiVariableMap implements Map<String, Object> {
 
-    private final LocalContextProvider provider;
+    private final LocalContext context;
     private final boolean lazy;
 
     private List<String> varNames;
@@ -81,11 +81,11 @@ public class BiVariableMap implements Map<String, Object> {
      * Constructs an empty map. Users do not instantiate this map. The map is created
      * internally.
      *
-     * @param provider
+     * @param context
      * @param lazy
      */
-    public BiVariableMap(LocalContextProvider provider, boolean lazy) {
-        this.provider = provider;
+    public BiVariableMap(LocalContext context, boolean lazy) {
+        this.context = context;
         this.lazy = lazy;
     }
 
@@ -107,7 +107,7 @@ public class BiVariableMap implements Map<String, Object> {
         return variables == null ? variables = new ArrayList<BiVariable>() : variables;
     }
 
-    public Ruby getRuntime() { return provider.getRuntime(); }
+    public Ruby getRuntime() { return context.getRuntime(); }
 
     /**
      * Returns a local variable behavior
@@ -115,7 +115,7 @@ public class BiVariableMap implements Map<String, Object> {
      * @return a local variable behavior
      */
     public LocalVariableBehavior getLocalVariableBehavior() {
-        return provider.getLocalVariableBehavior();
+        return context.getLocalVariableBehavior();
     }
 
     /**
@@ -224,7 +224,7 @@ public class BiVariableMap implements Map<String, Object> {
         final RubyObject robj = getReceiverObject(receiver);
         // attemps to retrieve global variables
         if ( isLazy() ) {
-            VariableInterceptor.tryLazyRetrieval(provider.getLocalVariableBehavior(), this, robj, key);
+            VariableInterceptor.tryLazyRetrieval(context.getLocalVariableBehavior(), this, robj, key);
         }
         BiVariable var = getVariable(robj, (String) key);
         return var == null ? null : var.getJavaObject();
@@ -334,7 +334,7 @@ public class BiVariableMap implements Map<String, Object> {
             var.setJavaObject(robj.getRuntime(), value);
         }
         else { // creates new value
-            var = VariableInterceptor.getVariableInstance(provider.getLocalVariableBehavior(), robj, key, value);
+            var = VariableInterceptor.getVariableInstance(context.getLocalVariableBehavior(), robj, key, value);
             if ( var != null ) update(key, var);
         }
         return oldValue;

--- a/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
+++ b/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
@@ -36,7 +36,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +46,7 @@ import org.jruby.RubyObject;
 import org.jruby.embed.LocalVariableBehavior;
 import org.jruby.embed.variable.BiVariable;
 import org.jruby.embed.variable.VariableInterceptor;
+import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -76,6 +77,7 @@ public class BiVariableMap implements Map<String, Object> {
 
     private List<String> varNames;
     private List<BiVariable> variables;
+    private Map<String, IRubyObject> localVariables;
 
     /**
      * Constructs an empty map. Users do not instantiate this map. The map is created
@@ -173,11 +175,19 @@ public class BiVariableMap implements Map<String, Object> {
      * @param key is a key to be tested its presence
      * @return <code>true</code> if this map contains a mapping for the specified key
      */
-    @Override
-    public boolean containsKey(final Object key) {
-        if ( varNames == null || key == null ) return false;
-        return varNames.contains( checkKey(key) );
-    }
+	@Override
+	public boolean containsKey(final Object key) {
+		return containsKey(null, key);
+	}
+
+	public boolean containsKey(final Object receiver, final Object key) {
+		final String name = checkKey(key);
+		final VariableAccessor acc = VariableAccessor.getInstance(getLocalVariableBehavior(), name);
+		if (acc == null)
+			return false;
+		final IRubyObject rec = getReceiver(receiver);
+		return acc.containsKey(this, rec, name);
+	}
 
     /**
      * Returns <code>true</code> if this map maps one or more keys to the
@@ -219,20 +229,26 @@ public class BiVariableMap implements Map<String, Object> {
      * @return the value in simple Java object to which the specified key is mapped, or
      *         {@code null} if this map contains no mapping for the key
      */
-    public Object get(Object receiver, Object key) {
-        checkKey(key);
-        final RubyObject robj = getReceiverObject(receiver);
-        // attemps to retrieve global variables
-        if ( isLazy() ) {
-            VariableInterceptor.tryLazyRetrieval(context.getLocalVariableBehavior(), this, robj, key);
-        }
-        BiVariable var = getVariable(robj, (String) key);
-        return var == null ? null : var.getJavaObject();
-    }
+	public Object get(Object receiver, Object key) {
+		final String name = checkKey(key);
+		final VariableAccessor acc = VariableAccessor.getInstance(getLocalVariableBehavior(), name);
+		if (acc == null)
+			return null;
+		final IRubyObject rec = getReceiver(receiver);
+		return toJava(acc.retrieve(this, rec, name));
+	}
 
-    private RubyObject getReceiverObject(final Object receiver) {
-        return receiver instanceof RubyObject ? (RubyObject) receiver : getTopSelf();
-    }
+	private Object toJava(final IRubyObject value) {
+		return value != null ? value.toJava(Object.class) : null;
+	}
+
+	private IRubyObject getReceiver(final Object receiver) {
+		if (receiver == null)
+			return null;
+		if (receiver instanceof IRubyObject rec)
+			return rec;
+		throw new IllegalArgumentException("receiver object is not a Ruby object");
+	}
 
     private RubyObject getTopSelf() {
         return (RubyObject) getRuntime().getTopSelf();
@@ -324,21 +340,18 @@ public class BiVariableMap implements Map<String, Object> {
      * @return the previous value associated with <code>key</code>, or
      *         <code>null</code> if there was no mapping for <code>key</code>.
      */
-    public Object put(Object receiver, String key, Object value) {
-        checkKey(key);
-        final RubyObject robj = getReceiverObject(receiver);
-        BiVariable var = getVariable(robj, key);
-        Object oldValue = null;
-        if ( var != null ) { // updates
-            oldValue = var.getJavaObject();
-            var.setJavaObject(robj.getRuntime(), value);
-        }
-        else { // creates new value
-            var = VariableInterceptor.getVariableInstance(context.getLocalVariableBehavior(), robj, key, value);
-            if ( var != null ) update(key, var);
-        }
-        return oldValue;
-    }
+	public Object put(Object receiver, String key, Object value) {
+		final String name = checkKey(key);
+		final VariableAccessor acc = VariableAccessor.getInstance(getLocalVariableBehavior(), name);
+		if (acc == null)
+			return null;
+		final IRubyObject rec = getReceiver(receiver);
+		final IRubyObject prevValue = acc.retrieve(this, rec, name);
+		final IRubyObject rubyValue = value instanceof IRubyObject ? (IRubyObject) value
+				: JavaEmbedUtils.javaToRuby(getRuntime(), value);
+		acc.inject(this, rec, name, rubyValue);
+		return toJava(prevValue);
+	}
 
     /**
      * Returns Ruby's local variable names this map has. The returned array is mainly
@@ -346,44 +359,75 @@ public class BiVariableMap implements Map<String, Object> {
      *
      * @return String array of Ruby's local variable names
      */
-    public String[] getLocalVarNames() {
-        if ( variables == null ) return EMPTY_STRING_ARRAY;
+	public String[] getLocalVarNames() {
+		if (localVariables == null)
+			return EMPTY_STRING_ARRAY;
+		return localVariables.keySet().toArray(String[]::new);
+	}
 
-        List<String> localVarNames = new ArrayList<>(variables.size());
-        for ( final BiVariable var : variables ) {
-            if ( var.getType() == BiVariable.Type.LocalVariable ) {
-                localVarNames.add( var.getName() );
-            }
-        }
-        return localVarNames.toArray(new String[localVarNames.size()]);
+    Set<String> getLocalVariableNames() {
+    	if (localVariables == null)
+    		return Set.of();
+    	return localVariables.keySet();
     }
 
+    IRubyObject getLocalVariable(final String name) {
+    	if (localVariables == null)
+    		return null;
+		return localVariables.get(name);
+	}
+    
+    void setLocalVariable(final String name, final IRubyObject value) {
+    	if (localVariables == null)
+    		localVariables = new HashMap<String, IRubyObject>();
+		localVariables.put(name, value);
+	}
+    
+    void removeLocalVariable(final String name) {
+    	if (localVariables != null)
+    		localVariables.remove(name);
+	}
+    
     /**
      * Returns Ruby's local variable values this map has. The returned array is
      * mainly used to inject local variables to Ruby scripts while evaluating.
      *
      * @return IRubyObject array of Ruby's local variable names.
      */
-    public IRubyObject[] getLocalVarValues() {
-        if ( variables == null ) return IRubyObject.NULL_ARRAY;
+    @Deprecated
+	public IRubyObject[] getLocalVarValues() {
+		if (localVariables == null)
+			return IRubyObject.NULL_ARRAY;
+		return localVariables.values().toArray(IRubyObject[]::new);
+	}
 
-        List<IRubyObject> localVarValues = new ArrayList<>(variables.size());
-        for ( final BiVariable var : variables ) {
-            if ( var.getType() == BiVariable.Type.LocalVariable ) {
-                localVarValues.add( var.getRubyObject() );
-            }
-        }
-        return localVarValues.toArray( new IRubyObject[ localVarValues.size() ] );
-    }
+	void inject(final DynamicScope scope) {
+		if (localVariables == null)
+			return;
+		final String[] names = scope.getAllNamesInScope();
+		for (int i = 0; i < names.length; i++)
+			if (localVariables.containsKey(names[i]))
+				scope.setValue(i, localVariables.get(names[i]), 0);
+	}
 
-    void inject(final DynamicScope scope) {
-        VariableInterceptor.inject(this, scope);
-    }
+	void retrieve(final IRubyObject receiver) {
+		if (persistLocalVariables(getLocalVariableBehavior())) {
+			final DynamicScope scope = (DynamicScope) receiver.getRuntime().getCurrentContext().getCurrentScope();
+			final String[] names = scope.getAllNamesInScope();
+			for (int i = 0; i < names.length; i++)
+				setLocalVariable(names[i], scope.getValue(i, 0));
+		}
+	}
 
-    void retrieve(final IRubyObject receiver) {
-        final RubyObject robj = getReceiverObject(receiver);
-        VariableInterceptor.retrieve(getLocalVariableBehavior(), this, robj);
-    }
+	private boolean persistLocalVariables(LocalVariableBehavior localVariableBehavior) {
+		switch (getLocalVariableBehavior()) {
+		case BSF:
+		case PERSISTENT:
+			return true;
+		default:
+			return false;
+		}
+	}
 
     void terminate() {
         VariableInterceptor.terminateGlobalVariables(getLocalVariableBehavior(), getVariables(), getRuntime());
@@ -402,7 +446,7 @@ public class BiVariableMap implements Map<String, Object> {
      */
     @Override
     public Object remove(final Object key) {
-        return removeFrom(getTopSelf(), key);
+        return removeFrom(null, key);
     }
 
     /**
@@ -416,22 +460,16 @@ public class BiVariableMap implements Map<String, Object> {
      * @return the previous value associated with <code>key</code>, or
      *         <code>null</code> if there was no mapping for <code>key</code>.
      */
-    public Object removeFrom(final Object receiver, final Object key) {
-        if ( variables == null ) return null;
-        checkKey(key);
-        final RubyObject robj = getReceiverObject(receiver);
-        for ( int i = 0; i < size(); i++ ) {
-            if ( key.equals( varNames.get(i) ) ) {
-                final BiVariable var = variables.get(i);
-                if ( var.isReceiverIdentical(robj) ) {
-                    varNames.remove(i);
-                    variables.remove(i);
-                    return var.getJavaObject();
-                }
-            }
-        }
-        return null;
-    }
+	public Object removeFrom(final Object receiver, final Object key) {
+		final String name = checkKey(key);
+		final VariableAccessor acc = VariableAccessor.getInstance(getLocalVariableBehavior(), name);
+		if (acc == null)
+			return null;
+		final IRubyObject rec = getReceiver(receiver);
+		final IRubyObject prevValue = acc.retrieve(this, rec, name);
+		acc.remove(this, rec, name);
+		return toJava(prevValue);
+	}
 
     /**
      * Copies all of the mappings from the specified map to this map.
@@ -488,10 +526,18 @@ public class BiVariableMap implements Map<String, Object> {
      *
      * @return a set view of the keys contained in this map
      */
-    @Override
-    public Set<String> keySet() {
-        return new LinkedHashSet<String>( getNames() );
-    }
+	@Override
+	public Set<String> keySet() {
+		return keySet(null);
+	}
+
+	public Set<String> keySet(final Object receiver) {
+		final IRubyObject rec = getReceiver(receiver);
+		final Set<String> names = new HashSet<>();
+		for (final VariableAccessor acc : VariableAccessor.getAll(getLocalVariableBehavior()))
+			names.addAll(acc.keySet(this, rec));
+		return names;
+	}
 
     /**
      * Returns a {@link Collection} view of the values contained in this map.

--- a/core/src/main/java/org/jruby/embed/internal/ClassVariableAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/ClassVariableAccessor.java
@@ -1,0 +1,81 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2009-2011 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.util.List;
+
+import org.jruby.RubyClass;
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * An implementation of BiVariable for a Ruby class variable.
+ *
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ */
+public class ClassVariableAccessor extends VariableAccessor {
+	private static final String VALID_NAME = "@@([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
+
+	ClassVariableAccessor() {
+		super(VALID_NAME, true, Type.ClassVariable);
+	}
+
+	private RubyClass getReceiverClass(BiVariableMap map, IRubyObject receiver) {
+		if (receiver != null)
+			return receiver.getMetaClass();
+		return map.getRuntime().getTopSelf().getMetaClass();
+	}
+
+	@Override
+	List<String> keySet(BiVariableMap map, IRubyObject receiver) {
+		return getReceiverClass(map, receiver).getClassVariableNameList();
+	}
+
+	@Override
+	IRubyObject retrieve(BiVariableMap map, IRubyObject receiver, String name) {
+		RubyClass klazz = getReceiverClass(map, receiver);
+		// getClassVar throws an exception when attempting to read a nonexistent class
+		// variable, so we need to guard against that
+		if (!klazz.getClassVariableNameList().contains(name))
+			return null;
+		return klazz.getClassVar(name);
+	}
+
+	@Override
+	void inject(BiVariableMap map, IRubyObject receiver, String name, IRubyObject value) {
+		getReceiverClass(map, receiver).setClassVar(name, value);
+	}
+
+	@Override
+	void remove(BiVariableMap map, IRubyObject receiver, String name) {
+		getReceiverClass(map, receiver).removeClassVariable(name);
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/ConcurrentLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/ConcurrentLocalContextProvider.java
@@ -29,60 +29,39 @@
  */
 package org.jruby.embed.internal;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicReference;
-import org.jruby.Ruby;
-import org.jruby.RubyInstanceConfig;
 import org.jruby.embed.LocalVariableBehavior;
 
 /**
- * Concurrent type local context provider.
- * Ruby runtime returned from the getRuntime() method is a classloader-global runtime.
- * While variables (except global variables) and constants are thread local.
+ * Concurrent type local context provider. Ruby runtime returned from the
+ * getRuntime() method is a classloader-global runtime. While variables (except
+ * global variables) and constants are thread local.
  *
- * @author Yoko Harada &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
  */
 public class ConcurrentLocalContextProvider extends AbstractLocalContextProvider {
-    private final ThreadLocalContext contextHolder = new ThreadLocalContext(this::getInstance);
+	private final ThreadLocalContext contextHolder = new ThreadLocalContext(this::createGlobalContext);
 
-    public ConcurrentLocalContextProvider(LocalVariableBehavior behavior) {
-        super( getGlobalRuntimeConfigOrNew(), behavior );
-    }
+	public ConcurrentLocalContextProvider(LocalVariableBehavior behavior) {
+		super(getGlobalRuntimeConfigOrNew(), behavior);
+	}
 
-    public ConcurrentLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
-        super( getGlobalRuntimeConfigOrNew(), behavior );
-        this.lazy = lazy;
-    }
+	public ConcurrentLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
+		super(getGlobalRuntimeConfigOrNew(), behavior);
+		this.lazy = lazy;
+	}
 
-    @Override
-    public Ruby getRuntime() {
-        return getGlobalRuntime(this);
-    }
+	protected LocalContext createGlobalContext() {
+		return new GlobalContext(config, behavior, lazy);
+	}
 
-    @Override
-    public RubyInstanceConfig getRubyInstanceConfig() {
-        return getGlobalRuntimeConfig(this);
-    }
+	@Override
+	protected LocalContext getLocalContext() {
+		return contextHolder.get();
+	}
 
-    @Override
-    public BiVariableMap getVarMap() {
-        return contextHolder.get().getVarMap(this);
-    }
-
-    @Override
-    public Map getAttributeMap() {
-        return contextHolder.get().getAttributeMap();
-    }
-
-    @Override
-    public boolean isRuntimeInitialized() {
-        return Ruby.isGlobalRuntimeReady();
-    }
-
-    @Override
-    public void terminate() {
-    	contextHolder.terminate();
-    }
-
+	@Override
+	public void terminate() {
+		contextHolder.terminate();
+	}
 }

--- a/core/src/main/java/org/jruby/embed/internal/ConstantAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/ConstantAccessor.java
@@ -1,0 +1,125 @@
+/*
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2009-2012 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jruby.RubyClass;
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * An implementation of BiVariable for a Ruby constant.
+ *
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ */
+class ConstantAccessor extends VariableAccessor {
+	private static final String VALID_NAME = "[A-Z]([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
+
+	ConstantAccessor() {
+		super(VALID_NAME, true, Type.Constant);
+	}
+
+	@Override
+	Collection<String> keySet(BiVariableMap map, IRubyObject receiver) {
+		if (receiver == null) {
+			final Set<String> result = new HashSet<>();
+			final RubyClass klazz = map.getRuntime().getTopSelf().getMetaClass();
+			result.addAll(klazz.getConstantNames());
+			result.addAll(klazz.getSuperClass().getConstantNames());
+			return result;
+		} else
+			return receiver.getMetaClass().getConstantNames();
+	}
+
+	@Override
+	boolean containsKey(BiVariableMap map, IRubyObject receiver, String name) {
+		if (receiver == null) {
+			// avoid creating a large temp collection just to look for a single value
+			final RubyClass klazz = map.getRuntime().getTopSelf().getMetaClass();
+			if (klazz.getConstantNames().contains(name))
+				return true;
+			return klazz.getSuperClass().getConstantNames().contains(name);
+		} else
+			return receiver.getMetaClass().getConstantNames().contains(name);
+	}
+
+	@Override
+	IRubyObject retrieve(final BiVariableMap map, final IRubyObject receiver, final String name) {
+		if (receiver == null) {
+			final RubyClass klazz = map.getRuntime().getTopSelf().getMetaClass();
+			if (klazz.getConstantNames().contains(name))
+				return klazz.getConstant(name);
+			// also obtain constants from top self's superclass. this isn't entirely
+			// consistent (they cannot be removed) but should be useful for getting
+			// top-level constants
+			return klazz.getSuperClass().getConstant(name);
+		} else {
+			final RubyClass klazz = receiver.getMetaClass();
+			if (klazz.getConstantNames().contains(name))
+				return klazz.getConstant(name);
+			return null;
+		}
+	}
+
+	@Override
+	void inject(final BiVariableMap map, final IRubyObject receiver, final String name, final IRubyObject value) {
+		if (receiver == null)
+			map.getRuntime().getTopSelf().getMetaClass().storeConstant(name, value);
+		else
+			receiver.getMetaClass().storeConstant(name, value);
+		map.getRuntime().getConstantInvalidator(name).invalidate();
+	}
+
+	@Override
+	void remove(final BiVariableMap map, final IRubyObject receiver, final String name) {
+		final IRubyObject rubyName = JavaUtil.convertJavaToRuby(map.getRuntime(), name);
+		final ThreadContext context = map.getRuntime().getCurrentContext();
+		if (receiver == null) {
+			final RubyClass klazz = map.getRuntime().getTopSelf().getMetaClass();
+			// remove_const throws an exception if the named constant is missing, so we
+			// always need to check for existence first
+			if (klazz.getConstantNames().contains(name))
+				klazz.remove_const(context, rubyName);
+		} else {
+			final RubyClass klazz = receiver.getMetaClass();
+			if (klazz.getConstantNames().contains(name))
+				klazz.remove_const(context, rubyName);
+		}
+		// we should probably invalidate the constant here. otherwise code might keep
+		// using the previous value
+		map.getRuntime().getConstantInvalidator(name).invalidate();
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/GlobalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/GlobalContext.java
@@ -1,0 +1,106 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2009-2011 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import org.jruby.Ruby;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.embed.LocalVariableBehavior;
+
+/**
+ * {@link LocalContext} instance that uses the {@link Ruby#getGlobalRuntime()
+ * global runtime}. Each instance still has its own {@link BiVariableMap
+ * variables} and attributes.
+ * <p>
+ * Used by {@link ConcurrentLocalContextProvider} with one instance per thread,
+ * thus providing one set of variables per thread. A singleton instance is also
+ * held by {@link SingletonLocalContextProvider}, providing one global set of
+ * variables across the classloader that loaded JRuby.
+ */
+class GlobalContext extends LocalContext {
+	public GlobalContext(RubyInstanceConfig config, LocalVariableBehavior behavior) {
+		this(config, behavior, false);
+	}
+
+	public GlobalContext(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
+		super(config, behavior, lazy);
+	}
+
+	@Override
+	Ruby getRuntime() {
+		return getGlobalRuntime();
+	}
+
+	@Override
+	boolean isInitialized() {
+		return Ruby.isGlobalRuntimeReady();
+	}
+
+	@Override
+	RubyInstanceConfig getRubyInstanceConfig() {
+		return getGlobalRuntimeConfig();
+	}
+
+	/**
+	 * Get a reference to the Classloader-global Ruby runtime. If nothing else
+	 * messes with the global runtime (the common case), then it will be configured
+	 * according to the {@link RubyInstanceConfig} provided in the constructor.
+	 * <p>
+	 * If some other thread initializes a global runtime first, or if
+	 * {@link Ruby#useAsGlobalRuntime()} or
+	 * {@code JRuby.runtime.use_as_global_runtime} is called, then this method
+	 * behaves like {@link Ruby#getGlobalRuntime()} and its
+	 * {@link RubyInstanceConfig} may differ from the {@link LocalContextProvider}.
+	 */
+	Ruby getGlobalRuntime() {
+		// this method can run concurrently in several threads in
+		// ConcurrentLocalContextProvider
+		if (isInitialized())
+			return Ruby.getGlobalRuntime();
+
+		// global runtime not yet set. create one with the requested configuration
+		Ruby runtime = Ruby.newInstance(config);
+		if (runtime != Ruby.getGlobalRuntime())
+			// boundary case: while we weren't looking, some other thread initialized the
+			// global runtime. when only a single LocalContextProvider is used, the other
+			// thread will have created it with the same configuration. even if it's
+			// configured differently, we can use that other runtime (and should, for
+			// consistency). but we do need to cleanly dispose of the one we just created.
+			runtime.tearDown();
+		return Ruby.getGlobalRuntime();
+	}
+
+	RubyInstanceConfig getGlobalRuntimeConfig() {
+		// make sure we do not yet initialize the runtime here
+		if (isInitialized())
+			return getGlobalRuntime().getInstanceConfig();
+
+		return config;
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/GlobalVariableAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/GlobalVariableAccessor.java
@@ -1,0 +1,68 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2009-2012 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.util.Set;
+
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * An implementation of VariableAccessor for a Ruby global variable.
+ *
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ */
+class GlobalVariableAccessor extends VariableAccessor {
+	private static final String VALID_NAME = "\\$(([a-zA-Z]|_|\\d)*|-[a-zA-Z]|[!-~&&[^#%()-\\{\\}\\[\\]\\|\\^]])";
+
+	GlobalVariableAccessor() {
+		super(VALID_NAME, false, Type.GlobalVariable);
+	}
+
+	Set<String> keySet(final BiVariableMap map, final IRubyObject receiver) {
+		return map.getRuntime().getGlobalVariables().getNames();
+	}
+
+	@Override
+	IRubyObject retrieve(final BiVariableMap map, final IRubyObject receiver, final String name) {
+		return map.getRuntime().getGlobalVariables().get(name);
+	}
+
+	@Override
+	void inject(final BiVariableMap map, final IRubyObject receiver, final String name, final IRubyObject value) {
+		map.getRuntime().getGlobalVariables().set(name, value);
+	}
+
+	@Override
+	void remove(final BiVariableMap map, final IRubyObject receiver, final String name) {
+		map.getRuntime().getGlobalVariables().clear(name);
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/InstanceVariableAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/InstanceVariableAccessor.java
@@ -1,0 +1,78 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2009-2011 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jruby.Ruby;
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * An implementation of BiVariable for a Ruby instance variable.
+ *
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ */
+class InstanceVariableAccessor extends VariableAccessor {
+	private static final String VALID_NAME = "@([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
+
+	InstanceVariableAccessor() {
+		super(VALID_NAME, true, Type.InstanceVariable);
+	}
+
+	private IRubyObject getReceiver(BiVariableMap map, IRubyObject receiver) {
+		if (receiver == null)
+			return map.getRuntime().getTopSelf();
+		return receiver;
+	}
+
+	@Override
+	List<String> keySet(BiVariableMap map, IRubyObject receiver) {
+		return getReceiver(map, receiver).getInstanceVariables().getInstanceVariableNameList();
+	}
+
+	@Override
+	IRubyObject retrieve(BiVariableMap map, IRubyObject receiver, String name) {
+		return getReceiver(map, receiver).getInstanceVariables().getInstanceVariable(name);
+	}
+
+	@Override
+	void inject(BiVariableMap map, IRubyObject receiver, String name, IRubyObject value) {
+		getReceiver(map, receiver).getInstanceVariables().setInstanceVariable(name, value);
+	}
+
+	@Override
+	void remove(BiVariableMap map, IRubyObject receiver, String name) {
+		getReceiver(map, receiver).getInstanceVariables().removeInstanceVariable(name);
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/LocalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/LocalContext.java
@@ -40,25 +40,24 @@ import org.jruby.embed.AttributeName;
 import org.jruby.embed.LocalVariableBehavior;
 
 public class LocalContext {
+	protected final RubyInstanceConfig config;
+	private final LocalVariableBehavior behavior;
+	private final boolean lazy;
 
-    private final RubyInstanceConfig config;
-    private final LocalVariableBehavior behavior;
-    private final boolean lazy;
+	private Ruby runtime;
 
-    private Ruby runtime = null;
+	private BiVariableMap varMap;
+	private Map<AttributeName, Object> attributes;
 
-    private BiVariableMap varMap;
-    private Map<AttributeName, Object> attributes;
+	public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior) {
+		this(config, behavior, false);
+	}
 
-    public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior) {
-        this(config, behavior, false);
-    }
-
-    public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
-        this.config = config;
-        this.behavior = behavior;
-        this.lazy = lazy;
-    }
+	public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
+		this.config = config;
+		this.behavior = behavior;
+		this.lazy = lazy;
+	}
 
     // This method is used only from ThreadLocalContextProvider.
     // Other providers should instantialte runtime in their own way.
@@ -67,56 +66,67 @@ public class LocalContext {
         return getRuntime();
     }
 
-    public BiVariableMap getVarMap(LocalContextProvider provider) {
-        if (varMap == null) {
-            synchronized(this) {
-                if (varMap == null) {
-                    varMap = new BiVariableMap(provider, lazy);
-                }
-            }
-        }
-        return varMap;
-    }
+	public BiVariableMap getVarMap(LocalContextProvider provider) {
+		if (varMap == null) {
+			synchronized (this) {
+				if (varMap == null) {
+					varMap = new BiVariableMap(this, lazy);
+				}
+			}
+		}
+		return varMap;
+	}
 
-    public LocalVariableBehavior getLocalVariableBehavior() {
-        return behavior;
-    }
+	public LocalVariableBehavior getLocalVariableBehavior() {
+		return behavior;
+	}
 
-    @SuppressWarnings("MapReplaceableByEnumMap")
-    public Map<?, Object> getAttributeMap() {
-        if (attributes == null) {
-            synchronized(this) {
-                if (attributes == null) {
-                    attributes = new HashMap<AttributeName, Object>();
-                    attributes.put(AttributeName.READER, new InputStreamReader(System.in));
-                    attributes.put(AttributeName.WRITER, new PrintWriter(System.out, true));
-                    attributes.put(AttributeName.ERROR_WRITER, new PrintWriter(System.err, true));
-                }
-            }
-        }
-        return attributes;
-    }
+	@SuppressWarnings("MapReplaceableByEnumMap")
+	public Map<?, Object> getAttributeMap() {
+		if (attributes == null) {
+			synchronized (this) {
+				if (attributes == null) {
+					attributes = new HashMap<AttributeName, Object>();
+					attributes.put(AttributeName.READER, new InputStreamReader(System.in));
+					attributes.put(AttributeName.WRITER, new PrintWriter(System.out, true));
+					attributes.put(AttributeName.ERROR_WRITER, new PrintWriter(System.err, true));
+				}
+			}
+		}
+		return attributes;
+	}
 
-    public void remove() {
-        if (attributes != null) {
-            synchronized(this) { attributes.clear(); }
-        }
-        if (varMap != null) {
-            synchronized(this) { varMap.clear(); }
-        }
-    }
+	public void remove() {
+		// FIXME this should probably close READER, WRITER, ERROR_WRITER, but only if
+		// they aren't stdio
+		if (attributes != null) {
+			synchronized (this) {
+				attributes.clear();
+			}
+		}
+		if (varMap != null) {
+			synchronized (this) {
+				varMap.clear();
+			}
+		}
+	}
 
-    Ruby getRuntime() {
-        if (runtime == null) {
-            synchronized(this) {
-                if (runtime == null) {
-                    runtime = Ruby.newInstance(config);
-                }
-            }
-        }
-        return runtime;
-    }
+	Ruby getRuntime() {
+		if (runtime == null) {
+			synchronized (this) {
+				if (runtime == null) {
+					runtime = Ruby.newInstance(config);
+				}
+			}
+		}
+		return runtime;
+	}
 
-    boolean isInitialized() { return runtime != null; }
+	boolean isInitialized() {
+		return runtime != null;
+	}
 
+	RubyInstanceConfig getRubyInstanceConfig() {
+		return getRuntime().getInstanceConfig();
+	}
 }

--- a/core/src/main/java/org/jruby/embed/internal/LocalGlobalVariableAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/LocalGlobalVariableAccessor.java
@@ -1,0 +1,81 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2009-2012 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * An implementation of BiVariable for JSR223 style global variable. The
+ * assigned name is like a local variables in Java, but a global in Ruby.
+ *
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ */
+class LocalGlobalVariableAccessor extends VariableAccessor {
+	private static final String VALID_NAME = "([a-zA-Z]|(_([a-zA-Z]|_|\\d)))([a-zA-Z]|_|\\d)*";
+
+	LocalGlobalVariableAccessor() {
+		super(VALID_NAME, false, Type.LocalGlobalVariable);
+	}
+
+	Set<String> keySet(final BiVariableMap map, final IRubyObject receiver) {
+		// Ruby globals always start with a $ which needs to be stripped by the
+		// substring(1).
+		// they also permit a few special forms that don't match the valid names for
+		// LocalGlobalVariable. we remove them from the list here so those variables are
+		// consistently invisible and inaccessible using this API
+		return map.getRuntime().getGlobalVariables().getNames().stream().map(s -> s.substring(1))
+				.filter(this::isValidName).collect(Collectors.toSet());
+	}
+
+	@Override
+	boolean containsKey(BiVariableMap map, IRubyObject receiver, String name) {
+		return map.getRuntime().getGlobalVariables().getNames().contains("$" + name);
+	}
+
+	@Override
+	IRubyObject retrieve(final BiVariableMap map, final IRubyObject receiver, final String name) {
+		return map.getRuntime().getGlobalVariables().get('$' + name);
+	}
+
+	@Override
+	void inject(final BiVariableMap map, final IRubyObject receiver, final String name, final IRubyObject value) {
+		map.getRuntime().getGlobalVariables().set('$' + name, value);
+	}
+
+	@Override
+	void remove(final BiVariableMap map, final IRubyObject receiver, final String name) {
+		map.getRuntime().getGlobalVariables().clear('$' + name);
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/LocalVariableAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/LocalVariableAccessor.java
@@ -1,0 +1,70 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2009-2011 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.util.Set;
+
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * An implementation of BiVariable for a persistent local variable. This type of
+ * a local variable survives over multiple evaluation.
+ *
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ */
+class LocalVariableAccessor extends VariableAccessor {
+	private static final String VALID_NAME = "([a-z]|_)([a-zA-Z]|_|\\d)*";
+
+	public LocalVariableAccessor() {
+		super(VALID_NAME, false, Type.LocalVariable);
+	}
+
+	@Override
+	Set<String> keySet(BiVariableMap map, IRubyObject receiver) {
+		return map.getLocalVariableNames();
+	}
+
+	@Override
+	IRubyObject retrieve(BiVariableMap map, IRubyObject receiver, String name) {
+		return map.getLocalVariable(name);
+	}
+
+	@Override
+	void inject(BiVariableMap map, IRubyObject receiver, String name, IRubyObject value) {
+		map.setLocalVariable(name, value);
+	}
+
+	@Override
+	void remove(BiVariableMap map, IRubyObject receiver, String name) {
+		map.removeLocalVariable(name);
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
@@ -29,53 +29,36 @@
  */
 package org.jruby.embed.internal;
 
-import org.jruby.Ruby;
 import org.jruby.embed.LocalVariableBehavior;
 
+<<<<<<< HEAD
 import java.util.Map;
 
 public class SingleThreadLocalContextProvider extends AbstractLocalContextProvider {
+	private final LocalContext instance;
 
-    private final LocalContext instance;
+	public SingleThreadLocalContextProvider(LocalVariableBehavior behavior) {
+		super(behavior);
+		instance = getInstance();
+	}
 
-    public SingleThreadLocalContextProvider(LocalVariableBehavior behavior) {
-        super(behavior);
-        instance = getInstance();
-    }
+	public SingleThreadLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
+		super(behavior);
+		this.lazy = lazy;
+		instance = getInstance();
+	}
 
-    public SingleThreadLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
-        super(behavior);
-        this.lazy = lazy;
-        instance = getInstance();
-    }
+	protected LocalContext getInstance() {
+		return new LocalContext(config, behavior, lazy);
+	}
 
-    private LocalContext getLocalContext() {
-        return instance;
-    }
+	@Override
+	protected LocalContext getLocalContext() {
+		return instance;
+	}
 
-    @Override
-    public Ruby getRuntime() {
-        return getLocalContext().getRuntime();
-    }
-
-    @Override
-    public BiVariableMap getVarMap() {
-        return getLocalContext().getVarMap(this);
-    }
-
-    @Override
-    public Map getAttributeMap() {
-        return getLocalContext().getAttributeMap();
-    }
-
-    @Override
-    public boolean isRuntimeInitialized() {
-        return getLocalContext().isInitialized();
-    }
-
-    @Override
-    public void terminate() {
-        getLocalContext().remove();
-    }
-
+	@Override
+	public void terminate() {
+		instance.remove();
+	}
 }

--- a/core/src/main/java/org/jruby/embed/internal/SingletonLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/SingletonLocalContextProvider.java
@@ -29,106 +29,77 @@
  */
 package org.jruby.embed.internal;
 
-import java.util.Map;
-import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.embed.LocalVariableBehavior;
 
 /**
- * Singleton type local context provider.
- * As of JRuby 1.5.0 Ruby runtime returned from the getRuntime() method is a
- * classloader-global runtime.
+ * Singleton type local context provider. As of JRuby 1.5.0 Ruby runtime
+ * returned from the getRuntime() method is a classloader-global runtime.
  *
- * @author Yoko Harada &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
+ * @author Yoko Harada
+ *         &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
  */
 public class SingletonLocalContextProvider extends AbstractLocalContextProvider {
+	private static volatile LocalContext localContext;
 
-    private static volatile LocalContext localContext;
+	public SingletonLocalContextProvider(LocalVariableBehavior behavior) {
+		super(getGlobalRuntimeConfigOrNew(), behavior);
+	}
 
-    public static SingletonLocalContextProvider getProvider(final LocalVariableBehavior behavior, final boolean lazy) {
-        if (localContext == null) initLocalContext(behavior, lazy);
-        return new SingletonLocalContextProvider(localContext.getLocalVariableBehavior(), lazy);
-    }
+	public SingletonLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
+		this(getGlobalRuntimeConfigOrNew(), behavior, lazy);
+	}
 
-    private static void initLocalContext(final LocalVariableBehavior behavior, final boolean lazy) {
-        synchronized( SingletonLocalContextProvider.class ) {
-            if (localContext == null) {
-                localContext = new LocalContext(getGlobalRuntimeConfigOrNew(), behavior, lazy);
-            }
-        }
-    }
+	private SingletonLocalContextProvider(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
+		super(config, behavior);
+		this.lazy = lazy;
+	}
 
-    private LocalContext sharedLocalContext() {
-        if (localContext == null) initLocalContext(behavior, lazy);
-        return localContext;
-    }
+	private static void initLocalContext(final LocalVariableBehavior behavior, final boolean lazy) {
+		synchronized (SingletonLocalContextProvider.class) {
+			if (localContext == null) {
+				localContext = new GlobalContext(getGlobalRuntimeConfigOrNew(), behavior, lazy);
+			}
+		}
+	}
+
+	public static SingletonLocalContextProvider getProvider(final LocalVariableBehavior behavior, final boolean lazy) {
+		if (localContext == null)
+			initLocalContext(behavior, lazy);
+		return new SingletonLocalContextProvider(localContext.getLocalVariableBehavior(), lazy);
+	}
+
+	@Override
+	protected LocalContext getLocalContext() {
+		if (localContext == null)
+			initLocalContext(behavior, lazy);
+		return localContext;
+	}
+
+	@Override
+	public void terminate() {
+		if (localContext != null) {
+			synchronized (SingletonLocalContextProvider.class) {
+				if (localContext != null) {
+					localContext.remove();
+					localContext = null;
+				}
+			}
+		}
+	}
+
+	@Deprecated(since = "9.0.0.0") // no longer used
+	public static LocalContext getLocalContextInstance(RubyInstanceConfig config, LocalVariableBehavior behavior,
+			boolean lazy) {
+		if (localContext == null)
+			initLocalContext(behavior, lazy);
+		return localContext;
+	}
 
     @Deprecated(since = "9.0.0.0") // no longer used
-    public static LocalContext getLocalContextInstance(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
-        if (localContext == null) {
-            synchronized( SingletonLocalContextProvider.class ) {
-                if (localContext == null) {
-                    localContext = new LocalContext(config, behavior, lazy);
-                }
-            }
-        }
-        return localContext;
-    }
-
-    @Deprecated(since = "9.0.0.0") // no longer used
-    public static LocalVariableBehavior getLocalVariableBehaviorOrNull() {
-        if (localContext == null) return null;
-        return localContext.getLocalVariableBehavior();
-    }
-
-    public SingletonLocalContextProvider(LocalVariableBehavior behavior) {
-        super( getGlobalRuntimeConfigOrNew(), behavior );
-    }
-
-    public SingletonLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
-        this( getGlobalRuntimeConfigOrNew(), behavior, lazy );
-    }
-
-    private SingletonLocalContextProvider(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
-        super( config, behavior );
-        this.lazy = lazy;
-    }
-
-    @Override
-    public Ruby getRuntime() {
-        return getGlobalRuntime(this);
-    }
-
-    @Override
-    public RubyInstanceConfig getRubyInstanceConfig() {
-        return getGlobalRuntimeConfig(this);
-    }
-
-    @Override
-    public boolean isRuntimeInitialized() {
-        return Ruby.isGlobalRuntimeReady();
-    }
-
-    @Override
-    public BiVariableMap getVarMap() {
-        return sharedLocalContext().getVarMap(this);
-    }
-
-    @Override
-    public Map getAttributeMap() {
-        return sharedLocalContext().getAttributeMap();
-    }
-
-    @Override
-    public void terminate() {
-        if (localContext != null) {
-            synchronized( SingletonLocalContextProvider.class ) {
-                if (localContext != null) {
-                    localContext.remove();
-                    localContext = null;
-                }
-            }
-        }
-    }
-
+	public static LocalVariableBehavior getLocalVariableBehaviorOrNull() {
+		if (localContext == null)
+			return null;
+		return localContext.getLocalVariableBehavior();
+	}
 }

--- a/core/src/main/java/org/jruby/embed/internal/ThreadSafeLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/ThreadSafeLocalContextProvider.java
@@ -29,47 +29,31 @@
  */
 package org.jruby.embed.internal;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicReference;
-import org.jruby.Ruby;
 import org.jruby.embed.LocalVariableBehavior;
 
 public class ThreadSafeLocalContextProvider extends AbstractLocalContextProvider {
-    private final ThreadLocalContext contextHolder = new ThreadLocalContext(this::getInstance);
+	private final ThreadLocalContext contextHolder = new ThreadLocalContext(this::createLocalContext);
 
-    public ThreadSafeLocalContextProvider(LocalVariableBehavior behavior) {
-        super(behavior);
-    }
+	public ThreadSafeLocalContextProvider(LocalVariableBehavior behavior) {
+		super(behavior);
+	}
 
-    public ThreadSafeLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
-        super(behavior);
-        this.lazy = lazy;
-    }
+	public ThreadSafeLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
+		super(behavior);
+		this.lazy = lazy;
+	}
 
-    @Override
-    public Ruby getRuntime() {
-        return contextHolder.get().getRuntime();
-    }
+	protected LocalContext createLocalContext() {
+		return new LocalContext(config, behavior, lazy);
+	}
 
-    @Override
-    public BiVariableMap getVarMap() {
-        return contextHolder.get().getVarMap(this);
-    }
+	@Override
+	protected LocalContext getLocalContext() {
+		return contextHolder.get();
+	}
 
-    @Override
-    public Map getAttributeMap() {
-        return contextHolder.get().getAttributeMap();
-    }
-
-    @Override
-    public boolean isRuntimeInitialized() {
-        return contextHolder.get().isInitialized();
-    }
-
-    @Override
-    public void terminate() {
-    	contextHolder.terminate();
-    }
-
+	@Override
+	public void terminate() {
+		contextHolder.terminate();
+	}
 }

--- a/core/src/main/java/org/jruby/embed/internal/VariableAccessor.java
+++ b/core/src/main/java/org/jruby/embed/internal/VariableAccessor.java
@@ -1,0 +1,144 @@
+package org.jruby.embed.internal;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.jruby.embed.LocalVariableBehavior;
+import org.jruby.embed.variable.BiVariable.Type;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * Basically mirrors the {@link AbstractVariable} class hierarchy, but isn't
+ * meant to be held as one instance per variable. Instead, there is now one
+ * instance for each kind of variable.
+ */
+abstract class VariableAccessor {
+	private final Pattern validNamePattern;
+	private final boolean hasReceicer;
+	private Type type;
+
+	private static final VariableAccessor ARGV = new ArgvAccessor();
+	private static final VariableAccessor LOCALGLOBAL = new LocalGlobalVariableAccessor();
+	private static final VariableAccessor LOCAL = new LocalVariableAccessor();
+	private static final VariableAccessor GLOBAL = new GlobalVariableAccessor();
+	private static final VariableAccessor INSTANCE = new InstanceVariableAccessor();
+	private static final VariableAccessor CLASS = new ClassVariableAccessor();
+	private static final VariableAccessor CONSTANT = new ConstantAccessor();
+
+	static List<VariableAccessor> getAll(LocalVariableBehavior behavior) {
+		switch (behavior) {
+		case GLOBAL:
+			return List.of(ARGV, LOCALGLOBAL);
+		case BSF:
+			return List.of(ARGV, LOCAL, GLOBAL);
+		case PERSISTENT:
+		case TRANSIENT:
+			return List.of(ARGV, GLOBAL, INSTANCE, CLASS, CONSTANT, LOCAL);
+		default:
+			throw new IllegalArgumentException(behavior.toString());
+		}
+	}
+
+	static VariableAccessor getInstance(LocalVariableBehavior behavior, String name) {
+		for (final VariableAccessor acc : getAll(behavior))
+			if (acc.isValidName(name))
+				return acc;
+		return null;
+	}
+
+	VariableAccessor(final String validNamePattern, final boolean hasReceicer, final Type type) {
+		this.validNamePattern = Pattern.compile(validNamePattern);
+		this.hasReceicer = hasReceicer;
+		this.type = type;
+	}
+
+	boolean isValidName(final String name) {
+		if (name == null)
+			return false;
+		return validNamePattern.matcher(name).matches();
+	}
+
+	boolean hasReceiver() {
+		return hasReceicer;
+	}
+
+	Type getType() {
+		return type;
+	}
+
+	/**
+	 * Tests whether the given variable exists.
+	 * 
+	 * @param runtime  the BiVariableMap object
+	 * @param receiver a receiver object. <code>null</code> to set a value on the
+	 *                 top self object. ignored for types of variable that aren't
+	 *                 associated with a ruby object, such as local or global
+	 *                 variables.
+	 * @param name     name of the variable. must match {@link #isValidName(String)}
+	 * @return <code>true</code> if a variable of the given name exists
+	 */
+	boolean containsKey(BiVariableMap map, IRubyObject receiver, String name) {
+		// this is a separate method because keySet produces a large temporary list for
+		// ConstantAccessor and LocalGlobalVariableAccessor. containsKey is overridden
+		// for these two cases.
+		return keySet(map, receiver).contains(name);
+	}
+
+	/**
+	 * Lists all variables of the given type. The returned set may or may not be a
+	 * copy and should never be modified externally. This operation may be somewhat
+	 * expensive and can return a large result.
+	 * 
+	 * @param runtime  the BiVariableMap object
+	 * @param receiver a receiver object. <code>null</code> to set a value on the
+	 *                 top self object. ignored for types of variable that aren't
+	 *                 associated with a ruby object, such as local or global
+	 *                 variables.
+	 * @return a Collection of variable names. need not actually be a Set
+	 */
+	abstract Collection<String> keySet(BiVariableMap map, IRubyObject receiver);
+
+	/**
+	 * Creates or updates a variable.
+	 * 
+	 * @param runtime  the BiVariableMap object
+	 * @param receiver a receiver object. <code>null</code> to write a variable on
+	 *                 the top self object. ignored for types of variable that
+	 *                 aren't associated with a ruby object, such as local or global
+	 *                 variables.
+	 * @param name     name of the variable. must match {@link #isValidName(String)}
+	 * @param value    new value of the variable
+	 */
+	abstract void inject(BiVariableMap map, IRubyObject receiver, String name, IRubyObject value);
+
+	/**
+	 * Reads the value of a variable. Reading nonexistent variables may cause a
+	 * warning to be issued.
+	 * 
+	 * @param runtime  the BiVariableMap object
+	 * @param receiver a receiver object. <code>null</code> to read a variable on
+	 *                 the top self object. ignored for types of variable that
+	 *                 aren't associated with a ruby object, such as local or global
+	 *                 variables.
+	 * @param name     name of the variable. must match {@link #isValidName(String)}
+	 * @return the value of the variable. <code>null</code> if it is set to
+	 *         {@code nil} or doesn't exist.
+	 */
+	abstract IRubyObject retrieve(BiVariableMap map, IRubyObject receiver, String name);
+
+	/**
+	 * Unsets / deletes a variable, or sets it to {@code nil}. Deleting a
+	 * nonexistent global variable may actually end up creating it but with a nil
+	 * value. FIXME that isn't very consistent!! Also, deletion is ignored if a
+	 * variable doesn't exist – that, at least, is logical.
+	 * 
+	 * @param runtime  the BiVariableMap object
+	 * @param receiver a receiver object. <code>null</code> to set a value on the
+	 *                 top self object. ignored for types of variable that aren't
+	 *                 associated with a ruby object, such as local or global
+	 *                 variables.
+	 * @param name     name of the variable. must match {@link #isValidName(String)}
+	 */
+	abstract void remove(BiVariableMap map, IRubyObject receiver, String name);
+}

--- a/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
+++ b/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
@@ -134,6 +134,7 @@ public class VariableInterceptor {
      * @param map a variable map that has name-value pairs to be injected
      * @param scope scope to inject local variable values
      */
+    @Deprecated
     public static void inject(BiVariableMap map, DynamicScope scope) {
         // lvar might not be given while parsing but be given when evaluating.
         // to avoid ArrayIndexOutOfBoundsException, checks the length of scope.getValues()
@@ -156,6 +157,7 @@ public class VariableInterceptor {
      * @param map variable map that holds retrieved name-value pairs.
      * @param receiver a receiver when the script has been evaluated once
      */
+    @Deprecated
     public static void retrieve(LocalVariableBehavior behavior, BiVariableMap map, RubyObject receiver) {
         Argv.retrieve(receiver, map);
         switch (behavior) {

--- a/core/src/test/java/org/jruby/embed/internal/ConcurrentLocalContextProviderTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/ConcurrentLocalContextProviderTest.java
@@ -153,7 +153,7 @@ public class ConcurrentLocalContextProviderTest {
     /**
      * Test of getRuntime method, of class ConcurrentLocalContextProvider.
      */
-    //@Test
+    @Test
     public void testGetRuntime() {
         logger1.info("getRuntime");
         ConcurrentLocalContextProvider cook =
@@ -173,7 +173,7 @@ public class ConcurrentLocalContextProviderTest {
     /**
      * Test of getRubyInstanceConfig method, of class ConcurrentLocalContextProvider.
      */
-    //@Test
+    @Test
     public void testGetRubyInstanceConfig() {
         logger1.info("getRubyInstanceConfig");
         ConcurrentLocalContextProvider cook =
@@ -190,18 +190,16 @@ public class ConcurrentLocalContextProviderTest {
             // no need to test
         }
 
-        ConcurrentLocalContextProviderStub provider = new ConcurrentLocalContextProviderStub(LocalVariableBehavior.TRANSIENT);
-        provider.isGlobalRuntimeReady = false;
+        ConcurrentLocalContextProviderStub provider = new ConcurrentLocalContextProviderStub();
+        provider.stub.isGlobalRuntimeReady = false;
         assertNotNull( provider.getRubyInstanceConfig() );
-        assertFalse( provider.runtimeInitialized ); // make sure we do not call getRuntime()
-
-
+        assertFalse( provider.stub.runtimeInitialized ); // make sure we do not call getRuntime()
     }
 
     /**
      * Test of getVarMap method, of class ConcurrentLocalContextProvider.
      */
-    //@Test
+    @Test
     public void testGetVarMap() {
         logger1.info("getVarMap");
         ConcurrentLocalContextProvider cook =
@@ -223,7 +221,7 @@ public class ConcurrentLocalContextProviderTest {
     /**
      * Test of getAttributeMap method, of class ConcurrentLocalContextProvider.
      */
-    //@Test
+    @Test
     public void testGetAttributeMap() {
         logger1.info("getAttributeMap");
         ConcurrentLocalContextProvider cook =
@@ -244,7 +242,7 @@ public class ConcurrentLocalContextProviderTest {
     /**
      * Test of isRuntimeInitialized method, of class ConcurrentLocalContextProvider.
      */
-    //@Test
+    @Test
     public void testIsRuntimeInitialized() {
         logger1.info("isRuntimeInitialized");
         ConcurrentLocalContextProvider cook =
@@ -254,7 +252,7 @@ public class ConcurrentLocalContextProviderTest {
         else assertFalse(result);
     }
 
-    //@Test
+    @Test
     public void testTerminate() {
         logger1.info("isTerminate");
         ConcurrentLocalContextProvider cook =
@@ -266,34 +264,18 @@ public class ConcurrentLocalContextProviderTest {
         }
     }
 
+    // do not use this test stub for testing concurrency behavior!
+    // unlike the real class, it doesn't have per-thread variables etc
     private static class ConcurrentLocalContextProviderStub extends ConcurrentLocalContextProvider {
+    	private GlobalContextStub stub = new GlobalContextStub();
 
-        Boolean isGlobalRuntimeReady = null;
-
-        ConcurrentLocalContextProviderStub(LocalVariableBehavior behavior) {
-            super( behavior );
+        ConcurrentLocalContextProviderStub() {
+            super(LocalVariableBehavior.TRANSIENT, true);
         }
 
-        ConcurrentLocalContextProviderStub(LocalVariableBehavior behavior, boolean lazy) {
-            super( behavior, lazy );
-        }
-
-        boolean runtimeInitialized = false;
-
-        @Override
-        public Ruby getRuntime() {
-            runtimeInitialized = true;
-            return super.getRuntime();
-        }
-
-        @Override
-        boolean isGlobalRuntimeReady() {
-            if ( isGlobalRuntimeReady != null ) {
-                return isGlobalRuntimeReady.booleanValue();
-            }
-            return super.isGlobalRuntimeReady();
-        }
-
+		@Override
+		protected LocalContext createGlobalContext() {
+			return stub;
+		}
     }
-
 }

--- a/core/src/test/java/org/jruby/embed/internal/GlobalContextStub.java
+++ b/core/src/test/java/org/jruby/embed/internal/GlobalContextStub.java
@@ -1,0 +1,40 @@
+package org.jruby.embed.internal;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jruby.Ruby;
+import org.jruby.embed.LocalVariableBehavior;
+
+public class GlobalContextStub extends GlobalContext {
+	AtomicReference<Ruby> globalRuntimeHolder = new AtomicReference<Ruby>();
+	boolean runtimeInitialized;
+	Boolean isGlobalRuntimeReady;
+
+	public GlobalContextStub() {
+		super(AbstractLocalContextProvider.getGlobalRuntimeConfigOrNew(), LocalVariableBehavior.TRANSIENT, true);
+	}
+
+	@Override
+	public Ruby getRuntime() {
+		runtimeInitialized = true;
+		return super.getRuntime();
+	}
+
+	@Override
+	boolean isInitialized() {
+		if (isGlobalRuntimeReady != null)
+			return isGlobalRuntimeReady.booleanValue();
+		return super.isInitialized();
+	}
+
+	@Override
+	Ruby getGlobalRuntime() {
+		if (isGlobalRuntimeReady)
+			return globalRuntimeHolder.get();
+
+		final Ruby globalRuntime = super.getGlobalRuntime();
+		isGlobalRuntimeReady = true;
+		globalRuntimeHolder.set(globalRuntime);
+		return globalRuntime;
+	}
+}

--- a/core/src/test/java/org/jruby/embed/internal/SingletonLocalContextProviderTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/SingletonLocalContextProviderTest.java
@@ -28,43 +28,30 @@ public class SingletonLocalContextProviderTest {
             assertTrue(Ruby.getGlobalRuntime().getInstanceConfig() == provider.getRubyInstanceConfig());
         }
 
-        SingletonLocalContextProviderStub provider = newProviderStub();
-        provider.isGlobalRuntimeReady = false;
+        SingletonLocalContextProviderStub provider = new SingletonLocalContextProviderStub();
+        provider.stub.isGlobalRuntimeReady = false;
+        provider.stub.globalRuntimeHolder.set(null);
         assertNotNull( provider.getRubyInstanceConfig() );
-        assertFalse( provider.runtimeInitialized ); // make sure we do not call getRuntime()
+        assertFalse( provider.stub.runtimeInitialized ); // make sure we do not call getRuntime()
 
-        provider.isGlobalRuntimeReady = true;
+        provider.stub.isGlobalRuntimeReady = true;
+        provider.stub.globalRuntimeHolder.set(Ruby.getGlobalRuntime());
         assertNotNull( provider.getRubyInstanceConfig() );
         assertSame(Ruby.getGlobalRuntime().getInstanceConfig(), provider.getRubyInstanceConfig());
 
-        final AtomicReference<Ruby> globalRuntimeHolder = new AtomicReference<Ruby>();
-        provider = new SingletonLocalContextProviderStub() {
-
-            {
-                isGlobalRuntimeReady = false;
-            }
-
-            @Override
-            Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
-                if ( isGlobalRuntimeReady ) return globalRuntimeHolder.get();
-
-                final Ruby globalRuntime = super.getGlobalRuntime(provider);
-                isGlobalRuntimeReady = true;
-                globalRuntimeHolder.set(globalRuntime);
-                return globalRuntime;
-            }
-
-        };
+        provider = new SingletonLocalContextProviderStub();
+        provider.stub.isGlobalRuntimeReady = false;
+        provider.stub.globalRuntimeHolder.set(null);
 
         final RubyInstanceConfig config = provider.getRubyInstanceConfig();
         assertNotNull( config );
-        assertNull( globalRuntimeHolder.get() );
+        assertNull( provider.stub.globalRuntimeHolder.get() );
 
-        provider.getRuntime();
+        //provider.getRuntime();
         assertNotNull( provider.getRuntime() );
         assertSame( config, provider.getRubyInstanceConfig() );
-        assertNotNull( globalRuntimeHolder.get() );
-        assertSame( config, globalRuntimeHolder.get().getInstanceConfig() );
+        assertNotNull( provider.stub.globalRuntimeHolder.get() );
+        assertSame( config, provider.stub.globalRuntimeHolder.get().getInstanceConfig() );
     }
 
     @Test
@@ -92,48 +79,16 @@ public class SingletonLocalContextProviderTest {
         return new SingletonLocalContextProvider(LocalVariableBehavior.TRANSIENT, true);
     }
 
-    private SingletonLocalContextProviderStub newProviderStub() {
-        return new SingletonLocalContextProviderStub();
-    }
-
     private static class SingletonLocalContextProviderStub extends SingletonLocalContextProvider {
+		GlobalContextStub stub = new GlobalContextStub();
 
-        Boolean isGlobalRuntimeReady = null;
+		private SingletonLocalContextProviderStub() {
+			super(LocalVariableBehavior.TRANSIENT, true);
+		}
 
-        private SingletonLocalContextProviderStub() {
-            super( LocalVariableBehavior.TRANSIENT, true );
-        }
-
-        SingletonLocalContextProviderStub(LocalVariableBehavior behavior) {
-            super( behavior );
-        }
-
-        SingletonLocalContextProviderStub(LocalVariableBehavior behavior, boolean lazy) {
-            super( behavior, lazy );
-        }
-
-        boolean runtimeInitialized = false;
-
-        @Override
-        public Ruby getRuntime() {
-            runtimeInitialized = true;
-            return super.getRuntime();
-        }
-
-        @Override
-        boolean isGlobalRuntimeReady() {
-            if ( isGlobalRuntimeReady != null ) {
-                return isGlobalRuntimeReady.booleanValue();
-            }
-            return super.isGlobalRuntimeReady();
-        }
-
-        //@Override
-        //Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
-        //    if ( globalRuntime != null ) return globalRuntime;
-        //    return super.getGlobalRuntime(provider);
-        //}
-
-    }
-
+		@Override
+		protected LocalContext getLocalContext() {
+			return stub;
+		}
+	}
 }


### PR DESCRIPTION
This is an attempt at refactoring the `BiVariableMap` interface so it no longer keeps a copy of every single Ruby variable. It does still have to store all local variables, but for everything else it can retrieve them from either the specified receiver object or the Ruby runtime's global state.

This means instance varibles are no longer stored in `BiVariableMap`, thus they can no longer cause the #8527 memory leak. It should also improve performance somewhat because it avoids a lot of copying before and after every evaluation.

It does however introduce 2 minor behavior changes:
- Since the "java type" of variables set via the RedBridge API can also no longer be stored, it is no longer preserved across the set/evaluate/get cycle. That is, a variable that has been set to a `String[]` will now come back as a `RubyArray` object (which can be used as a `List<String>`, but not `String[]`) when retrieved after evaluation. This is undocumented behavior, but it's a change from the previous behavior where reading the variable after evaluation would always try to convert its value back to the same type that was used for setting it.
- Variables are no longer snapshotted after evaluation. For `LocalContextProvider`s that use the global runtime, i.e. `ConcurrentLocalContextProvider` and obviously `SingletonLocalContextProvider`, this means that other threads can change the value of a global variable, constant, class variable, etc. between the evaluation and when the variable is read. As far as I can tell, evaluation and retrieval of (global etc.) variables has never been an atomic operation to begin with, but the timing window for getting race-y behavior is now somewhat larger.