### PR TITLE
chore: fix build badges on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # JRuby - an implementation of the Ruby language on the JVM
 
-Master: [![JRuby CI](https://github.com/jruby/jruby/actions/workflows/ci.yml/badge.svg)](https://github.com/jruby/jruby/actions/workflows/ci.yml), [![JRuby CI (Windows)](https://github.com/jruby/jruby/actions/workflows/ci-windows.yml/badge.svg)](https://github.com/jruby/jruby/actions/workflows/ci-windows.yml)
-9.3 branch: [![JRuby CI](https://github.com/jruby/jruby/actions/workflows/ci.yml/badge.svg?branch=jruby-9.3)](https://github.com/jruby/jruby/actions/workflows/ci.yml), [![JRuby CI (Windows)](https://github.com/jruby/jruby/actions/workflows/ci-windows.yml/badge.svg?branch=jruby-9.3)](https://github.com/jruby/jruby/actions/workflows/ci-windows.yml)
+master/`10.1`▸ [![Master JRuby CI](https://github.com/jruby/jruby/actions/workflows/ci.yml/badge.svg)](https://github.com/jruby/jruby/actions/workflows/ci.yml)
+┃ `10.0`▸ [![10.0 JRuby CI](https://github.com/jruby/jruby/actions/workflows/ci.yml/badge.svg?branch=jruby-10.0)](https://github.com/jruby/jruby/actions/workflows/ci.yml)
+┃ `9.4`▸ [![9.4 JRuby CI](https://github.com/jruby/jruby/actions/workflows/ci.yml/badge.svg?branch=jruby-9.4)](https://github.com/jruby/jruby/actions/workflows/ci.yml)
 
 ## About
 


### PR DESCRIPTION
Preview should show correctly.

Dedicated windows workflows are removed now, it seems (except maybe 9.4, but not worth worrying about)