### PR TITLE
Restore RubyHash(Ruby, int) for older ARJDBC versions

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -290,16 +290,21 @@ public class RubyHash extends RubyObject implements Map {
         this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, defaultValue));
     }
 
+    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.6.0", forRemoval = true)
     public RubyHash(Ruby runtime, IRubyObject defaultValue, int buckets) {
         super(runtime, runtime.getHash());
+        // ensure no subclasses call this constructor
+        assert getClass() == RubyHash.class;
         this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, defaultValue, buckets));
     }
 
-    // TODO should this be deprecated ? (to be efficient, internals should deal with RubyHash directly)
+    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.3.0", forRemoval = true)
     public RubyHash(Ruby runtime, Map valueMap, IRubyObject defaultValue) {
         super(runtime, runtime.getHash());
+        // ensure no subclasses call this constructor
+        assert getClass() == RubyHash.class;
         this.setDelegate(RubyHashLinkedBuckets.newHash(runtime, valueMap, defaultValue));
     }
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -266,9 +266,13 @@ public class RubyHash extends RubyObject implements Map {
     // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.6.0", forRemoval = true)
     public RubyHash(Ruby runtime, int buckets) {
-        this(runtime, UNDEF, buckets);
+        super(runtime, runtime.getHash());
+        // ensure no subclasses call this constructor
+        assert getClass() == RubyHash.class;
+        this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, buckets));
     }
 
+    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.6.0", forRemoval = true)
     public RubyHash(Ruby runtime) {
         super(runtime, runtime.getHash());

--- a/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
+++ b/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
@@ -174,10 +174,6 @@ public class RubyHashLinkedBuckets extends RubyHash {
         allocFirst();
     }
 
-    protected RubyHashLinkedBuckets(Ruby runtime, int buckets) {
-        this(runtime, UNDEF, buckets);
-    }
-
     protected RubyHashLinkedBuckets(Ruby runtime) {
         this(runtime, UNDEF);
     }
@@ -234,7 +230,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     }
 
     public static RubyHashLinkedBuckets newLBHash(Ruby runtime, int buckets) {
-        return new RubyHashLinkedBuckets(runtime, buckets);
+        return new RubyHashLinkedBuckets(runtime, UNDEF, buckets);
     }
 
     public static RubyHashLinkedBuckets newLBHash(Ruby runtime, int buckets, boolean objectSpace) {


### PR DESCRIPTION
This constructor is used by several current versions of ARJDBC. It was fixed for future versions in https://github.com/jruby/activerecord-jdbc-adapter/pull/1210 but not backported to any of the earlier versions yet.