### PR TITLE
[9.4] backport [ji] support java.lang.Throwable#backtrace_locations (#9461)

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -43,6 +43,7 @@ import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaInternalBlockBody;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.RubyStringBuilder;
@@ -229,9 +230,8 @@ public abstract class JavaLang {
         public static IRubyObject backtrace(final ThreadContext context, final IRubyObject self) {
             final Ruby runtime = context.runtime;
             java.lang.Throwable throwable = unwrapIfJavaObject(self);
-            // TODO instead this should get aligned with NativeException !?!
             StackTraceElement[] stackTrace = throwable.getStackTrace();
-            if ( stackTrace == null ) return context.nil; // never actually happens
+            if ( stackTrace == null ) return context.nil;
             final int len = stackTrace.length;
             if ( len == 0 ) return RubyArray.newEmptyArray(runtime);
             IRubyObject[] backtrace = new IRubyObject[len];
@@ -239,6 +239,20 @@ public abstract class JavaLang {
                 backtrace[i] = RubyString.newString(runtime, stackTrace[i].toString());
             }
             return RubyArray.newArrayMayCopy(runtime, backtrace);
+        }
+
+        @JRubyMethod
+        public static IRubyObject backtrace_locations(final ThreadContext context, final IRubyObject self) {
+            java.lang.Throwable throwable = unwrapIfJavaObject(self);
+            StackTraceElement[] stackTrace = throwable.getStackTrace();
+            if ( stackTrace == null ) return context.nil;
+            final int len = stackTrace.length;
+            if ( len == 0 ) return RubyArray.newEmptyArray(context.runtime);
+            RubyStackTraceElement[] rubyStackTrace = new RubyStackTraceElement[len];
+            for ( int i = 0; i < len; i++ ) {
+                rubyStackTrace[i] = new RubyStackTraceElement(stackTrace[i]);
+            }
+            return RubyThread.Location.newLocationArray(context.runtime, rubyStackTrace);
         }
 
         @JRubyMethod // can not set backtrace for a java.lang.Throwable

--- a/test/jruby/test_backtraces.rb
+++ b/test/jruby/test_backtraces.rb
@@ -82,6 +82,22 @@ class TestBacktraces < Test::Unit::TestCase
     assert_equal 1, ruby_trace.length # only once!
   end
 
+  def test_java_backtrace_locations
+    org.jruby.test.TestHelper.throwTestHelperException
+    raise 'did no raise exception'
+  rescue java.lang.Exception => e
+    locations = e.backtrace_locations
+    assert_kind_of Array, locations
+    assert_kind_of Thread::Backtrace::Location, locations[0]
+
+    location = locations[0]
+    assert_equal 'org/jruby/test/TestHelper.java', location.path
+
+    assert_operator location.lineno, :>, 1
+    assert_equal 'throwTestHelperException', location.label
+    assert_match /TestHelper\.java:\d+:in .throwTestHelperException/, location.to_s
+  end
+
   def test_simple_exception_recursive
     @offset = __LINE__
     def meth(n)


### PR DESCRIPTION
Cherry-picks #9461 from commit 6d7819e5 to the `9.4` branch as discussed in https://github.com/jruby/jruby/issues/9458#issuecomment-4555215846
