### PR TITLE
Clean up more divergent keyword logic

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -721,7 +721,8 @@ public class IRRuntimeHelpers {
         return last;
     }
 
-    public static KwargsAction kwargsActionJIT(IRubyObject last, boolean ruby2Keywords, int callInfo) {
+    @JIT
+    private static KwargsAction kwargsActionJIT(IRubyObject last, boolean ruby2Keywords, int callInfo) {
         boolean isKwarg = hasKeywords(callInfo);
         if (ruby2Keywords) {
             // ruby2_keywords only get unmarked if it enters a method which accepts keywords.
@@ -792,6 +793,7 @@ public class IRRuntimeHelpers {
      * @param callInfo the callInfo metadata for the call
      * @return true if keywords should be processed, false otherwise
      */
+    @Interp
     private static boolean shouldHandleKwargs(IRubyObject[] args, int callInfo) {
         if (args.length > 0) {
             return shouldHandleKwargs(args[args.length - 1], callInfo);
@@ -809,6 +811,7 @@ public class IRRuntimeHelpers {
      * @param callInfo the callInfo metadata for the call
      * @return true if keywords should be processed, false otherwise
      */
+    @JIT
     private static boolean shouldHandleKwargs(IRubyObject lastArg, int callInfo) {
         return !keywordsEmpty(callInfo) && lastArg instanceof RubyHash;
     }
@@ -824,6 +827,7 @@ public class IRRuntimeHelpers {
         RETURN_HASH
     }
 
+    @Interp
     private static IRubyObject receiveKeywordsHash(ThreadContext context, IRubyObject[] args, boolean hasRestArgs,
                                                    boolean acceptsKeywords, boolean ruby2_keywords_method, int callInfo) {
         RubyHash hash = (RubyHash) args[args.length - 1];

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -705,7 +705,8 @@ public class IRRuntimeHelpers {
     @JIT
     public static IRubyObject receiveSpecificArityKeywords(ThreadContext context, IRubyObject last, boolean ruby2Keywords) {
         int callInfo = ThreadContext.resetCallInfo(context);
-        if (last instanceof RubyHash hash) {
+        if (shouldHandleKwargs(last, callInfo)) {
+            RubyHash hash = (RubyHash) last;
             KwargsAction kwargsAction = kwargsActionJIT(last, ruby2Keywords, callInfo);
             return switch (kwargsAction) {
                 case RETURN_DUP -> hash.dupFast(context);
@@ -778,7 +779,14 @@ public class IRRuntimeHelpers {
     }
 
     private static boolean shouldHandleKwargs(IRubyObject[] args, int callInfo) {
-        return (callInfo & CALL_KEYWORD_EMPTY) == 0 && args.length >= 1 && args[args.length - 1] instanceof RubyHash;
+        if (args.length > 0) {
+            return shouldHandleKwargs(args[args.length - 1], callInfo);
+        }
+        return false;
+    }
+
+    private static boolean shouldHandleKwargs(IRubyObject lastArg, int callInfo) {
+        return (callInfo & CALL_KEYWORD_EMPTY) == 0 && lastArg instanceof RubyHash;
     }
 
     enum KwargsAction {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -778,6 +778,20 @@ public class IRRuntimeHelpers {
         return UNDEFINED;
     }
 
+    /**
+     * For the given the argument list and callInfo, determine whether keyword argument
+     * processing should happen. The basic requirements are:
+     *
+     * <ul>
+     *     <li>callInfo metadata does not indicate explicitly-empty keyword args</li>
+     *     <li>one or more arguments in the argument list</li>
+     *     <li>last argument is a Hash</li>
+     * </ul>
+     *
+     * @param args the argument list
+     * @param callInfo the callInfo metadata for the call
+     * @return true if keywords should be processed, false otherwise
+     */
     private static boolean shouldHandleKwargs(IRubyObject[] args, int callInfo) {
         if (args.length > 0) {
             return shouldHandleKwargs(args[args.length - 1], callInfo);
@@ -785,8 +799,18 @@ public class IRRuntimeHelpers {
         return false;
     }
 
+    /**
+     * For the given last argument and callInfo, determine whether keyword argument
+     * processing should happen.
+     * </p>
+     * See {@link #shouldHandleKwargs(IRubyObject[], int)}.
+     *
+     * @param lastArg the last argument in the argument list
+     * @param callInfo the callInfo metadata for the call
+     * @return true if keywords should be processed, false otherwise
+     */
     private static boolean shouldHandleKwargs(IRubyObject lastArg, int callInfo) {
-        return (callInfo & CALL_KEYWORD_EMPTY) == 0 && lastArg instanceof RubyHash;
+        return !keywordsEmpty(callInfo) && lastArg instanceof RubyHash;
     }
 
     enum KwargsAction {

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -1554,6 +1554,13 @@ public final class ThreadContext {
         return hasKeywords(callInfo) && !keywordsEmpty(callInfo);
     }
 
+    /**
+     * Return true if the given callInfo indicates keywords are explicitly empty and
+     * should not be processed.
+     *
+     * @param callInfo the callInfo for a call
+     * @return true if marked as empty, false otherwise
+     */
     public static boolean keywordsEmpty(int callInfo) {
         return (callInfo & CALL_KEYWORD_EMPTY) != 0;
     }

--- a/spec/ruby/language/delegation_spec.rb
+++ b/spec/ruby/language/delegation_spec.rb
@@ -59,6 +59,20 @@ describe "delegation with def(...)" do
 
     a.new.delegate(1, b: 2).should == Range.new([[], {}, nil], nil, true)
   end
+
+  it "passes non-keyword trailing hash through without modification" do
+    a = Class.new(DelegationSpecs::Target)
+    a.class_eval(<<-RUBY)
+      def delegate(...)
+        target_single(...)
+      end
+    RUBY
+
+    h = {a:1}
+    h.freeze
+    h2 = a.new.delegate(h)
+    h2.should.equal?(h)
+  end
 end
 
 describe "delegation with def(x, ...)" do

--- a/spec/ruby/language/fixtures/delegation.rb
+++ b/spec/ruby/language/fixtures/delegation.rb
@@ -7,5 +7,9 @@ module DelegationSpecs
     def target_block(*args, **kwargs)
       yield [kwargs, args]
     end
+
+    def target_single(arg)
+      arg
+    end
   end
 end


### PR DESCRIPTION
There's still enough divergent keyword argument logic to cause #9462 due to a JIT path failing to check for empty kwargs. That fix and others will be part of this PR to unify more of the two sides.
