### PR TITLE
ASM update

### DIFF
--- a/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
+++ b/core/src/test/java/org/jruby/test/TestRubyInstanceConfig.java
@@ -148,7 +148,7 @@ public class TestRubyInstanceConfig extends Base {
 
     public void testBytecodeVersion() throws Exception {
         assertEquals("it uses Opcodes.V21 for '21'", Opcodes.V21, RubyInstanceConfig.calculateBytecodeVersion("21"));
-        assertEquals("it uses Opcodes.V23 for '23'", Opcodes.V23, RubyInstanceConfig.calculateBytecodeVersion("23"));
+        assertEquals("it uses Opcodes.V25 for '25'", Opcodes.V25, RubyInstanceConfig.calculateBytecodeVersion("25"));
 
         PrintStream err = System.err;
         String specVersion = System.getProperty("java.specification.version");

--- a/pom.rb
+++ b/pom.rb
@@ -74,7 +74,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
              "rake.version": '13.2.1',
              "jruby-launcher.version": '1.1.6',
              "ant.version": '1.9.8',
-             "asm.version": '9.7.1',
+             "asm.version": '9.10.1',
              "jar-dependencies.version": '0.4.1',
              "jffi.version": '1.3.15',
              "joda.time.version": '2.14.0')

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ DO NOT MODIFY - GENERATED CODE
   </distributionManagement>
   <properties>
     <ant.version>1.9.8</ant.version>
-    <asm.version>9.7.1</asm.version>
+    <asm.version>9.10.1</asm.version>
     <base.java.version>21</base.java.version>
     <base.javac.version>21</base.javac.version>
     <github.global.server>github</github.global.server>


### PR DESCRIPTION
Update to latest ObjectWeb ASM library.

This brings in support for JVM bytecode versions newer than Java 23.