### PR TITLE
Make JVM bytecode version detection more robust

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -55,6 +55,7 @@ import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
 import org.objectweb.asm.Opcodes;
 
 import java.io.*;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1832,14 +1833,39 @@ public class RubyInstanceConfig {
 
     private static int initJavaBytecodeVersion() {
         final String specVersion = Options.BYTECODE_VERSION.load();
+        return calculateBytecodeVersion(specVersion);
+    }
 
-        int version = Integer.parseInt(specVersion);
-        switch (version) {
-            default:
-            case 21:
-            case 22:
-                return Opcodes.V21;
+    public static int calculateBytecodeVersion(String givenVersion) {
+        // try given version, falling back on property and then lowest supported
+        int bytecodeVersion = parseJavaVersion(givenVersion);
+
+        if (bytecodeVersion != -1) return bytecodeVersion;
+
+        String defaultVersion = SafePropertyAccessor.getProperty("java.specification.version", "21");
+        if (givenVersion.equals(defaultVersion)) {
+            // can't determine spec version, use lowest supported
+            return Opcodes.V21;
         }
+
+        // default is different than given, try again
+        bytecodeVersion = parseJavaVersion(defaultVersion);
+
+        if (bytecodeVersion != -1) return bytecodeVersion;
+
+        System.err.println("unsupported Java version " + givenVersion + " and default version " + defaultVersion + ", using 21");
+        return Opcodes.V21;
+    }
+
+    private static int parseJavaVersion(String givenVersion) {
+        try {
+            int version = Integer.parseInt(givenVersion);
+            Field versionField = Opcodes.class.getField("V" + version);
+            return (Integer) versionField.get(null);
+        } catch (Exception e) {
+            // return -1 below
+        }
+        return -1;
     }
 
     @Deprecated(since = "1.7.0")

--- a/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
+++ b/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
@@ -31,6 +31,7 @@ package org.jruby.test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
@@ -39,6 +40,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.load.LoadService;
+import org.objectweb.asm.Opcodes;
 
 import static org.jruby.api.Access.loadService;
 
@@ -142,5 +144,28 @@ public class TestRubyInstanceConfig extends Base {
       if (osName.contains("mac")) return "/dev/fd/0";
 
       return "/dev/stdin";
+    }
+
+    public void testBytecodeVersion() throws Exception {
+        assertEquals("it uses Opcodes.V21 for '21'", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("21"));
+        assertEquals("it uses Opcodes.V23 for '23'", Opcodes.V23, RubyInstanceConfig.calculateBytecodeVersion("23"));
+
+        PrintStream err = System.err;
+        String specVersion = System.getProperty("java.specification.version");
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); PrintStream ps = new PrintStream(baos)) {
+            System.setProperty( "java.specification.version", "22");
+            assertEquals("it falls back on java.specification.version for unsupported versions", Opcodes.V22, RubyInstanceConfig.calculateBytecodeVersion("999"));
+            assertEquals("it falls back on java.specification.version for unsupported versions", Opcodes.V22, RubyInstanceConfig.calculateBytecodeVersion("1.7"));
+            assertEquals("it falls back on java.specification.version for unsupported versions", Opcodes.V22, RubyInstanceConfig.calculateBytecodeVersion("gobbledygook"));
+
+            System.setErr(ps);
+            System.setProperty( "java.specification.version", "gobbledygook");
+            assertEquals("it falls back on 21 when given version and system version are both unsupported", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("jabberwocky"));
+            assertEquals("it outputs a warning when given version and system version are both unsupported", "unsupported Java version jabberwocky and default version gobbledygook, using 21", new String(baos.toByteArray()).replaceAll("[\\n\\r]", ""));
+        } finally {
+            System.setErr(err);
+            System.setProperty("java.specification.version", specVersion);
+        }
     }
 }


### PR DESCRIPTION
* Unsupported configured versions fall back on system default
* Unsupported configured and default versions fall back on 21

All combinations are tested.