### PR TITLE
Shade redline to avoid conflicting with external versions

### DIFF
--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -25,6 +25,7 @@ project 'JRuby Core' do
                     { pattern: 'org.objectweb', shadedPattern: 'org.jruby.org.objectweb' },
                     { pattern: 'me.qmx.jitescript', shadedPattern: 'org.jruby.me.qmx.jitescript' },
                     { pattern: 'com.dylibso.chicory', shadedPattern: 'com.jruby.internal.org.dylibso.chicory'},
+                    { pattern: 'io.roastedroot.redline', shadedPattern: 'com.jruby.internal.io.roastedroot.redline'},
                     { pattern: 'org.ruby_lang.prism', shadedPattern: 'org.jruby.internal.prism'},
                     { pattern: 'org.jruby.parser.prism', shadedPattern: 'org.jruby.internal.parser.prism'}
                   ],

--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -41,7 +41,9 @@ project 'JRuby Core' do
                                      # Enable native access for JRuby and classpath classes when run not as a module
                                      'Enable-Native-Access' => 'ALL-UNNAMED',
                                    }
-                                 }],
+                                 },
+                                 { :@implementation => 'org.apache.maven.plugins.shade.resource.ServicesResourceTransformer'}
+                  ],
                   filters: [
                     { artifact: 'ch.randelshofer:fastdoubleparser', excludes: '**/23/**' },
                     { artifact: 'ch.randelshofer:fastdoubleparser', excludes: '**/17/**' },

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -57,6 +57,10 @@ DO NOT MODIFY - GENERATED CODE
                   <shadedPattern>com.jruby.internal.org.dylibso.chicory</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>io.roastedroot.redline</pattern>
+                  <shadedPattern>com.jruby.internal.io.roastedroot.redline</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.ruby_lang.prism</pattern>
                   <shadedPattern>org.jruby.internal.prism</shadedPattern>
                 </relocation>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -78,6 +78,7 @@ DO NOT MODIFY - GENERATED CODE
                     <Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
                   </manifestEntries>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
               <filters>
                 <filter>


### PR DESCRIPTION
This was the cause of CI issues reported in ruby/prism#4123