### PR TITLE
Make JVM bytecode version detection more robust

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1806,23 +1806,42 @@ public class RubyInstanceConfig {
         return calculateBytecodeVersion(specVersion);
     }
 
-    public static int calculateBytecodeVersion(String specVersion) {
-        if (specVersion.indexOf('.') != -1) {
-            switch (specVersion) {
-                default:
-                    System.err.println("unsupported Java version " + specVersion + ", using 1.8");
-                case "1.8":
-                    return Opcodes.V1_8;
-            }
+    public static int calculateBytecodeVersion(String givenVersion) {
+        // try given version, falling back on property and then lowest supported
+        int bytecodeVersion = parseJavaVersion(givenVersion);
+
+        if (bytecodeVersion != -1) return bytecodeVersion;
+
+        String defaultVersion = SafePropertyAccessor.getProperty("java.specification.version", "1.8");
+        if (givenVersion.equals(defaultVersion)) {
+            // can't determine spec version, use lowest supported
+            return Opcodes.V1_8;
         }
 
-        int version = Integer.parseInt(specVersion);
+        // default is different than given, try again
+        bytecodeVersion = parseJavaVersion(defaultVersion);
+
+        if (bytecodeVersion != -1) return bytecodeVersion;
+
+        System.err.println("unsupported Java version " + givenVersion + " and default version " + defaultVersion + ", using 1.8");
+        return Opcodes.V1_8;
+    }
+
+    private static int parseJavaVersion(String givenVersion) {
+        switch (givenVersion) {
+            case "1.8":
+            case "8":
+                return Opcodes.V1_8;
+        }
+
         try {
+            int version = Integer.parseInt(givenVersion);
             Field versionField = Opcodes.class.getField("V" + version);
             return (Integer) versionField.get(null);
         } catch (Exception e) {
-            return Opcodes.V21;
+            // return -1 below
         }
+        return -1;
     }
 
     @Deprecated

--- a/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
+++ b/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
@@ -152,17 +152,26 @@ public class TestRubyInstanceConfig extends Base {
 
     public void testBytecodeVersion() throws Exception {
         assertEquals("it uses Opcodes.V1_8 for '1.8'", Opcodes.V1_8, RubyInstanceConfig.calculateBytecodeVersion("1.8"));
+        assertEquals("it uses Opcodes.V1_8 for '8'", Opcodes.V1_8, RubyInstanceConfig.calculateBytecodeVersion("8"));
         assertEquals("it uses Opcodes.V9 for '9'", Opcodes.V9, RubyInstanceConfig.calculateBytecodeVersion("9"));
         assertEquals("it uses Opcodes.V21 for '21'", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("21"));
-        assertEquals("it uses Opcodes.V21 for '21'", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("21"));
-        assertEquals("it falls back on Opcodes.V21 for high unsupported versions", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("99"));
+
         PrintStream err = System.err;
+        String specVersion = System.getProperty("java.specification.version");
+
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); PrintStream ps = new PrintStream(baos)) {
+            System.setProperty( "java.specification.version", "9");
+            assertEquals("it falls back on java.specification.version for unsupported versions", Opcodes.V9, RubyInstanceConfig.calculateBytecodeVersion("999"));
+            assertEquals("it falls back on java.specification.version for unsupported versions", Opcodes.V9, RubyInstanceConfig.calculateBytecodeVersion("1.7"));
+            assertEquals("it falls back on java.specification.version for unsupported versions", Opcodes.V9, RubyInstanceConfig.calculateBytecodeVersion("gobbledygook"));
+
             System.setErr(ps);
-            assertEquals("it falls back on Opcodes.V1_8 for low unsupported versions", Opcodes.V1_8, RubyInstanceConfig.calculateBytecodeVersion("1.7"));
-            assertEquals("it outputs an error message for low unsupported versions", "unsupported Java version 1.7, using 1.8", new String(baos.toByteArray()).replaceAll("[\\n\\r]", ""));
+            System.setProperty( "java.specification.version", "gobbledygook");
+            assertEquals("it falls back on 1.8 when given version and system version are both unsupported", Opcodes.V1_8, RubyInstanceConfig.calculateBytecodeVersion("jabberwocky"));
+            assertEquals("it outputs a warning when given version and system version are both unsupported", "unsupported Java version jabberwocky and default version gobbledygook, using 1.8", new String(baos.toByteArray()).replaceAll("[\\n\\r]", ""));
         } finally {
             System.setErr(err);
+            System.setProperty("java.specification.version", specVersion);
         }
     }
 }


### PR DESCRIPTION
* Both 1.8 and 8 work for Java 1.8
* Unsupported configured versions fall back on system default
* Unsupported configured and default versions fall back on 1.8

All combinations are tested.