### PR TITLE
Implement Proc#refined

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1134,6 +1134,9 @@ public class RubyModule extends RubyObject {
         if (context.getCurrentStaticScope().isWithinMethod()) {
             throw runtimeError(context, "Module#using is not permitted in methods");
         }
+        if (context.getCurrentStaticScope().isWithinRefinementsProc()) {
+            throw runtimeError(context, "Module#using is not permitted in a proc with refinements");
+        }
 
         // I pass the cref even though I don't need to so that the concept is simpler to read
         StaticScope staticScope = context.getCurrentStaticScope();
@@ -1164,7 +1167,12 @@ public class RubyModule extends RubyObject {
         RefinementStore refinementStore = module.refinementStore;
         if (refinementStore == null) return; // No refinements registered for this module
 
-        Map<RubyModule, RubyModule> refinements = refinementStore.refinements;
+        // Snapshot under the map's own lock: Proc#refined activates refinements from arbitrary threads
+        // while Module#refine on another thread may be mutating this map.
+        Map<RubyModule, RubyModule> refinements;
+        synchronized (refinementStore.refinements) {
+            refinements = new IdentityHashMap<>(refinementStore.refinements);
+        }
         for (Map.Entry<RubyModule, RubyModule> entry: refinements.entrySet()) {
             usingRefinement(context, cref, entry.getKey(), entry.getValue());
         }
@@ -2938,9 +2946,21 @@ public class RubyModule extends RubyObject {
         return context.getCurrentFrame().getSelf() == this ? context.getCurrentVisibility() : PUBLIC;
     }
 
+    private static void checkNotRefinementsProc(ThreadContext context, Block block) {
+        // A method defined from a Proc#refined proc would silently drop its refinements (a method is invoked
+        // against its method entry, not the proc's refinement scope), so reject it.
+        if (block.getBody() instanceof IRBlockBody body) {
+            IRClosure closure = body.getScope();
+            if (closure != null && closure.isRefinementsClone()) {
+                throw argumentError(context, "can't define a method from a Proc with refinements");
+            }
+        }
+    }
+
     public IRubyObject defineMethodFromBlock(ThreadContext context, IRubyObject arg0, Block block, Visibility visibility) {
         RubySymbol name = checkID(context, arg0);
         if (!block.isGiven()) throw argumentError(context, "tried to create Proc object without a block");
+        checkNotRefinementsProc(context, block);
 
         if ("initialize".equals(name.idString())) visibility = PRIVATE;
 
@@ -2984,6 +3004,7 @@ public class RubyModule extends RubyObject {
         if (context.runtime.getProc().isInstance(arg1)) {
             // double-testing args.length here, but it avoids duplicating the proc-setup code in two places
             RubyProc proc = (RubyProc)arg1;
+            checkNotRefinementsProc(context, proc.getBlock());
 
             newMethod = createProcMethod(context.runtime, name.idString(), visibility, proc.getBlock());
         } else if (arg1 instanceof AbstractRubyMethod) {

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -39,6 +39,8 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.ir.IRClosure;
+import org.jruby.ir.interpreter.Interpreter;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.java.codegen.BlockInterfaceGenerator;
 import org.jruby.javasupport.Java;
@@ -58,6 +60,7 @@ import org.jruby.runtime.marshal.DataType;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.castAsModule;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -416,6 +419,43 @@ public class RubyProc extends RubyObject implements DataType {
     @JRubyMethod(name = "to_proc")
     public RubyProc to_proc() {
     	return this;
+    }
+
+    /**
+     * Return a new Proc whose body runs with the given modules' refinements active; the receiver is unchanged
+     * and the captured environment is shared.  Heavy (it deep-copies the block's IR), so the result is cached.
+     */
+    @JRubyMethod(name = "refined", rest = true)
+    public IRubyObject refined(ThreadContext context, IRubyObject[] args) {
+        if (args.length == 0) throw argumentError(context, "wrong number of arguments (given 0, expected 1+)");
+
+        BlockBody body = block.getBody();
+        if (fromMethod || !(body instanceof IRBlockBody)) {
+            throw argumentError(context, "can't apply refinements to a Proc without a Ruby block");
+        }
+
+        // Chaining is not allowed: activate multiple modules by passing them all in a single call.
+        if (((IRBlockBody) body).getScope().isRefinementsClone()) {
+            throw argumentError(context, "can't apply refinements to a Proc that already has refinements");
+        }
+
+        RubyModule[] modules = new RubyModule[args.length];
+        for (int i = 0; i < args.length; i++) {
+            modules[i] = castAsModule(context, args[i]);
+        }
+
+        IRClosure refinedClosure = ((IRBlockBody) body).getScope().refinementsClone(context, modules);
+        // Share the captured environment (binding holds the dynamic scope); clone the binding wrapper only so that
+        // proc setup (file/line/dummy-scope) does not mutate the original proc's binding.
+        Binding newBinding = block.getBinding().clone();
+        // A block from compiled top-level code has a null frame method name; the clone always runs interpreted,
+        // so give it the interpreter's top-level name or building a backtrace through it would crash.
+        if (newBinding.getMethod() == null) newBinding.setMethod(Interpreter.ROOT);
+        Block newBlock = new Block(refinedClosure.getBlockBody(), newBinding, block.type);
+
+        // The real class, not the receiver's metaclass: the refined proc must not inherit the receiver's
+        // singleton state (as in CRuby).  Proc subclasses are still preserved.
+        return newProc(context.runtime, getMetaClass().getRealClass(), newBlock, type, file, line);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/TopSelfFactory.java
+++ b/core/src/main/java/org/jruby/TopSelfFactory.java
@@ -117,6 +117,9 @@ public final class TopSelfFactory {
             @Override
             public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args) {
                 Arity.checkArgumentCount(context, args, 1, 1);
+                if (context.getCurrentStaticScope().isWithinRefinementsProc()) {
+                    throw context.runtime.newRuntimeError("main.using is not permitted in a proc with refinements");
+                }
                 RubyModule cref = context.getCurrentStaticScope().getOverlayModuleForWrite(context);
                 // unclear what the equivalent check would be for us
 //                rb_control_frame_t * prev_cfp = previous_frame(GET_THREAD());

--- a/core/src/main/java/org/jruby/ir/IRClassBody.java
+++ b/core/src/main/java/org/jruby/ir/IRClassBody.java
@@ -10,6 +10,11 @@ public class IRClassBody extends IRModuleBody {
     }
 
     @Override
+    protected IRModuleBody cloneInstance(IRScope lexicalParent, StaticScope scope) {
+        return new IRClassBody(getManager(), lexicalParent, getByteName(), getLine(), scope, executesOnce());
+    }
+
+    @Override
     public IRScopeType getScopeType() {
         return IRScopeType.CLASS_BODY;
     }

--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -1,10 +1,13 @@
 package org.jruby.ir;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
+import org.jruby.RubyModule;
 import org.jruby.RubySymbol;
 import org.jruby.ast.DefNode;
 import org.jruby.ast.IterNode;
@@ -26,6 +29,7 @@ import org.jruby.runtime.IRBlockBody;
 import org.jruby.runtime.MixedModeIRBlockBody;
 import org.jruby.runtime.InterpretedIRBlockBody;
 import org.jruby.runtime.Signature;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
 // Closures are contexts/scopes for the purpose of IR building.  They are self-contained and accumulate instructions
@@ -74,7 +78,13 @@ public class IRClosure extends IRScope {
     /** Used by cloning code for inlining */
     /* Inlining generates a new name and id and basic cloning will reuse the originals name */
     protected IRClosure(IRClosure c, IRScope lexicalParent, int closureId, ByteList fullName) {
-        super(c, lexicalParent);
+        // Inlining clones share the source's StaticScope.
+        this(c, lexicalParent, closureId, fullName, c.getStaticScope());
+    }
+
+    /** Used by Proc#refined cloning, which needs each clone to own a fresh StaticScope. */
+    protected IRClosure(IRClosure c, IRScope lexicalParent, int closureId, ByteList fullName, StaticScope staticScope) {
+        super(c, lexicalParent, staticScope);
         this.closureId = closureId;
         super.setByteName(fullName);
 
@@ -341,22 +351,155 @@ public class IRClosure extends IRScope {
         IRClosure clonedClosure;
         IRScope lexicalParent = ii.getScope();
 
+        // For Proc#refined we give the clone its own StaticScope whose enclosing scope points
+        // at the clone's lexical parent.
+        StaticScope refinementsScope = null;
+        if (ii.isRefinementsClone()) {
+            refinementsScope = getStaticScope().duplicate();
+            refinementsScope.setEnclosingScope(lexicalParent.getStaticScope());
+        }
+
         if (ii instanceof SimpleCloneInfo && !((SimpleCloneInfo) ii).isEnsureBlockCloneMode()) {
-            clonedClosure = new IRClosure(this, lexicalParent, closureId, getByteName());
+            clonedClosure = refinementsScope != null ?
+                    new IRClosure(this, lexicalParent, closureId, getByteName(), refinementsScope) :
+                    new IRClosure(this, lexicalParent, closureId, getByteName());
         } else {
             int id = lexicalParent.getNextClosureId();
             ByteList fullName = lexicalParent.getByteName();
             fullName = fullName != null ? fullName.dup() : new ByteList();
             fullName.append(CLOSURE_CLONE);
             fullName.append(java.lang.Integer.toString(id).getBytes());
-            clonedClosure = new IRClosure(this, lexicalParent, id, fullName);
+            clonedClosure = refinementsScope != null ?
+                    new IRClosure(this, lexicalParent, id, fullName, refinementsScope) :
+                    new IRClosure(this, lexicalParent, id, fullName);
         }
 
-        // WrappedIRClosure should always have a single unique IRClosure in them so we should
-        // not end up adding n copies of the same closure as distinct clones...
-        lexicalParent.addClosure(clonedClosure);
+        if (refinementsScope != null) {
+            refinementsScope.setIRScope(clonedClosure);
+            clonedClosure.setIsMaybeUsingRefinements();
+            clonedClosure.inRefinementsCloneTree = true;
+        }
+
+        // the top clone of a Proc#refined tree is grafted under the source's real lexical parent.
+        boolean graftedTopRefinementsClone = ii.isRefinementsClone() &&
+                !(lexicalParent instanceof IRClosure && ((IRClosure) lexicalParent).isInRefinementsCloneTree());
+        if (graftedTopRefinementsClone) {
+            // Only the TOP clone is user-visible (the proc returned by Proc#refined); flag it so chaining and
+            // define_method are rejected on it, but not on the nested closures it lexically encloses.
+            clonedClosure.refinementsClone = true;
+        } else {
+            // WrappedIRClosure should always have a single unique IRClosure in them so we should
+            // not end up adding n copies of the same closure as distinct clones...
+            lexicalParent.addClosure(clonedClosure);
+        }
 
         return cloneForInlining(ii, clonedClosure);
+    }
+
+    /**
+     * Single-slot memo of the most recent refinement-aware clone of a closure (see {@link #refinementsClone}).
+     */
+    static final class RefinementsCache {
+        final RubyModule[] modules;
+        final IRClosure clone;
+
+        RefinementsCache(RubyModule[] modules, IRClosure clone) {
+            this.modules = modules;
+            this.clone = clone;
+        }
+
+        boolean matches(RubyModule[] other) {
+            return Arrays.equals(modules, other);
+        }
+    }
+
+    /**
+     * True on every closure in a Proc#refined clone tree: the top clone and all closures it lexically
+     * encloses (which are deep-copied along with it).
+     */
+    private boolean inRefinementsCloneTree;
+
+    public boolean isInRefinementsCloneTree() {
+        return inRefinementsCloneTree;
+    }
+
+    /**
+     * True only on the TOP clone of a Proc#refined tree -- the closure that directly backs the proc the user
+     * receives.  Used to reject chaining Proc#refined and to reject defining a method from such a proc.
+     */
+    private boolean refinementsClone;
+
+    public boolean isRefinementsClone() {
+        return refinementsClone;
+    }
+
+    /**
+     * Return a refinement-aware clone of this closure for the given modules, reusing the cached clone when the same
+     * modules (by identity and order) were used last time.  A miss recomputes via {@link #cloneForRefinements} and
+     * overwrites the single slot, emitting a performance-category warning when an existing entry is evicted.
+     * Lock-free: a race only causes a redundant clone, which is harmless.
+     *
+     * @param context the current thread context
+     * @param modules the refinement modules to activate (freshly allocated array; stored without copying)
+     * @return a clone whose body runs with the given refinements active
+     */
+    public IRClosure refinementsClone(ThreadContext context, RubyModule[] modules) {
+        Map<IRClosure, RefinementsCache> cacheMap = getManager().getRefinementsCloneCache();
+        RefinementsCache cache = cacheMap.get(this);
+        if (cache != null) {
+            if (cache.matches(modules)) {
+                // Proc#ruby2_keywords marks the scope, possibly after the clone was memoized; a stale
+                // clone must be rebuilt, not reused (as in CRuby).
+                if (cache.clone.isRuby2Keywords() == isRuby2Keywords()) return cache.clone;
+                context.runtime.getWarnings().warnPerformance(
+                        "Proc#refined re-copies the block because the ruby2_keywords flag changed after the copy was memoized");
+            } else {
+                context.runtime.getWarnings().warnPerformance(
+                        "Proc#refined called with different modules for the same block disables memoization");
+            }
+        }
+
+        IRClosure clone = cloneForRefinements(context, modules);
+        // Build the clone's BlockBody now, before publishing it through the cache, so a thread that later
+        // reads the shared clone on a cache hit sees a fully-built body (via the put's happens-before) and never
+        // races another thread to create a second one in the lazy getBlockBody().
+        clone.getBlockBody();
+        cacheMap.put(this, new RefinementsCache(modules, clone));
+
+        return clone;
+    }
+
+    /**
+     * Produce a refinement-aware deep copy of this closure tree for Proc#refined: the copy gets its own
+     * StaticScope with the given modules' refinements activated and its call sites re-created as refined.
+     *
+     * Private: callers go through {@link #refinementsClone}, which memoizes the clone.
+     *
+     * @param context the current thread context
+     * @param modules the refinement modules to activate
+     * @return a new IRClosure whose body runs with the given refinements active
+     */
+    private IRClosure cloneForRefinements(ThreadContext context, RubyModule[] modules) {
+        // Cloning reads the startup InterpreterContext as its instruction source.
+        if (getInterpreterContext() == null) {
+            throw context.runtime.newArgumentError("cannot create a refinements-aware copy of this proc");
+        }
+
+        SimpleCloneInfo ii = new SimpleCloneInfo(getLexicalParent(), false, false, true);
+        IRClosure clone = cloneForInlining(ii);
+        clone.setArgumentDescriptors(getArgumentDescriptors());
+
+        // The constructor registered the clone in its lexical parent's child-scope list; detach the grafted
+        // top clone so the shared parent does not retain it.
+        clone.getLexicalParent().removeChildScope(clone);
+
+        // Activate the requested refinements on the clone's own overlay module so refined call sites resolve them.
+        RubyModule overlay = clone.getStaticScope().getOverlayModuleForWrite(context);
+        for (RubyModule module : modules) {
+            RubyModule.usingModule(context, overlay, module);
+        }
+
+        return clone;
     }
 
     public Signature getSignature() {

--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -31,9 +31,12 @@ import org.jruby.ir.passes.CompilerPass;
 import org.jruby.ir.passes.CompilerPassListener;
 import org.jruby.ir.passes.CompilerPassScheduler;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -98,6 +101,11 @@ public class IRManager {
     private IRBuilderFactory builderFactory;
     private AtomicLong callSiteCounter = new AtomicLong(1);
 
+    // Proc#refined cache: source closure -> its most recent refinements clone (see IRClosure#refinementsClone)
+    // Entries live for the runtime's lifetime; weak keys would never clear because the value reaches its key.
+    private final Map<IRClosure, IRClosure.RefinementsCache> refinementsCloneCache =
+            Collections.synchronizedMap(new IdentityHashMap<>());
+
     public IRManager(Ruby runtime, RubyInstanceConfig config) {
         this.runtime = runtime;
         this.config = config;
@@ -120,6 +128,10 @@ public class IRManager {
 
     public Ruby getRuntime() {
         return runtime;
+    }
+
+    Map<IRClosure, IRClosure.RefinementsCache> getRefinementsCloneCache() {
+        return refinementsCloneCache;
     }
 
     public Nil getNil() {

--- a/core/src/main/java/org/jruby/ir/IRMetaClassBody.java
+++ b/core/src/main/java/org/jruby/ir/IRMetaClassBody.java
@@ -10,6 +10,11 @@ public class IRMetaClassBody extends IRClassBody {
     }
 
     @Override
+    protected IRModuleBody cloneInstance(IRScope lexicalParent, StaticScope scope) {
+        return new IRMetaClassBody(getManager(), lexicalParent, getByteName(), getLine(), scope);
+    }
+
+    @Override
     public IRScopeType getScopeType() {
         return IRScopeType.METACLASS_BODY;
     }

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -40,6 +40,7 @@ import org.jruby.ir.interpreter.InterpreterContext;
 import org.jruby.ir.operands.Label;
 import org.jruby.ir.operands.LocalVariable;
 import org.jruby.ir.representations.BasicBlock;
+import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.ArgumentDescriptor;
 import org.jruby.runtime.CallType;
@@ -78,6 +79,23 @@ public class IRMethod extends IRScope {
     @Override
     public boolean hasBeenBuilt() {
         return defNode == null;
+    }
+
+    /**
+     * Deep-copy this method for a Proc#refined clone: a {@code def} inside a refined proc must capture that
+     * proc's refinements (like a {@code def} inside a {@code using} scope), so the defined method keeps
+     * resolving the refined methods.  For ordinary inlining the shared original is returned unchanged.
+     */
+    public IRMethod cloneForInlining(CloneInfo ii) {
+        if (!ii.isRefinementsClone()) return this;
+
+        // Cloning copies already-built instructions, so make sure ours are built first.
+        return cloneScopeForRefinements(ii.getScope(), lazilyAcquireInterpreterContext(), (parent, scope) -> {
+            IRMethod clone = new IRMethod(getManager(), parent, null, getByteName(), isInstanceMethod, getLine(),
+                    scope, getCoverageMode());
+            clone.setArgumentDescriptors(getArgumentDescriptors());
+            return clone;
+        });
     }
 
     public MethodData getMethodData() {

--- a/core/src/main/java/org/jruby/ir/IRModuleBody.java
+++ b/core/src/main/java/org/jruby/ir/IRModuleBody.java
@@ -1,5 +1,6 @@
 package org.jruby.ir;
 
+import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.util.ByteList;
 
@@ -15,6 +16,23 @@ public class IRModuleBody extends IRScope {
         if (staticScope != null) {
             staticScope.setIRScope(this);
         }
+    }
+
+    /**
+     * Deep-copy this module/class body for a Proc#refined clone: a {@code class}/{@code module} (re)opened
+     * inside a refined proc must see that proc's refinements, in the body and in any {@code def} it contains.
+     * For ordinary inlining the shared original is returned unchanged.
+     */
+    public IRModuleBody cloneForInlining(CloneInfo ii) {
+        if (!ii.isRefinementsClone()) return this;
+
+        // Class/module bodies are built eagerly when their enclosing scope is built, so the IC is available here.
+        return cloneScopeForRefinements(ii.getScope(), builtInterpreterContext(), this::cloneInstance);
+    }
+
+    /** Construct an empty copy of this body of the correct concrete type for a refinements clone. */
+    protected IRModuleBody cloneInstance(IRScope lexicalParent, StaticScope scope) {
+        return new IRModuleBody(getManager(), lexicalParent, getByteName(), getLine(), scope, executesOnce);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import org.jruby.runtime.DynamicScope;
@@ -144,16 +145,20 @@ public abstract class IRScope implements ParseResult {
     private boolean needsCodeCoverage;
     private boolean usesEval;
 
-    // Used by cloning code for inlining
-    protected IRScope(IRScope s, IRScope lexicalParent) {
+    /**
+     * Copy constructor used by cloning code (inlining shares the source's StaticScope; Proc#refined cloning
+     * supplies a fresh one so a refinements overlay can be attached without mutating the original).
+     */
+    protected IRScope(IRScope s, IRScope lexicalParent, StaticScope staticScope) {
         this.lexicalParent = lexicalParent;
         this.manager = s.manager;
         this.lineNumber = s.lineNumber;
-        this.staticScope = s.staticScope;
+        this.staticScope = staticScope;
         this.nextClosureIndex = s.nextClosureIndex;
         this.interpreterContext = null;
         this.coverageMode = CoverageData.NONE;
         this.localVars = new HashMap<>(s.localVars);
+        this.ruby2Keywords = s.ruby2Keywords;
         this.scopeId = globalScopeCount.getAndIncrement();
 
         setupLexicalContainment();
@@ -213,6 +218,10 @@ public abstract class IRScope implements ParseResult {
 
     protected synchronized void addChildScope(IRScope scope) {
         lexicalChildren.add(scope);
+    }
+
+    protected synchronized void removeChildScope(IRScope scope) {
+        lexicalChildren.remove(scope);
     }
 
     public synchronized List<IRScope> getLexicalScopes() {
@@ -615,6 +624,30 @@ public abstract class IRScope implements ParseResult {
         if (RubyInstanceConfig.IR_COMPILER_DEBUG) LOG.info(interpreterContext.toString());
 
         return interpreterContext;
+    }
+
+    /**
+     * Shared body of the IRMethod/IRModuleBody Proc#refined clone: give the copy its own StaticScope reaching
+     * the enclosing clone's refinements overlay, flag it maybe-using-refinements, and re-create its instructions.
+     * The caller supplies the source InterpreterContext and a constructor for the empty copy.
+     */
+    protected <T extends IRScope> T cloneScopeForRefinements(IRScope lexicalParent, InterpreterContext sourceIC,
+                                                             BiFunction<IRScope, StaticScope, T> constructor) {
+        StaticScope refinementsScope = getStaticScope().duplicate();
+        refinementsScope.setEnclosingScope(lexicalParent.getStaticScope());
+
+        T clone = constructor.apply(lexicalParent, refinementsScope);
+        refinementsScope.setIRScope(clone);
+        clone.setIsMaybeUsingRefinements();
+
+        SimpleCloneInfo clonedII = new SimpleCloneInfo(clone, false, false, true);
+        List<Instr> newInstrs = new ArrayList<>(sourceIC.getInstructions().length);
+        for (Instr i : sourceIC.getInstructions()) {
+            newInstrs.add(i.clone(clonedII));
+        }
+        clone.allocateInterpreterContext(newInstrs, sourceIC.getTemporaryVariableCount(), sourceIC.getFlags());
+
+        return clone;
     }
 
     private Instr[] cloneInstrs() {

--- a/core/src/main/java/org/jruby/ir/instructions/ArrayDerefInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ArrayDerefInstr.java
@@ -45,6 +45,11 @@ public class ArrayDerefInstr extends OneOperandArgNoBlockCallInstr {
 
     @Override
     public Instr clone(CloneInfo ii) {
+        // The optimized aref path bypasses refinements (dispatches through CachingCallSite.isBuiltin), so a
+        // clone into a refined scope falls back to a generic refined call, like the fixnum/float fast paths.
+        if (isPotentiallyRefined() || ii.getScope().maybeUsingRefinements()) {
+            return super.clone(ii);
+        }
         return new ArrayDerefInstr(ii.getScope(), (Variable) getResult().cloneForInlining(ii),
                 getReceiver().cloneForInlining(ii), key, getFlags());
     }

--- a/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
@@ -27,7 +27,14 @@ public class CallInstr extends CallBase implements ResultInstr {
 
     public static CallInstr create(IRScope scope, CallType callType, Variable result, RubySymbol name, Operand receiver,
                                    Operand[] args, Operand closure, int flags) {
-        boolean isPotentiallyRefined = scope.maybeUsingRefinements();
+        return create(scope, callType, result, name, receiver, args, closure, flags, false);
+    }
+
+    // clone() passes the source instruction's flag so a refined call stays refined even
+    // when it is cloned into a scope without the refinement flag.
+    private static CallInstr create(IRScope scope, CallType callType, Variable result, RubySymbol name, Operand receiver,
+                                    Operand[] args, Operand closure, int flags, boolean potentiallyRefined) {
+        boolean isPotentiallyRefined = potentiallyRefined || scope.maybeUsingRefinements();
 
         if (!containsArgSplat(args)) {
             boolean hasClosure = closure != NullBlock.INSTANCE;
@@ -121,9 +128,11 @@ public class CallInstr extends CallBase implements ResultInstr {
         return NoResultCallInstr.create(getCallType(), getName(), getReceiver(), getCallArgs(), getClosureArg(), isPotentiallyRefined());
     }*/
 
+    // Shared by the specialized subclasses: create() re-picks the specialization from the cloned operand
+    // shapes and the effective refinement flag, so a refinements clone drops the fixnum/float fast paths.
     @Override
     public Instr clone(CloneInfo ii) {
-        return new CallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
+        return create(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
                 getClosureArg().cloneForInlining(ii),
                 getFlags(), isPotentiallyRefined()

--- a/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
@@ -42,7 +42,7 @@ public class DefineClassInstr extends TwoOperandResultBaseInstr implements Fixed
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new DefineClassInstr(ii.getRenamedVariable(result), body,
+        return new DefineClassInstr(ii.getRenamedVariable(result), (IRClassBody) body.cloneForInlining(ii),
                 getContainer().cloneForInlining(ii), getSuperClass().cloneForInlining(ii));
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/DefineClassMethodInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineClassMethodInstr.java
@@ -38,7 +38,7 @@ public class DefineClassMethodInstr extends OneOperandInstr implements FixedArit
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new DefineClassMethodInstr(getContainer().cloneForInlining(ii), method);
+        return new DefineClassMethodInstr(getContainer().cloneForInlining(ii), method.cloneForInlining(ii));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/DefineInstanceMethodInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineInstanceMethodInstr.java
@@ -40,7 +40,7 @@ public class DefineInstanceMethodInstr extends NoOperandInstr implements FixedAr
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new DefineInstanceMethodInstr(method);
+        return new DefineInstanceMethodInstr(method.cloneForInlining(ii));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/DefineMetaClassInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineMetaClassInstr.java
@@ -53,7 +53,8 @@ public class DefineMetaClassInstr extends OneOperandResultBaseInstr implements F
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new DefineMetaClassInstr(ii.getRenamedVariable(result), getObject().cloneForInlining(ii), metaClassBody);
+        return new DefineMetaClassInstr(ii.getRenamedVariable(result), getObject().cloneForInlining(ii),
+                metaClassBody.cloneForInlining(ii));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
@@ -43,7 +43,8 @@ public class DefineModuleInstr extends OneOperandResultBaseInstr implements Fixe
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new DefineModuleInstr(ii.getRenamedVariable(result), getContainer().cloneForInlining(ii), body);
+        return new DefineModuleInstr(ii.getRenamedVariable(result), getContainer().cloneForInlining(ii),
+                body.cloneForInlining(ii));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
@@ -4,13 +4,11 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
-import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.Fixnum;
 import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
-import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
@@ -28,12 +26,6 @@ public class OneFixnumArgNoBlockCallInstr extends CallInstr {
         assert args.length == 1;
 
         this.fixNum = ((Fixnum) args[0]).value;
-    }
-
-    @Override
-    public Instr clone(CloneInfo ii) {
-        return new OneFixnumArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
     }
 
     public long getFixnumArg() {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
@@ -4,13 +4,11 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
-import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.Float;
 import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
-import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
@@ -28,13 +26,6 @@ public class OneFloatArgNoBlockCallInstr extends CallInstr {
         assert args.length == 1;
 
         this.flote = ((Float) args[0]).value;
-    }
-
-    @Override
-    public Instr clone(CloneInfo ii) {
-        return new OneFloatArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined()
-        );
     }
 
     public double getFloatArg() {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
@@ -4,11 +4,9 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
-import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
-import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallType;
@@ -22,14 +20,6 @@ public class OneOperandArgBlockCallInstr extends CallInstr {
                                        Operand receiver, Operand[] args, Operand closure, int flags,
                                        boolean isPotentiallyRefined) {
         super(scope, Operation.CALL_1OB, callType, result, name, receiver, args, closure, flags, isPotentiallyRefined);
-    }
-
-    @Override
-    public Instr clone(CloneInfo ii) {
-        return new OneOperandArgBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getClosureArg().cloneForInlining(ii), getFlags(), isPotentiallyRefined()
-        );
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
@@ -4,12 +4,10 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
-import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
-import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
@@ -28,13 +26,6 @@ public class OneOperandArgNoBlockCallInstr extends CallInstr {
                                          RubySymbol name, Operand receiver, Operand[] args, int flags,
                                          boolean isPotentiallyRefined) {
         super(scope, op, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
-    }
-
-    @Override
-    public Instr clone(CloneInfo ii) {
-        return new OneOperandArgNoBlockCallInstr(ii.getScope(), Operation.CALL_1O, getCallType(),
-                ii.getRenamedVariable(result), getName(), getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getFlags(), isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
@@ -4,12 +4,10 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
-import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
-import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
@@ -21,13 +19,6 @@ public class TwoOperandArgNoBlockCallInstr  extends CallInstr  {
     public TwoOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                          Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined) {
         super(scope, Operation.CALL_2O, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
-    }
-
-    @Override
-    public Instr clone(CloneInfo ii) {
-        return new TwoOperandArgNoBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined()
-        );
     }
 
     public Operand getArg2() {

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
@@ -4,12 +4,10 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
-import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
-import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.DynamicScope;
@@ -28,12 +26,6 @@ public class ZeroOperandArgNoBlockCallInstr extends CallInstr {
     public ZeroOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                           Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined) {
         super(scope, Operation.CALL_0O, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
-    }
-
-    @Override
-    public Instr clone(CloneInfo ii) {
-        return new ZeroOperandArgNoBlockCallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
-                getReceiver().cloneForInlining(ii), cloneCallArgs(ii), getFlags(), isPotentiallyRefined());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/SymbolProc.java
+++ b/core/src/main/java/org/jruby/ir/operands/SymbolProc.java
@@ -5,6 +5,7 @@ import org.jruby.ir.IRVisitor;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.runtime.ThreadContext;
 
 /**
@@ -29,6 +30,15 @@ public class SymbolProc extends ImmutableLiteral {
     @Override
     public Object createCacheObject(ThreadContext context) {
         return IRRuntimeHelpers.newSymbolProc(context, getName());
+    }
+
+    @Override
+    public Operand cloneForInlining(CloneInfo ii) {
+        // A baked &:sym caches a *non-refined* symbol proc, so it would ignore the refinements activated on a
+        // Proc#refined clone.
+        if (ii.isRefinementsClone()) return new Symbol(name);
+
+        return this;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/WrappedIRClosure.java
+++ b/core/src/main/java/org/jruby/ir/operands/WrappedIRClosure.java
@@ -61,6 +61,11 @@ public class WrappedIRClosure extends Operand {
 
     @Override
     public Operand cloneForInlining(CloneInfo info) {
+        // For Proc#refined we must deep-clone nested closures
+        if (info.isRefinementsClone()) {
+            return new WrappedIRClosure(info.getRenamedVariable(self), closure.cloneForInlining(info));
+        }
+
         // Making interp instrs so that if JIT hits IRClosure we will not concurrently modify the same IRScope.
         if (info instanceof SimpleCloneInfo && !((SimpleCloneInfo) info).isEnsureBlockCloneMode()) {
             // FIXME: It really bothers me we do not clone closure here but cloning like main clone case loses interpContext + other things.

--- a/core/src/main/java/org/jruby/ir/transformations/inlining/CloneInfo.java
+++ b/core/src/main/java/org/jruby/ir/transformations/inlining/CloneInfo.java
@@ -26,11 +26,22 @@ public abstract class CloneInfo {
     public SimpleCloneInfo cloneForCloningClosure(IRClosure clonedClosure) {
         // If cloning for ensure block cloning we want to propagate that to child closure clones
         boolean ensureClone = this instanceof SimpleCloneInfo && ((SimpleCloneInfo) this).isEnsureBlockCloneMode();
-        SimpleCloneInfo clone = new SimpleCloneInfo(clonedClosure, ensureClone);
+        // If cloning for Proc#refined we must propagate that so nested closures are also made refinement-aware
+        SimpleCloneInfo clone = new SimpleCloneInfo(clonedClosure, ensureClone, false, isRefinementsClone());
 
         clone.variableRenameMap.putAll(variableRenameMap);
 
         return clone;
+    }
+
+    /**
+     * Is this clone being performed to produce a refinement-aware copy (Proc#refined)?  When true, call-like
+     * instructions are re-created as refined call sites bound to the clone's static scope.
+     *
+     * @return true if this is a refinements clone
+     */
+    public boolean isRefinementsClone() {
+        return false;
     }
 
     /**

--- a/core/src/main/java/org/jruby/ir/transformations/inlining/SimpleCloneInfo.java
+++ b/core/src/main/java/org/jruby/ir/transformations/inlining/SimpleCloneInfo.java
@@ -10,20 +10,32 @@ import org.jruby.ir.operands.Variable;
  */
 public class SimpleCloneInfo extends CloneInfo {
     private final boolean isEnsureBlock;
+    private final boolean refinementsClone;
     private boolean cloneIPC;
 
-    public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock, boolean cloneIPC) {
+    public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock, boolean cloneIPC, boolean refinementsClone) {
         super(scope);
 
         this.isEnsureBlock = isEnsureBlock;
+        this.cloneIPC = cloneIPC;
+        this.refinementsClone = refinementsClone;
+    }
+
+    public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock, boolean cloneIPC) {
+        this(scope, isEnsureBlock, cloneIPC, false);
     }
 
     public SimpleCloneInfo(IRScope scope, boolean isEnsureBlock) {
-        this(scope, isEnsureBlock, false);
+        this(scope, isEnsureBlock, false, false);
     }
 
     public boolean isEnsureBlockCloneMode() {
         return this.isEnsureBlock;
+    }
+
+    @Override
+    public boolean isRefinementsClone() {
+        return this.refinementsClone;
     }
 
     public boolean shouldCloneIPC() {

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -56,6 +56,7 @@ import org.jruby.ast.LocalAsgnNode;
 import org.jruby.ast.LocalVarNode;
 import org.jruby.ast.Node;
 import org.jruby.ast.VCallNode;
+import org.jruby.ir.IRClosure;
 import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRScopeType;
@@ -868,6 +869,21 @@ public class StaticScope implements Serializable, Cloneable {
     public boolean isWithinMethod() {
         for (StaticScope current = this; current != null; current = current.getEnclosingScope()) {
             if (current.getScopeType().isMethod()) return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if we are lexically within the body of a Proc#refined proc (its refinements clone tree).
+     * `using` is rejected there: it would diverge the refinement set shared by the memoized clone.  Walk the
+     * enclosing-scope chain, since nested bodies/blocks/evals reach the clone through it.
+     * @return true if so
+     */
+    public boolean isWithinRefinementsProc() {
+        for (StaticScope current = this; current != null; current = current.getEnclosingScope()) {
+            IRScope irScope = current.getIRScope();
+            if (irScope instanceof IRClosure && ((IRClosure) irScope).isInRefinementsCloneTree()) return true;
         }
 
         return false;

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -179,6 +179,13 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
                 ensureInstrsReady();
                 closure.getNearestTopLocalVariableScope().prepareForCompilation();
 
+                // A Proc#refined clone is grafted under an already-built enclosing scope, so the recursive
+                // prepareForCompilation above can short-circuit before reaching it.  Build the closure's own full IR
+                // directly in that case so the refinement-aware clone can still be JIT-compiled.
+                if (closure.getFullInterpreterContext() == null) {
+                    closure.prepareForCompilation();
+                }
+
                 FullInterpreterContext fic = closure.getFullInterpreterContext();
 
                 if (fic == null || !fic.hasExplicitCallProtocol()) {

--- a/test/jruby/test_proc_refined.rb
+++ b/test/jruby/test_proc_refined.rb
@@ -1,0 +1,501 @@
+require 'test/unit'
+require 'test/jruby/test_helper'
+require 'tempfile'
+require 'jruby'
+
+class TestProcRefined < Test::Unit::TestCase
+  include TestHelper
+  module StringRefinement
+    refine String do
+      def shout
+        upcase + "!"
+      end
+    end
+  end
+
+  module IntegerRefinement
+    refine Integer do
+      def double
+        self * 2
+      end
+    end
+  end
+
+  # A second String#shout refinement with a different result, used to tell which refinement set is active.
+  module StringRefinement2
+    refine String do
+      def shout
+        downcase + "?"
+      end
+    end
+  end
+
+  # Refines operators so the specialized call paths (opt_plus / opt_lt / opt_aref equivalents) are exercised.
+  module Operators
+    refine Integer do
+      def +(other) = "plus(#{self},#{other})"
+      def <(other) = "lt"
+    end
+    refine Array do
+      def [](i) = "at#{i}"
+    end
+  end
+
+  # Refines Hash#[] to exercise the string-literal aref fast path (ArrayDerefInstr), which the builder emits
+  # only in unrefined scopes and which otherwise dispatches straight to the builtin.
+  module HashAref
+    refine Hash do
+      def [](k) = "aref(#{k})"
+    end
+  end
+
+  class SuperBase
+    def greet = "base"
+  end
+
+  # A refinement whose method calls super to reach the method it refines.
+  module SuperModule
+    refine SuperBase do
+      def greet = "ref-" + super
+    end
+  end
+
+  # `using` inside a refined proc's body is rejected: the memoized clone shares refined call sites across
+  # every proc derived from the same (source, modules) key, which is only sound while all of them run under the
+  # same refinement set.  A `using` mid-body would diverge that set and poison the shared clone.  The refinement
+  # set is fixed at refined() time instead; pass every module in the single refined() call.  (MRI parity: the
+  # same RuntimeError messages are raised by CRuby.)
+  def test_using_rejected_in_body
+    # main.using resolves to the top-level main object, so build these procs at the top level.
+    mod = "TestProcRefined::StringRefinement"
+    # main.using directly in the body
+    pr = eval("->(){ using #{mod} }", TOPLEVEL_BINDING).refined(StringRefinement)
+    assert_raise_with_message(RuntimeError, /main\.using is not permitted in a proc with refinements/) { pr.call }
+    # main.using in a block nested inside the refined proc
+    pr = eval("->(){ [1].each { using #{mod} } }", TOPLEVEL_BINDING).refined(StringRefinement)
+    assert_raise_with_message(RuntimeError, /main\.using is not permitted in a proc with refinements/) { pr.call }
+    # Module#using in a class/module body opened inside the refined proc (built at the top level so the enclosing
+    # scope chain does not lexically pass through a method, which would trip the "not permitted in methods" guard).
+    pr = eval("->(){ Class.new { using #{mod} } }", TOPLEVEL_BINDING).refined(StringRefinement)
+    assert_raise_with_message(RuntimeError, /Module#using is not permitted in a proc with refinements/) { pr.call }
+    # Module#using when the refined proc is run via module_eval (self is the module, but the block's scope is
+    # still the clone, so the walk finds it).
+    pr = eval("proc { using #{mod} }", TOPLEVEL_BINDING).refined(StringRefinement)
+    assert_raise_with_message(RuntimeError, /Module#using is not permitted in a proc with refinements/) { Module.new.module_eval(&pr) }
+  end
+
+  # The refined proc is created from the receiver's real class: it must not inherit the receiver's
+  # singleton state (CRuby behaves the same), while Proc subclasses are preserved.
+  def test_singleton_state_not_inherited
+    pr = ->(s) { s.shout }
+    def pr.tag = :orig
+    refined = pr.refined(StringRefinement)
+    assert_equal(false, refined.respond_to?(:tag))
+    assert_equal("HI!", refined.call("hi"))
+    sub = Class.new(Proc)
+    sub_refined = sub.new { |s| s.shout }.refined(StringRefinement)
+    assert_equal(sub, sub_refined.class)
+  end
+
+  # Refinement activation (refined -> usingModuleRecursive) can run on any thread while another
+  # thread mutates the same module's refinement map via Module#refine; the activation must
+  # snapshot the map instead of iterating it unsynchronized (ConcurrentModificationException).
+  def test_concurrent_refined_and_refine
+    mod = Module.new { refine(String) { def shout = upcase } }
+    fillers = Array.new(2) { Module.new { refine(String) { def noop = self } } }
+    src = ->(s) { s.shout }
+    writer = Thread.new do
+      300.times { mod.module_eval { refine(Class.new) { def x = 1 } } }
+    end
+    i = 0
+    assert_nothing_raised do
+      while writer.alive?
+        # alternate the second module to defeat the single-slot memo and force re-activation
+        assert_equal("HI", src.refined(mod, fillers[i % 2]).call("hi"))
+        i += 1
+      end
+      assert_equal("HI", src.refined(mod, fillers[0]).call("hi"))
+    end
+  ensure
+    writer.join
+  end
+
+  # `refine` (which only defines methods on a refinement module, without activating them in the current scope)
+  # does not touch the active refinement set, so unlike `using` it is allowed inside a refined proc's body.
+  def test_refine_allowed_in_body
+    refined = ->(s) {
+      Module.new { refine(String) { def whisper = "w" } }
+      s.shout
+    }.refined(StringRefinement)
+    assert_nothing_raised { assert_equal("HI!", refined.call("hi")) }
+  end
+
+  # class_eval gets its own copy of the refinement scope, so running a refined proc through it must not
+  # pollute the memoized clone that later derivations reuse.
+  def test_module_eval_does_not_leak_refinements
+    body = proc { "ok".shout }.refined(StringRefinement)
+    assert_equal("OK!", Class.new.class_eval(&body))
+    again = proc { "ok".shout }.refined(StringRefinement)
+    assert_equal("OK!", Class.new.class_eval(&again))
+  end
+
+  # Each refined clone is grafted under the SOURCE proc's (shared, long-lived) lexical parent, but it must
+  # not be registered in that parent's nested-closure / lexical-child lists: doing so would retain every discarded
+  # clone forever (memory leak) and race with concurrent calls on those unsynchronized/AOT lists.  Drive many
+  # cache-missing clones (distinct module each time) and assert the parent's lists do not grow.
+  def test_clones_not_retained_by_lexical_parent
+    prc = ->(s) { s.to_s }
+    closure = JRuby.reference(prc).get_block.get_body.get_scope
+    parent = closure.get_lexical_parent
+    before_closures = parent.get_closures.size
+    before_children = parent.get_lexical_scopes.size
+    200.times do
+      mod = Module.new { refine(String) { def to_s; "x"; end } }
+      prc.refined(mod).call("hi")
+    end
+    assert_operator parent.get_closures.size - before_closures, :<=, 1,
+                    "refined clones accumulated in the source's parent nestedClosures"
+    assert_operator parent.get_lexical_scopes.size - before_children, :<=, 1,
+                    "refined clones accumulated in the source's parent lexicalChildren"
+  end
+
+  # A /o (once) regexp literal interpolating a refined-method call is built under the refinement, and the clone's
+  # once cache is independent of the source proc's.
+  def test_once_regexp
+    refined = ->(s) { /\A#{s.shout}\z/o }.refined(StringRefinement)
+    r1 = refined.call("ab")
+    assert_equal('\AAB!\z', r1.source)
+    assert_same(r1, refined.call("zz")) # /o caches the first regexp on the clone's own once entry
+    # the original proc has no refinement, so building the regexp raises
+    assert_raise(NoMethodError) { ->(s) { /\A#{s.shout}\z/o }.call("ab") }
+  end
+
+  # A proc created lexically INSIDE a refined proc is not itself "a proc that already has refinements": it
+  # only inherits the enclosing refinements lexically.  refined (and define_method) must therefore be
+  # accepted on it, and the inner proc must see both the enclosing refinement and the one it adds.  Only the proc
+  # handed back by refined is rejected for chaining.
+  def test_nested_proc_inside_refined_proc_is_not_a_chain
+    result = -> {
+      inner = ->(s, n) { [s.shout, n.double] }
+      inner.refined(StringRefinement).call("hi", 3)
+    }.refined(IntegerRefinement).call
+    # StringRefinement is added on the inner clone; IntegerRefinement is inherited from the enclosing refined proc.
+    assert_equal ["HI!", 6], result
+
+    # define_method from such a nested proc is allowed (it is not the refined result itself).
+    assert_nothing_raised do
+      -> { Class.new { define_method(:m, ->(s) { s }) } }.refined(IntegerRefinement).call
+    end
+  end
+
+  # An exception raised through a refined clone whose source block was created at top level (so the captured
+  # frame has no method name) must still build a backtrace -- the clone always runs interpreted, and a null frame name
+  # used to crash backtrace construction with a Java NullPointerException instead of surfacing the Ruby exception.
+  def test_exception_backtrace_through_top_level_clone
+    refined = -> { raise "boom" }.refined(StringRefinement)
+    err = assert_raise(RuntimeError) { refined.call }
+    assert_equal "boom", err.message
+    assert_match(/block in /, err.backtrace.first)
+  end
+
+  # The refined clone must work when reached through the block-yield path (each(&proc)), not just #call.
+  def test_yield_path
+    forwarded = []
+    rr = ->(s) { forwarded << s.shout }.refined(StringRefinement)
+    %w[p q].each(&rr)
+    assert_equal(["P!", "Q!"], forwarded)
+  end
+
+  # The refinement must be carried when the clone is reached through the generic C invocation paths
+  # (Method#call, Fiber, Thread) rather than a direct optimized Proc#call.
+  def test_c_call_paths
+    refined = ->(s) { s.shout }.refined(StringRefinement)
+    assert_equal("A!", refined.send(:call, "a"))
+    assert_equal("B!", refined.method(:call).call("b"))
+    assert_equal("C!", Fiber.new(&refined).resume("c"))
+    assert_equal("D!", Thread.new("d", &refined).value)
+  end
+
+  # Repeating the same (proc, modules) reuses the cached clone but stays correct; a different module set must
+  # not return the previously cached clone, and switching back is still correct.
+  def test_memoized
+    orig = ->(s) { s.shout }
+    assert_equal("HI!", orig.refined(StringRefinement).call("hi"))
+    assert_equal("HI!", orig.refined(StringRefinement).call("hi"))
+    assert_equal("hi?", orig.refined(StringRefinement2).call("hi"))
+    assert_equal("HI!", orig.refined(StringRefinement).call("hi"))
+  end
+
+  # Run the block with performance warnings enabled and $stderr captured; return the captured output.
+  def capture_performance_warnings
+    require 'stringio'
+    old = Warning[:performance]
+    Warning[:performance] = true
+    stderr, $stderr = $stderr, StringIO.new
+    begin
+      yield
+      $stderr.string
+    ensure
+      $stderr = stderr
+      Warning[:performance] = old
+    end
+  end
+
+  # A differing module set overwrites the single memo slot and emits a performance-category
+  # warning, as in CRuby.
+  def test_memo_different_modules_warning
+    orig = ->(s) { s.shout }
+    orig.refined(StringRefinement).call("hi")
+    out = capture_performance_warnings do
+      orig.refined(StringRefinement2).call("hi")
+    end
+    assert_match(/Proc#refined called with different modules for the same block disables memoization/, out)
+  end
+
+  # Proc#ruby2_keywords marks the shared block scope, possibly after a clone was memoized.  The stale
+  # memo is rebuilt (with a warning naming the cause) rather than reused or mutated: the new proc
+  # delegates keywords like its source, while procs built before the mark keep their creation-time
+  # behavior.  Mirrors CRuby's test_refined_ruby2_keywords_memo.
+  def test_memo_ruby2_keywords
+    target = ->(a, k: nil) { [a, k] }
+    pr = proc { |*args| target.call(*args) }
+    q1 = pr.refined(StringRefinement) # memoize a clone before the mark
+    pr.ruby2_keywords
+    assert_equal([1, 2], pr.call(1, k: 2))
+    out = capture_performance_warnings do
+      q2 = pr.refined(StringRefinement)
+      assert_equal([1, 2], q2.call(1, k: 2))
+      # the clone made before the mark is not retroactively changed
+      assert_raise(ArgumentError) { q1.call(1, k: 2) }
+      # the rebuilt memo is hit from now on; no further warnings
+      assert_equal([1, 2], pr.refined(StringRefinement).call(1, k: 2))
+    end
+    assert_match(/Proc#refined re-copies the block because the ruby2_keywords flag changed after the copy was memoized/, out)
+    assert_equal(1, out.scan(/ruby2_keywords flag changed/).size)
+  end
+
+  # Procs sharing the same source block but capturing different closure environments hit the same cache slot
+  # (the environment is not part of the key), yet each clone must keep its own captured environment.
+  def test_memo_distinct_environments
+    factory = ->(tag) { ->(s) { "#{tag}:#{s.shout}" } }
+    p1 = factory.call("A")
+    p2 = factory.call("B")
+    r1 = p1.refined(StringRefinement)
+    r2 = p2.refined(StringRefinement)
+    assert_equal("A:X!", r1.call("x"))
+    assert_equal("B:Y!", r2.call("y"))
+    assert_equal("A:X!", r1.call("x"))
+  end
+
+  # The clone must reproduce the begin/rescue/ensure control flow (copied exception regions, shared locals).
+  def test_rescue_ensure
+    refined = ->(s) {
+      r = nil
+      begin
+        r = s.shout
+      rescue NoMethodError
+        r = "rescued"
+      ensure
+        r = "#{r}."
+      end
+      r
+    }.refined(StringRefinement)
+    assert_equal("YO!.", refined.call("yo"))
+  end
+
+  # Keyword and optional arguments must be reproduced on the clone.
+  def test_keyword_and_optional_args
+    refined = ->(a, b = "z", c:, d: "w") {
+      [a, b, c, d].map { |x| x.shout }.join
+    }.refined(StringRefinement)
+    assert_equal("A!Z!C!W!", refined.call("a", c: "c"))
+    assert_equal("A!B!C!D!", refined.call("a", "b", c: "c", d: "d"))
+  end
+
+  # Literal when-clauses compile to a jump table that must survive the clone.
+  def test_case_when_literal
+    refined = ->(s) {
+      case s.shout
+      when "A!" then 1
+      when "B!" then 2
+      else 0
+      end
+    }.refined(StringRefinement)
+    assert_equal(1, refined.call("a"))
+    assert_equal(2, refined.call("b"))
+    assert_equal(0, refined.call("c"))
+  end
+
+  # A flip-flop keeps state keyed off the local scope; the clone must run its own flip state, and a second call
+  # starts from a fresh state.
+  def test_flip_flop
+    body = ->(arr) {
+      out = []
+      arr.each { |i| out << i if (i == 2)..(i == 4) }
+      out
+    }
+    refined = body.refined(StringRefinement)
+    assert_equal([2, 3, 4], refined.call([1, 2, 3, 4, 5]))
+    assert_equal([2, 3, 4], refined.call([1, 2, 3, 4, 5]))
+  end
+
+  # The clone reports the same source location, parameters and arity as the source proc.
+  def test_preserves_location_and_parameters
+    orig = ->(a, b = 1, *c, d:, **e, &f) { a }
+    refined = orig.refined(StringRefinement)
+    assert_equal(orig.source_location, refined.source_location)
+    assert_equal(orig.parameters, refined.parameters)
+    assert_equal(orig.arity, refined.arity)
+  end
+
+  # Operator refinements must apply on the clone (specialized call paths) without leaking into the originals.
+  def test_operators
+    refined = ->(a, b) { [a + b, a < b] }.refined(Operators)
+    assert_equal(["plus(1,2)", "lt"], refined.call(1, 2))
+    aref = ->(a) { a[0] }.refined(Operators)
+    assert_equal("at0", aref.call([9]))
+    assert_equal(3, ->(a, b) { a + b }.call(1, 2))
+  end
+
+  # A string-literal Hash aref compiles to the optimized ArrayDerefInstr, which bypasses refinements; the
+  # Proc#refined clone must fall back to a normal refined call so the refinement still applies (matching CRuby
+  # and a fresh build under `using`).
+  def test_optimized_aref
+    refined = ->(h) { h["x"] }.refined(HashAref)
+    assert_equal("aref(x)", refined.call({ "x" => 1 }))
+    # the original proc keeps the builtin fast path
+    assert_equal(1, ->(h) { h["x"] }.call({ "x" => 1 }))
+  end
+
+  # A refined method may call super to reach the method it refines.
+  def test_super
+    refined = ->(o) { o.greet }.refined(SuperModule)
+    assert_equal("ref-base", refined.call(SuperBase.new))
+  end
+
+  # The clone shares the source proc's environment, so a recursive call through a captured local reaches the
+  # refined clone again and keeps the refinements.
+  def test_recursion_sees_refinements
+    fact = nil
+    fact = ->(s) { s.empty? ? "" : s[0].shout + fact.call(s[1..]) }.refined(StringRefinement)
+    assert_equal("A!B!C!", fact.call("abc"))
+  end
+
+  # Many independently created refined clones must all survive GC and keep working.
+  def test_gc
+    procs = 100.times.map { ->(s) { s.shout }.refined(StringRefinement) }
+    JRuby.gc rescue GC.start
+    procs.each { |pr| assert_equal("A!", pr.call("a")) }
+  end
+
+  # A Symbol#to_proc (&:shout) evaluated inside a refined clone resolves the method under the clone's refinements.
+  # A baked &:sym caches a non-refined symbol proc; the clone rewrites it to a plain symbol so the (now refined)
+  # call site converts it through Symbol#toRefinedProc with the clone's refinement scope.
+  def test_symbol_to_proc_sees_refinements
+    refined = ->(arr) { arr.map(&:shout) }.refined(StringRefinement)
+    assert_equal(["A!", "B!"], refined.call(["a", "b"]))
+    # the original proc has no refinement, so the symbol proc raises
+    assert_raise(NoMethodError) { ->(arr) { arr.map(&:shout) }.call(["a"]) }
+  end
+
+  # A literal `def` inside the block captures the clone's refinements (like a def inside a `using` scope), so the
+  # refinement also applies when that method is called later.  Covers both a singleton def and an instance def.
+  def test_def_in_block_sees_refinements
+    refined = ->(s) {
+      o = Object.new
+      def o.m = "hi".shout
+      [s.shout, o.m]
+    }.refined(StringRefinement)
+    assert_equal(["YO!", "HI!"], refined.call("yo"))
+
+    inst = ->(s) {
+      k = Class.new { def m; "hi".shout; end }
+      [s.shout, k.new.m]
+    }.refined(StringRefinement)
+    assert_equal(["YO!", "HI!"], inst.call("yo"))
+
+    # the original proc's def must NOT see refinements
+    assert_raise(NoMethodError) do
+      ->(s) { o = Object.new; def o.m = "hi".shout; o.m }.call("yo")
+    end
+  end
+
+  # A class/module (re)opened with a `class`/`module` keyword inside a refined proc -- as opposed to via a
+  # class_eval/Class.new block -- compiles to its own class-body scope, which must also become refinement-aware
+  # so the body and any def inside it see the refinements (matching a body opened under a `using` scope).
+  #
+  # The `class`/`module` keyword is a syntax error inside a method body (even within a block there), so these
+  # procs are built at class-body scope (block bodies, which the keyword is legal in) rather than inside the
+  # test methods.
+  class ReopenTarget; end
+  module ReopenModule; end
+
+  # reopen an existing class
+  REOPEN_CLASS = ->(s) {
+    class ReopenTarget
+      def m = "hi".shout
+    end
+    [s.shout, ReopenTarget.new.m]
+  }
+  # define a brand-new class with a superclass, plus a module method, plus class << self
+  REOPEN_VARIANTS = ->(s) {
+    class ReopenSub < ReopenTarget
+      def m = "hi".shout
+    end
+    module ReopenModule
+      def self.m = "hi".shout
+    end
+    class ReopenTarget
+      class << self
+        def n = "hi".shout
+      end
+    end
+    [s.shout, ReopenSub.new.m, ReopenModule.m, ReopenTarget.n]
+  }
+  # an otherwise identical proc whose class body must NOT see refinements when called without refined
+  REOPEN_UNREFINED = ->(s) {
+    class ReopenTarget
+      def unrefined = "hi".shout
+    end
+    ReopenTarget.new.unrefined
+  }
+
+  def test_class_keyword_body_sees_refinements
+    refined = REOPEN_CLASS.refined(StringRefinement)
+    assert_equal(["YO!", "HI!"], refined.call("yo"))
+
+    variants = REOPEN_VARIANTS.refined(StringRefinement)
+    assert_equal(["YO!", "HI!", "HI!", "HI!"], variants.call("yo"))
+
+    # the original proc's class body must NOT see refinements
+    assert_raise(NoMethodError) { REOPEN_UNREFINED.call("yo") }
+  end
+
+  # A refinement-aware clone is grafted under an already-built enclosing scope, so it needs its own full IR
+  # built before it can be JIT-compiled.  Run in a subprocess with a low JIT threshold and synchronous (non
+  # background) compilation so both the original and the clone cross the threshold deterministically.  We
+  # assert two things: the refinement still produces correct results after JIT (and the original is
+  # unaffected), and -- crucially for guarding the fix -- that the clone did not hit "JIT failed".  Without
+  # the fix the clone cannot build its full IR and falls back to the interpreter, which is still correct, so
+  # the JIT log is what distinguishes a working fix from a silent regression.
+  def test_refinement_survives_jit
+    script = <<~'RUBY'
+      module R
+        refine(String) { def upcase; "REFINED"; end }
+      end
+      prc = ->(s) { s.upcase }
+      1000.times { exit(1) unless prc.call("hi") == "HI" }       # JIT the original (bare upcase) first
+      refined = prc.refined(R)
+      1000.times { exit(2) unless refined.call("hi") == "REFINED" } # drive the clone past the threshold
+      exit(3) unless prc.call("hi") == "HI"                      # original must stay unaffected post-JIT
+      print "OK"
+    RUBY
+    Tempfile.create(['jit_refine', '.rb']) do |f|
+      f.write(script)
+      f.flush
+      out = jruby("-Xjit.threshold=10 -Xjit.background=false -Xjit.logging #{f.path} 2>&1")
+      assert_include out, "OK", "refinement-aware proc produced wrong results under JIT"
+      assert_not_include out, "JIT failed", "refinement-aware clone could not be JIT-compiled"
+    end
+  end
+end


### PR DESCRIPTION
Add Proc#refined(mod1, ...), which returns a new Proc whose body runs
with the given modules' refinements active. The receiver is unchanged
and the captured closure environment is shared; only the refinement
scope differs.

In JRuby whether a call resolves refinements is decided at IR build
time: CallInstr.create reads scope.maybeUsingRefinements() and, when
true, builds a RefinedCachingCallSite that captures the static scope.
So a refinement-aware copy of the receiver proc's IR is required (the
analog of CRuby recursively deep-copying the block iseq); merely
swapping an overlay at runtime is not enough.

## Cost for code that never uses Proc#refined

Branch `proc-with-refinements-ruby-4.1` (feature commit `12c2bdea1c`), baseline = parent
commit `e66555aa43`.

### Memory

- **`RubyProc` / `IRScope`**: no new fields — zero overhead per proc or per scope.
- **`IRClosure`**: two `boolean` flags (`inRefinementsCloneTree`, `refinementsClone`).
  Verified with JOL 0.17 that they fall into existing alignment padding after
  `closureId`/`isEND`: instance size is unchanged with or without them
  (120 bytes with compressed oops, 192 bytes without) — exactly zero bytes per closure.

  ```
   96   4  int     IRClosure.closureId
  100   1  boolean IRClosure.isEND
  101   1  boolean IRClosure.inRefinementsCloneTree   <- added
  102   1  boolean IRClosure.refinementsClone         <- added
  103   1          (alignment/padding gap)
  104   4  ref     IRClosure.signature
  Instance size: 120 bytes
  ```

- **`IRManager`**: one empty memo map (`refinementsCloneCache`, a synchronized
  `IdentityHashMap`) per runtime, ~300 bytes. This is the only fixed cost for a runtime
  that never uses `Proc#refined`.
- The map is intentionally strong- and identity-keyed:
  - Weak keys could never clear because the memo value (the clone) reaches its own key
    through the shared lexical parent (tried and reverted in presquash history:
    `c9c955434a` -> `fd06ace73b`). CRuby's iseq-keyed memo has the same clone->source reach.
  - Identity keying avoids `IRScope.equals`' scopeId-wraparound collisions (`3b259619f5`).
  - Entries are bounded to one slot per source closure, so growth is bounded by the number
    of distinct closures ever passed to `refined`.
- The map is read only inside `Proc#refined` itself (`IRClosure#refinementsClone`); no other
  runtime path touches it.

### Speed

Methodology: microbenchmarks per touched path; each sample = min of 10 timed passes after
5 warmup passes in a fresh process; binaries alternated per round, and which side runs
first alternates per round to cancel drift. Values are medians of per-process samples.
Machine noise floor: identical-binary samples varied up to 13-19% (e.g. base fixnum_ops
0.538-0.609). Startup is measured on the bare jar (`java -Djruby.home=... -jar jruby.jar
-e 0`); comparing via the `bin/jruby` launchers was confounded by unrelated differences in
the two working trees' state.

| bench       | path exercised                            | n | base   | feature | delta  |
|-------------|-------------------------------------------|---|--------|---------|--------|
| yield       | block dispatch                            | 8 | 0.2956 | 0.3041  | +2.9%  |
| proc_call   | Proc#call                                 | 5 | 0.2279 | 0.2242  | -1.6%  |
| proc_new    | Block/BlockBody instantiation             | 5 | 0.1193 | 0.1201  | +0.7%  |
| sym_to_proc | baked `&:sym` (SymbolProc)                | 5 | 0.0329 | 0.0322  | -2.1%  |
| fixnum_ops  | specialized `+`/`<` call instrs           | 5 | 0.5508 | 0.5447  | -1.1%  |
| float_ops   | specialized float `+` call instr          | 5 | 0.4527 | 0.4435  | -2.0%  |
| aref        | ArrayDerefInstr (was modified)            | 8 | 0.5204 | 0.5028  | -3.4%  |
| ir_build    | parse + IR build (incl. ensure cloning)   | 5 | 0.0109 | 0.0089  | -18%*  |
| startup     | bare-jar `-e 0` wall time                 | 8 | 1.525  | 1.495   | -2.0%  |

\* millisecond-scale absolute values; dominated by noise.

Verdict: no measurable slowdown. Deltas scatter in both directions within the noise floor,
and the leaning benches are not stable across sessions: aref was +2.4% in an earlier run
and -3.4% here; yield's per-round pairs split 3 feature wins / 5 losses (median +2.0%).
Mechanistically, the changes on these paths (`ArrayDerefInstr`, `CallInstr`, specialized
instrs, `Define*Instr`) are confined to `clone()`/`create()` — build time only; no
runtime-executed code or runtime-read field changed.

Bench scripts and raw results are in: https://github.com/shugo/jruby-refined-bench
