### PR TITLE
[fix] @JRubyMethod error with required>=1 and var-args

### DIFF
--- a/core/src/main/java/org/jruby/anno/MethodDescriptor.java
+++ b/core/src/main/java/org/jruby/anno/MethodDescriptor.java
@@ -159,7 +159,7 @@ public abstract class MethodDescriptor<T> {
      * @return arity value of specific required arity which can be used as an unboxed call or -1 for all other cases.
      */
     public int calculateSpecificCallArity() {
-        if (optional == 0 && !rest) {
+        if (optional == 0 && !rest && !hasVarArgs) {
             if (required == 0) {
                 if (actualRequired <= MAX_REQUIRED_UNBOXED_ARITY) return actualRequired;
             } else if (required >= 0 && required <= MAX_REQUIRED_UNBOXED_ARITY) {

--- a/core/src/test/java/org/jruby/test/TestMethodFactories.java
+++ b/core/src/test/java/org/jruby/test/TestMethodFactories.java
@@ -43,6 +43,7 @@ import static org.jruby.api.Define.defineModule;
 public class TestMethodFactories extends Base {
     public void testInvocationMethodFactory() {
         var mod = defineModule(context, "Wombat" + hashCode()).defineMethods(context, MyBoundClass.class);
+        confirmMethods(mod);
         confirmCheckArity(mod);
     }
 
@@ -57,6 +58,13 @@ public class TestMethodFactories extends Base {
         IRubyObject nil = context.nil;
         assertTrue("four-arg method should be callable",
                 mod.searchMethod("four_arg_method").call(context, mod, mod.getMetaClass(), "four_arg_method", new IRubyObject[] {nil, nil, nil, nil}).isTrue());
+        // methods with required <= 3 and IRubyObject[] args (missing rest=true) should bind and be callable
+        assertTrue("one-arg method should be callable",
+                mod.searchMethod("one_arg_method").call(context, mod, mod.getMetaClass(), "one_arg_method", new IRubyObject[] {nil}).isTrue());
+        assertTrue("two-arg method should be callable",
+                mod.searchMethod("two_arg_method").call(context, mod, mod.getMetaClass(), "two_arg_method", new IRubyObject[] {nil, nil}).isTrue());
+        assertTrue("three-arg method should be callable",
+                mod.searchMethod("three_arg_method").call(context, mod, mod.getMetaClass(), "three_arg_method", new IRubyObject[] {nil, nil, nil}).isTrue());
     }
 
     // jruby/jruby#7851: Restore automatic arity checking with an opt-out
@@ -88,6 +96,23 @@ public class TestMethodFactories extends Base {
         // JRUBY-3649
         @JRubyMethod(required = 4)
         public static IRubyObject four_arg_method(ThreadContext context, IRubyObject self, IRubyObject[] obj) {
+            return context.tru;
+        }
+
+        // methods with required <= 3 and IRubyObject[] args (missing rest=true) should bind correctly
+        // instead of crashing with ArrayIndexOutOfBoundsException in loadArguments
+        @JRubyMethod(required = 1)
+        public static IRubyObject one_arg_method(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+            return context.tru;
+        }
+
+        @JRubyMethod(required = 2)
+        public static IRubyObject two_arg_method(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+            return context.tru;
+        }
+
+        @JRubyMethod(required = 3)
+        public static IRubyObject three_arg_method(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             return context.tru;
         }
 


### PR DESCRIPTION
fixing @JRubyMethod with IRubyObject[] and required >= 3

```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at org.jruby.dist/org.jruby.internal.runtime.methods.InvocationMethodFactory.loadArguments(InvocationMethodFactory.java:559)
	at org.jruby.dist/org.jruby.internal.runtime.methods.InvocationMethodFactory.createAnnotatedMethodInvocation(InvocationMethodFactory.java:782)
	at org.jruby.dist/org.jruby.internal.runtime.methods.InvocationMethodFactory.addAnnotatedMethodInvoker(InvocationMethodFactory.java:719)
	at org.jruby.dist/org.jruby.internal.runtime.methods.InvocationMethodFactory.getAnnotatedMethodClass(InvocationMethodFactory.java:279)
	at org.jruby.dist/org.jruby.internal.runtime.methods.InvocationMethodFactory.getAnnotatedMethod(InvocationMethodFactory.java:328)
	at org.jruby.dist/org.jruby.RubyModule.defineAnnotatedMethod(RubyModule.java:1400)
	at org.jruby.dist/org.jruby.RubyModule.defineAnnotatedMethod(RubyModule.java:1374)
	at org.jruby.dist/org.jruby.anno.TypePopulator$ReflectiveTypePopulator.populate(TypePopulator.java:119)
	at org.jruby.dist/org.jruby.RubyModule.defineAnnotatedMethodsIndividually(RubyModule.java:1368)
	at org.jruby.dist/org.jruby.RubyModule.defineAnnotatedMethods(RubyModule.java:1272)
	at org.netssh.bcrypt_pbkdf.BCryptPbkdfExt.load(BCryptPbkdfExt.java:18)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.jruby.dist/org.jruby.ext.jruby.JRubyUtilLibrary.loadExtension(JRubyUtilLibrary.java:258)
	at org.jruby.dist/org.jruby.ext.jruby.JRubyUtilLibrary.load_ext(JRubyUtilLibrary.java:219)

```

identified at https://github.com/net-ssh/bcrypt_pbkdf-ruby/pull/30