### PR TITLE
Fix Enumerator::Lazy value packing of source yields

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerator.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerator.rb
@@ -146,7 +146,9 @@ class Enumerator
       proc do |yielder, *args|
         catch yielder do
           obj.each(*args) do |*x|
-            yield yielder, *x
+            # Match CRuby's rb_enum_values_pack (enum.c):
+            #   0 args -> nil, 1 arg -> the value, N args -> Array.
+            yield yielder, (x.size <= 1 ? x.first : x)
           end
         end
       end


### PR DESCRIPTION
Lazy.make_proc was an arity-faithful passthrough (`yield yielder, *x`) instead of applying CRuby's rb_enum_values_pack rule (enum.c): 0 args -> nil, 1 arg -> the value, N args -> Array. Pipeline stages downstream expect the packed form, so a zero-argument source yield surfaced as `[]` and a multi-argument yield surfaced as separate block args, both diverging from MRI.

Specced via Enumerable#take / Enumerator::Lazy#take shared examples in https://github.com/ruby/spec/pull/1363.