### PR TITLE
Remove deprecated rubyhash constructors

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -290,16 +290,21 @@ public class RubyHash extends RubyObject implements Map {
         this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, defaultValue));
     }
 
+    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.6.0", forRemoval = true)
     public RubyHash(Ruby runtime, IRubyObject defaultValue, int buckets) {
         super(runtime, runtime.getHash());
+        // ensure no subclasses call this constructor
+        assert getClass() == RubyHash.class;
         this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, defaultValue, buckets));
     }
 
-    // TODO should this be deprecated ? (to be efficient, internals should deal with RubyHash directly)
+    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.3.0", forRemoval = true)
     public RubyHash(Ruby runtime, Map valueMap, IRubyObject defaultValue) {
         super(runtime, runtime.getHash());
+        // ensure no subclasses call this constructor
+        assert getClass() == RubyHash.class;
         this.setDelegate(RubyHashLinkedBuckets.newHash(runtime, valueMap, defaultValue));
     }
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -245,69 +245,6 @@ public class RubyHash extends RubyObject implements Map {
         assert this.getClass() != RubyHash.class;
     }
 
-    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
-    @Deprecated(since = "10.0.6.0", forRemoval = true)
-    public RubyHash(Ruby runtime, RubyClass klass) {
-        super(runtime, klass);
-        // ensure no subclasses call this constructor
-        assert getClass() == RubyHash.class;
-        setDelegate(this);
-    }
-
-    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
-    @Deprecated(since = "10.0.3.0")
-    public RubyHash(Ruby runtime, RubyClass klass, boolean objectSpace) {
-        super(runtime, klass, objectSpace);
-        // ensure no subclasses call this constructor
-        assert getClass() == RubyHash.class;
-        this.setDelegate(new RubyHashLinkedBuckets(runtime, klass, objectSpace));
-    }
-
-    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
-    @Deprecated(since = "10.0.6.0", forRemoval = true)
-    public RubyHash(Ruby runtime, int buckets) {
-        super(runtime, runtime.getHash());
-        // ensure no subclasses call this constructor
-        assert getClass() == RubyHash.class;
-        this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, buckets));
-    }
-
-    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
-    @Deprecated(since = "10.0.6.0", forRemoval = true)
-    public RubyHash(Ruby runtime) {
-        super(runtime, runtime.getHash());
-        // ensure no subclasses call this constructor
-        assert getClass() == RubyHash.class;
-        this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime));
-    }
-
-    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
-    @Deprecated(since = "10.0.6.0", forRemoval = true)
-    public RubyHash(Ruby runtime, IRubyObject defaultValue) {
-        super(runtime, runtime.getHash());
-        // ensure no subclasses call this constructor
-        assert getClass() == RubyHash.class;
-        this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, defaultValue));
-    }
-
-    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
-    @Deprecated(since = "10.0.6.0", forRemoval = true)
-    public RubyHash(Ruby runtime, IRubyObject defaultValue, int buckets) {
-        super(runtime, runtime.getHash());
-        // ensure no subclasses call this constructor
-        assert getClass() == RubyHash.class;
-        this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, defaultValue, buckets));
-    }
-
-    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
-    @Deprecated(since = "10.0.3.0", forRemoval = true)
-    public RubyHash(Ruby runtime, Map valueMap, IRubyObject defaultValue) {
-        super(runtime, runtime.getHash());
-        // ensure no subclasses call this constructor
-        assert getClass() == RubyHash.class;
-        this.setDelegate(RubyHashLinkedBuckets.newHash(runtime, valueMap, defaultValue));
-    }
-
     /* ============================
      * Here are hash internals
      * (This could be extracted to a separate class but it's not too large though)

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -266,9 +266,13 @@ public class RubyHash extends RubyObject implements Map {
     // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.6.0", forRemoval = true)
     public RubyHash(Ruby runtime, int buckets) {
-        this(runtime, UNDEF, buckets);
+        super(runtime, runtime.getHash());
+        // ensure no subclasses call this constructor
+        assert getClass() == RubyHash.class;
+        this.setDelegate(RubyHashLinkedBuckets.newLBHash(runtime, buckets));
     }
 
+    // Delegated constructor, to be hidden and returned to normal super constructor once no longer in use
     @Deprecated(since = "10.0.6.0", forRemoval = true)
     public RubyHash(Ruby runtime) {
         super(runtime, runtime.getHash());

--- a/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
+++ b/core/src/main/java/org/jruby/RubyHashLinkedBuckets.java
@@ -174,10 +174,6 @@ public class RubyHashLinkedBuckets extends RubyHash {
         allocFirst();
     }
 
-    protected RubyHashLinkedBuckets(Ruby runtime, int buckets) {
-        this(runtime, UNDEF, buckets);
-    }
-
     protected RubyHashLinkedBuckets(Ruby runtime) {
         this(runtime, UNDEF);
     }
@@ -234,7 +230,7 @@ public class RubyHashLinkedBuckets extends RubyHash {
     }
 
     public static RubyHashLinkedBuckets newLBHash(Ruby runtime, int buckets) {
-        return new RubyHashLinkedBuckets(runtime, buckets);
+        return new RubyHashLinkedBuckets(runtime, UNDEF, buckets);
     }
 
     public static RubyHashLinkedBuckets newLBHash(Ruby runtime, int buckets, boolean objectSpace) {


### PR DESCRIPTION
This does a final removal of all public `RubyHash` constructors, as discussed in #9456. This may or may not end up merging as-is, but is a reminded for 10.2 to revisit whether these constructors can finally be removed.