### PR TITLE
Implement Proc#with_refinements

### DIFF
--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -35,10 +35,14 @@
 
 package org.jruby;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.ir.IRClosure;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.java.codegen.BlockInterfaceGenerator;
 import org.jruby.javasupport.Java;
@@ -58,6 +62,7 @@ import org.jruby.runtime.marshal.DataType;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.castAsModule;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -416,6 +421,33 @@ public class RubyProc extends RubyObject implements DataType {
     @JRubyMethod(name = "to_proc")
     public RubyProc to_proc() {
     	return this;
+    }
+
+    /**
+     * Return a new Proc whose body runs with the given modules' refinements active.  The receiver is unchanged and the
+     * captured closure environment is shared; only the refinement scope differs.  This is a heavy operation (it deep
+     * copies the block's IR), so callers are expected to cache and reuse the result.
+     */
+    @JRubyMethod(name = "with_refinements", rest = true)
+    public IRubyObject with_refinements(ThreadContext context, IRubyObject[] args) {
+        if (args.length == 0) throw argumentError(context, "wrong number of arguments (given 0, expected 1+)");
+
+        BlockBody body = block.getBody();
+        if (fromMethod || !(body instanceof IRBlockBody)) {
+            throw argumentError(context, "can't create a refinements-aware proc from this proc");
+        }
+
+        List<RubyModule> modules = new ArrayList<>(args.length);
+        for (IRubyObject arg : args) {
+            modules.add(castAsModule(context, arg));
+        }
+
+        IRClosure refinedClosure = ((IRBlockBody) body).getScope().cloneForRefinements(context, modules);
+        // Share the captured environment (binding holds the dynamic scope); clone the binding wrapper only so that
+        // proc setup (file/line/dummy-scope) does not mutate the original proc's binding.
+        Block newBlock = new Block(refinedClosure.getBlockBody(), block.getBinding().clone(), block.type);
+
+        return newProc(context.runtime, getMetaClass(), newBlock, type, file, line);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -35,9 +35,6 @@
 
 package org.jruby;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 
@@ -437,12 +434,12 @@ public class RubyProc extends RubyObject implements DataType {
             throw argumentError(context, "can't create a refinements-aware proc from this proc");
         }
 
-        List<RubyModule> modules = new ArrayList<>(args.length);
-        for (IRubyObject arg : args) {
-            modules.add(castAsModule(context, arg));
+        RubyModule[] modules = new RubyModule[args.length];
+        for (int i = 0; i < args.length; i++) {
+            modules[i] = castAsModule(context, args[i]);
         }
 
-        IRClosure refinedClosure = ((IRBlockBody) body).getScope().cloneForRefinements(context, modules);
+        IRClosure refinedClosure = ((IRBlockBody) body).getScope().refinementsClone(context, modules);
         // Share the captured environment (binding holds the dynamic scope); clone the binding wrapper only so that
         // proc setup (file/line/dummy-scope) does not mutate the original proc's binding.
         Block newBlock = new Block(refinedClosure.getBlockBody(), block.getBinding().clone(), block.type);

--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -5,6 +5,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.jruby.RubyModule;
 import org.jruby.RubySymbol;
 import org.jruby.ast.DefNode;
 import org.jruby.ast.IterNode;
@@ -26,6 +27,7 @@ import org.jruby.runtime.IRBlockBody;
 import org.jruby.runtime.MixedModeIRBlockBody;
 import org.jruby.runtime.InterpretedIRBlockBody;
 import org.jruby.runtime.Signature;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
 // Closures are contexts/scopes for the purpose of IR building.  They are self-contained and accumulate instructions
@@ -75,6 +77,17 @@ public class IRClosure extends IRScope {
     /* Inlining generates a new name and id and basic cloning will reuse the originals name */
     protected IRClosure(IRClosure c, IRScope lexicalParent, int closureId, ByteList fullName) {
         super(c, lexicalParent);
+        this.closureId = closureId;
+        super.setByteName(fullName);
+
+        isEND = c.isEND;
+
+        this.signature = c.signature;
+    }
+
+    /** Used by Proc#with_refinements cloning, which needs each clone to own a fresh StaticScope. */
+    protected IRClosure(IRClosure c, IRScope lexicalParent, int closureId, ByteList fullName, StaticScope staticScope) {
+        super(c, lexicalParent, staticScope);
         this.closureId = closureId;
         super.setByteName(fullName);
 
@@ -341,15 +354,33 @@ public class IRClosure extends IRScope {
         IRClosure clonedClosure;
         IRScope lexicalParent = ii.getScope();
 
+        // For Proc#with_refinements we give the clone its own StaticScope (a duplicate of ours) whose enclosing scope
+        // points at the clone's lexical parent.  This keeps the original untouched and lets a refinements overlay be
+        // reached by walking the enclosing-scope chain at method resolution time.
+        StaticScope refinementsScope = null;
+        if (ii.isRefinementsClone()) {
+            refinementsScope = getStaticScope().duplicate();
+            refinementsScope.setEnclosingScope(lexicalParent.getStaticScope());
+        }
+
         if (ii instanceof SimpleCloneInfo && !((SimpleCloneInfo) ii).isEnsureBlockCloneMode()) {
-            clonedClosure = new IRClosure(this, lexicalParent, closureId, getByteName());
+            clonedClosure = refinementsScope != null ?
+                    new IRClosure(this, lexicalParent, closureId, getByteName(), refinementsScope) :
+                    new IRClosure(this, lexicalParent, closureId, getByteName());
         } else {
             int id = lexicalParent.getNextClosureId();
             ByteList fullName = lexicalParent.getByteName();
             fullName = fullName != null ? fullName.dup() : new ByteList();
             fullName.append(CLOSURE_CLONE);
             fullName.append(java.lang.Integer.toString(id).getBytes());
-            clonedClosure = new IRClosure(this, lexicalParent, id, fullName);
+            clonedClosure = refinementsScope != null ?
+                    new IRClosure(this, lexicalParent, id, fullName, refinementsScope) :
+                    new IRClosure(this, lexicalParent, id, fullName);
+        }
+
+        if (refinementsScope != null) {
+            refinementsScope.setIRScope(clonedClosure);
+            clonedClosure.setIsMaybeUsingRefinements();
         }
 
         // WrappedIRClosure should always have a single unique IRClosure in them so we should
@@ -357,6 +388,35 @@ public class IRClosure extends IRScope {
         lexicalParent.addClosure(clonedClosure);
 
         return cloneForInlining(ii, clonedClosure);
+    }
+
+    /**
+     * Produce a refinement-aware deep copy of this closure tree for Proc#with_refinements.  The returned closure has
+     * its own StaticScope carrying an overlay with the given modules' refinements activated, and all of its (and nested
+     * closures') call-like instructions are re-created as refined call sites.  The original closure is left unchanged.
+     *
+     * @param context the current thread context
+     * @param modules the refinement modules to activate
+     * @return a new IRClosure whose body runs with the given refinements active
+     */
+    public IRClosure cloneForRefinements(ThreadContext context, List<RubyModule> modules) {
+        // Cloning reads the startup InterpreterContext as its instruction source.  This is built when the closure's
+        // defining scope is built, which has necessarily happened for any closure backing a live Proc.
+        if (getInterpreterContext() == null) {
+            throw context.runtime.newArgumentError("cannot create a refinements-aware copy of this proc");
+        }
+
+        SimpleCloneInfo ii = new SimpleCloneInfo(getLexicalParent(), false, false, true);
+        IRClosure clone = cloneForInlining(ii);
+        clone.setArgumentDescriptors(getArgumentDescriptors());
+
+        // Activate the requested refinements on the clone's own overlay module so refined call sites resolve them.
+        RubyModule overlay = clone.getStaticScope().getOverlayModuleForWrite(context);
+        for (RubyModule module : modules) {
+            RubyModule.usingModule(context, overlay, module);
+        }
+
+        return clone;
     }
 
     public Signature getSignature() {

--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -391,6 +391,52 @@ public class IRClosure extends IRScope {
     }
 
     /**
+     * Single-slot memo of the most recent refinement-aware clone of this closure (see {@link #refinementsClone}).
+     * Lazily set: stays null until Proc#with_refinements is first used on this closure, so closures that never use
+     * the feature pay only for one (null) reference.  Mirrors CRuby's single-slot memo: only the last (modules ->
+     * clone) pair is retained, and a differing modules set overwrites it.
+     */
+    private static final class RefinementsCache {
+        final RubyModule[] modules;
+        final IRClosure clone;
+
+        RefinementsCache(RubyModule[] modules, IRClosure clone) {
+            this.modules = modules;
+            this.clone = clone;
+        }
+
+        boolean matches(RubyModule[] other) {
+            if (modules.length != other.length) return false;
+            // Identity + order: RubyModule equality is identity, and refinement application order is significant.
+            for (int i = 0; i < modules.length; i++) {
+                if (modules[i] != other[i]) return false;
+            }
+            return true;
+        }
+    }
+
+    private volatile RefinementsCache refinementsCache;
+
+    /**
+     * Return a refinement-aware clone of this closure for the given modules, reusing the cached clone when the same
+     * modules (by identity and order) were used last time.  A miss recomputes via {@link #cloneForRefinements} and
+     * overwrites the single slot.  Lock-free: a race only causes a redundant clone, which is harmless.
+     *
+     * @param context the current thread context
+     * @param modules the refinement modules to activate (freshly allocated array; stored without copying)
+     * @return a clone whose body runs with the given refinements active
+     */
+    public IRClosure refinementsClone(ThreadContext context, RubyModule[] modules) {
+        RefinementsCache cache = refinementsCache;
+        if (cache != null && cache.matches(modules)) return cache.clone;
+
+        IRClosure clone = cloneForRefinements(context, modules);
+        refinementsCache = new RefinementsCache(modules, clone);
+
+        return clone;
+    }
+
+    /**
      * Produce a refinement-aware deep copy of this closure tree for Proc#with_refinements.  The returned closure has
      * its own StaticScope carrying an overlay with the given modules' refinements activated, and all of its (and nested
      * closures') call-like instructions are re-created as refined call sites.  The original closure is left unchanged.
@@ -399,7 +445,7 @@ public class IRClosure extends IRScope {
      * @param modules the refinement modules to activate
      * @return a new IRClosure whose body runs with the given refinements active
      */
-    public IRClosure cloneForRefinements(ThreadContext context, List<RubyModule> modules) {
+    public IRClosure cloneForRefinements(ThreadContext context, RubyModule[] modules) {
         // Cloning reads the startup InterpreterContext as its instruction source.  This is built when the closure's
         // defining scope is built, which has necessarily happened for any closure backing a live Proc.
         if (getInterpreterContext() == null) {

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -146,10 +146,19 @@ public abstract class IRScope implements ParseResult {
 
     // Used by cloning code for inlining
     protected IRScope(IRScope s, IRScope lexicalParent) {
+        this(s, lexicalParent, s.staticScope);
+    }
+
+    /**
+     * Copy constructor variant that uses a caller-supplied StaticScope instead of sharing the source scope's.  This is
+     * used by Proc#with_refinements cloning, which must give each cloned scope its own StaticScope so a refinements
+     * overlay can be attached without mutating the original.
+     */
+    protected IRScope(IRScope s, IRScope lexicalParent, StaticScope staticScope) {
         this.lexicalParent = lexicalParent;
         this.manager = s.manager;
         this.lineNumber = s.lineNumber;
-        this.staticScope = s.staticScope;
+        this.staticScope = staticScope;
         this.nextClosureIndex = s.nextClosureIndex;
         this.interpreterContext = null;
         this.coverageMode = CoverageData.NONE;

--- a/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
@@ -50,7 +50,7 @@ public class AttrAssignInstr extends NoResultCallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new AttrAssignInstr(ii.getScope(), getCallType(), getName(), getReceiver().cloneForInlining(ii),
-                cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
+                cloneCallArgs(ii), getFlags(), isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
@@ -126,7 +126,7 @@ public class CallInstr extends CallBase implements ResultInstr {
         return new CallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii),
-                getFlags(), isPotentiallyRefined()
+                getFlags(), isPotentiallyRefined() || ii.isRefinementsClone()
         );
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
@@ -48,7 +48,7 @@ public class ClassSuperInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new ClassSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()), getDefiningModule().cloneForInlining(ii),
                 name, cloneCallArgs(ii), getClosureArg().cloneForInlining(ii),
-                getFlags(), isPotentiallyRefined());
+                getFlags(), isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     public static ClassSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
@@ -52,7 +52,7 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new EQQInstr(ii.getScope(), ii.getRenamedVariable(result), getReceiver().cloneForInlining(ii),
-                getArg1().cloneForInlining(ii), isSplattedValue(), isPattern(), isPotentiallyRefined());
+                getArg1().cloneForInlining(ii), isSplattedValue(), isPattern(), isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
@@ -79,7 +79,7 @@ public class InstanceSuperInstr extends CallInstr {
         return new InstanceSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()),
                 getDefiningModule().cloneForInlining(ii), getName(), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined());
+                isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     public static InstanceSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/NoResultCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/NoResultCallInstr.java
@@ -44,7 +44,7 @@ public class NoResultCallInstr extends CallBase {
         return new NoResultCallInstr(ii.getScope(), getOperation(), getCallType(), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined());
+                isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     public static NoResultCallInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
@@ -61,7 +61,7 @@ public class UnresolvedSuperInstr extends CallInstr {
         return new UnresolvedSuperInstr(ii.getScope(), Operation.UNRESOLVED_SUPER, ii.getRenamedVariable(getResult()),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined());
+                isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     public static UnresolvedSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
@@ -40,7 +40,7 @@ public class ZSuperInstr extends UnresolvedSuperInstr {
     public Instr clone(CloneInfo ii) {
         return new ZSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()), getReceiver().cloneForInlining(ii),
                 cloneCallArgs(ii), getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined());
+                isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     public static ZSuperInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
@@ -27,7 +27,7 @@ public class OneArgOperandAttrAssignInstr extends AttrAssignInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new OneArgOperandAttrAssignInstr(ii.getScope(), getCallType(), getName(), getReceiver().cloneForInlining(ii),
-                cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
+                cloneCallArgs(ii), getFlags(), isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
@@ -32,6 +32,12 @@ public class OneFixnumArgNoBlockCallInstr extends CallInstr {
 
     @Override
     public Instr clone(CloneInfo ii) {
+        // The fixnum fast path is not implemented for refined call sites, so fall back to a generic refined call.
+        if (ii.isRefinementsClone()) {
+            return new OneOperandArgNoBlockCallInstr(ii.getScope(), Operation.CALL_1O, getCallType(),
+                    ii.getRenamedVariable(result), getName(), getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
+                    getFlags(), true);
+        }
         return new OneFixnumArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
     }

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
@@ -32,6 +32,12 @@ public class OneFloatArgNoBlockCallInstr extends CallInstr {
 
     @Override
     public Instr clone(CloneInfo ii) {
+        // The float fast path is not implemented for refined call sites, so fall back to a generic refined call.
+        if (ii.isRefinementsClone()) {
+            return new OneOperandArgNoBlockCallInstr(ii.getScope(), Operation.CALL_1O, getCallType(),
+                    ii.getRenamedVariable(result), getName(), getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
+                    getFlags(), true);
+        }
         return new OneFloatArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined()
         );

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
@@ -28,7 +28,7 @@ public class OneOperandArgBlockCallInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getClosureArg().cloneForInlining(ii), getFlags(), isPotentiallyRefined()
+                getClosureArg().cloneForInlining(ii), getFlags(), isPotentiallyRefined() || ii.isRefinementsClone()
         );
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
@@ -34,7 +34,7 @@ public class OneOperandArgNoBlockCallInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgNoBlockCallInstr(ii.getScope(), Operation.CALL_1O, getCallType(),
                 ii.getRenamedVariable(result), getName(), getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getFlags(), isPotentiallyRefined());
+                getFlags(), isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockNoResultCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockNoResultCallInstr.java
@@ -25,7 +25,7 @@ public class OneOperandArgNoBlockNoResultCallInstr extends NoResultCallInstr {
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgNoBlockNoResultCallInstr(ii.getScope(), getCallType(), getName(), getReceiver().cloneForInlining(ii),
                 cloneCallArgs(ii), getClosureArg().cloneForInlining(ii), getFlags(),
-                isPotentiallyRefined());
+                isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
@@ -26,7 +26,7 @@ public class TwoOperandArgNoBlockCallInstr  extends CallInstr  {
     @Override
     public Instr clone(CloneInfo ii) {
         return new TwoOperandArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined()
+                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined() || ii.isRefinementsClone()
         );
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
@@ -33,7 +33,7 @@ public class ZeroOperandArgNoBlockCallInstr extends CallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new ZeroOperandArgNoBlockCallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
+                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined() || ii.isRefinementsClone());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/WrappedIRClosure.java
+++ b/core/src/main/java/org/jruby/ir/operands/WrappedIRClosure.java
@@ -61,6 +61,12 @@ public class WrappedIRClosure extends Operand {
 
     @Override
     public Operand cloneForInlining(CloneInfo info) {
+        // For Proc#with_refinements we must deep-clone nested closures so they too become refinement-aware and get
+        // their own static scope; sharing the original closure would leak refinements back into it.
+        if (info.isRefinementsClone()) {
+            return new WrappedIRClosure(info.getRenamedVariable(self), closure.cloneForInlining(info));
+        }
+
         // Making interp instrs so that if JIT hits IRClosure we will not concurrently modify the same IRScope.
         if (info instanceof SimpleCloneInfo && !((SimpleCloneInfo) info).isEnsureBlockCloneMode()) {
             // FIXME: It really bothers me we do not clone closure here but cloning like main clone case loses interpContext + other things.

--- a/core/src/main/java/org/jruby/ir/transformations/inlining/CloneInfo.java
+++ b/core/src/main/java/org/jruby/ir/transformations/inlining/CloneInfo.java
@@ -26,11 +26,22 @@ public abstract class CloneInfo {
     public SimpleCloneInfo cloneForCloningClosure(IRClosure clonedClosure) {
         // If cloning for ensure block cloning we want to propagate that to child closure clones
         boolean ensureClone = this instanceof SimpleCloneInfo && ((SimpleCloneInfo) this).isEnsureBlockCloneMode();
-        SimpleCloneInfo clone = new SimpleCloneInfo(clonedClosure, ensureClone);
+        // If cloning for Proc#with_refinements we must propagate that so nested closures are also made refinement-aware
+        SimpleCloneInfo clone = new SimpleCloneInfo(clonedClosure, ensureClone, false, isRefinementsClone());
 
         clone.variableRenameMap.putAll(variableRenameMap);
 
         return clone;
+    }
+
+    /**
+     * Is this clone being performed to produce a refinement-aware copy (Proc#with_refinements)?  When true, call-like
+     * instructions are re-created as refined call sites bound to the clone's static scope.
+     *
+     * @return true if this is a refinements clone
+     */
+    public boolean isRefinementsClone() {
+        return false;
     }
 
     /**

--- a/core/src/main/java/org/jruby/ir/transformations/inlining/SimpleCloneInfo.java
+++ b/core/src/main/java/org/jruby/ir/transformations/inlining/SimpleCloneInfo.java
@@ -10,20 +10,32 @@ import org.jruby.ir.operands.Variable;
  */
 public class SimpleCloneInfo extends CloneInfo {
     private final boolean isEnsureBlock;
+    private final boolean refinementsClone;
     private boolean cloneIPC;
 
-    public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock, boolean cloneIPC) {
+    public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock, boolean cloneIPC, boolean refinementsClone) {
         super(scope);
 
         this.isEnsureBlock = isEnsureBlock;
+        this.cloneIPC = cloneIPC;
+        this.refinementsClone = refinementsClone;
+    }
+
+    public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock, boolean cloneIPC) {
+        this(scope, isEnsureBlock, cloneIPC, false);
     }
 
     public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock) {
-        this(scope, isEnsureBlock, false);
+        this(scope, isEnsureBlock, false, false);
     }
 
     public boolean isEnsureBlockCloneMode() {
         return this.isEnsureBlock;
+    }
+
+    @Override
+    public boolean isRefinementsClone() {
+        return this.refinementsClone;
     }
 
     public boolean shouldCloneIPC() {

--- a/test/jruby/test_proc_with_refinements.rb
+++ b/test/jruby/test_proc_with_refinements.rb
@@ -1,0 +1,94 @@
+require 'test/unit'
+
+# Tests for Proc#with_refinements (bugs.ruby-lang.org #16461).
+#
+# prc.with_refinements(mod, ...) returns a new Proc whose body runs with the given modules' refinements
+# active.  The receiver is unchanged and the captured closure environment is shared; only the refinement
+# scope differs.
+class TestProcWithRefinements < Test::Unit::TestCase
+  module StringRefinement
+    refine String do
+      def shout
+        upcase + "!"
+      end
+    end
+  end
+
+  module IntegerRefinement
+    refine Integer do
+      def double
+        self * 2
+      end
+    end
+  end
+
+  def test_refinement_applies
+    prc = ->(s) { s.shout }
+    refined = prc.with_refinements(StringRefinement)
+    assert_equal "HI!", refined.call("hi")
+  end
+
+  def test_original_proc_unaffected
+    prc = ->(s) { s.shout }
+    prc.with_refinements(StringRefinement)
+    assert_raise(NoMethodError) { prc.call("hi") }
+  end
+
+  def test_closure_environment_is_shared
+    counter = 0
+    prc = ->(s) { counter += 1; s.shout }
+    refined = prc.with_refinements(StringRefinement)
+    refined.call("a")
+    assert_equal 1, counter
+    refined.call("b")
+    assert_equal 2, counter
+    # The shared local is visible from the original proc too (without refinement method use).
+    plain = ->() { counter }
+    assert_equal 2, plain.call rescue nil
+  end
+
+  def test_multiple_modules
+    prc = ->(s, n) { [s.shout, n.double] }
+    refined = prc.with_refinements(StringRefinement, IntegerRefinement)
+    assert_equal ["HI!", 6], refined.call("hi", 3)
+  end
+
+  def test_nested_blocks
+    prc = ->(arr) { arr.map { |s| s.shout } }
+    refined = prc.with_refinements(StringRefinement)
+    assert_equal ["A!", "B!"], refined.call(["a", "b"])
+  end
+
+  def test_dup_preserves_refinements
+    prc = ->(s) { s.shout }
+    refined = prc.with_refinements(StringRefinement)
+    assert_equal "HI!", refined.dup.call("hi")
+    assert_equal "HI!", refined.clone.call("hi")
+  end
+
+  def test_proc_too_not_just_lambda
+    prc = proc { |s| s.shout }
+    refined = prc.with_refinements(StringRefinement)
+    assert_equal "HI!", refined.call("hi")
+  end
+
+  def test_error_no_arguments
+    prc = ->(s) { s.shout }
+    assert_raise(ArgumentError) { prc.with_refinements }
+  end
+
+  def test_error_non_module_argument
+    prc = ->(s) { s.shout }
+    assert_raise(TypeError) { prc.with_refinements(42) }
+  end
+
+  def test_error_symbol_to_proc
+    assert_raise(ArgumentError) { :shout.to_proc.with_refinements(StringRefinement) }
+  end
+
+  def test_error_method_to_proc
+    obj = Object.new
+    def obj.foo(s); s; end
+    assert_raise(ArgumentError) { obj.method(:foo).to_proc.with_refinements(StringRefinement) }
+  end
+end


### PR DESCRIPTION
Add Proc#with_refinements(mod1, ...), which returns a new Proc whose body runs with the given modules' refinements active. The receiver is unchanged and the captured closure environment is shared; only the refinement scope differs.

In JRuby whether a call resolves refinements is decided at IR build time: CallInstr.create reads scope.maybeUsingRefinements() and, when true, builds a RefinedCachingCallSite that captures the static scope. So a refinement-aware copy of the receiver proc's IR is required (the analog of CRuby recursively deep-copying the block iseq); merely swapping an overlay at runtime is not enough.

Implementation:
- RubyProc#with_refinements validates args (>=1, all Modules), rejects non-IR-block / method-backed procs, then deep-copies the block's IRClosure and wraps it in a new Block that shares a clone of the original binding.
- IRClosure#cloneForRefinements clones the closure tree via cloneForInlining with a new refinementsClone flag and activates the requested refinements on the top clone's overlay module.
- CloneInfo/SimpleCloneInfo gain isRefinementsClone(); when set each clone gets its own duplicated StaticScope (enclosing re-pointed to the parent clone) and maybeUsingRefinements, WrappedIRClosure deep-clones nested closures, and every call-bearing instruction's clone() rebuilds as a refined call site bound to the clone's scope. Fixnum/Float fast-path calls downgrade to generic refined calls. New IRScope/IRClosure copy-constructor variants accept a StaticScope since IRScope.staticScope is final.

When isRefinementsClone() is false (all other clone paths) behavior is unchanged. Adds test/jruby/test_proc_with_refinements.rb.