### PR TITLE
Use Integer for JRuby VM messages

### DIFF
--- a/lib/ruby/stdlib/jruby/vm.rb
+++ b/lib/ruby/stdlib/jruby/vm.rb
@@ -69,7 +69,7 @@ module JRuby
       case obj
       when String
         @queue.put obj
-      when Fixnum
+      when Integer
         @queue.put obj
       end
     end

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -117,3 +117,4 @@ jruby/test_load_compiled_ruby
 jruby/test_load_compiled_ruby_class_from_classpath
 
 jruby/test_date_parse_limit
+jruby/test_jruby_vm

--- a/test/jruby/test_jruby_vm.rb
+++ b/test/jruby/test_jruby_vm.rb
@@ -1,0 +1,70 @@
+require 'test/unit'
+require 'jruby/vm'
+
+class TestJRubyVM < Test::Unit::TestCase
+  MESSAGE_TIMEOUT = 5
+  THREAD_JOIN_TIMEOUT_MS = 5_000
+
+  def setup
+    drain_messages
+  end
+
+  def teardown
+    drain_messages
+  end
+
+  def test_send_message_accepts_string_and_integer
+    ['message', 1].each do |message|
+      JRuby::VM.send_message(JRuby::VM_ID, message)
+
+      assert_equal message, wait_for_message
+    end
+  end
+
+  def test_child_vm_accepts_parent_vm_id
+    code = <<~'RUBY'
+      require 'jruby/vm'
+
+      parent = JRuby::VM.get_message
+      JRuby::VM.send_message(parent, 'ok')
+    RUBY
+
+    vm = JRuby::VM.spawn('--disable=rubyopt', '-e', code)
+    vm.start
+    sent = false
+
+    begin
+      vm << JRuby::VM_ID
+      sent = true
+
+      assert_equal 'ok', wait_for_message
+    ensure
+      # Unblock the child when the integer send fails, as it does before the fix.
+      vm.queue.put(JRuby::VM_ID) unless sent
+      vm.main.join(THREAD_JOIN_TIMEOUT_MS)
+      assert_equal false, vm.main.alive?, 'child JRuby VM did not terminate'
+    end
+  end
+
+  private
+
+  def wait_for_message
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + MESSAGE_TIMEOUT
+
+    loop do
+      message = JRuby::VM.poll_message
+      return message if message
+
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      flunk 'timed out waiting for JRuby::VM message' if now >= deadline
+
+      sleep 0.01
+    end
+  end
+
+  def drain_messages
+    loop do
+      break unless JRuby::VM.poll_message
+    end
+  end
+end


### PR DESCRIPTION
`JRuby::VM#send` checks `Fixnum` when accepting integer messages. On JRuby 10 / Ruby 3.4 semantics, `Fixnum` is undefined, so sending integer messages raises `NameError` before enqueuing.

Use `Integer` instead. This keeps integer messages working on JRuby 10 and remains compatible with older supported JRuby versions.

This fixes the sub-VM sample pattern:

```ruby
vm << JRuby::VM_ID
```

Fixes #9498.

## Testing

- JRuby 10:

```sh
docker run --rm \
  -v /home/ll/src/github.com/jruby/jruby:/workspace \
  -w /workspace \
  ghcr.io/datadog/images-rb/engines/jruby:10.0 \
  jruby -I /workspace/lib/ruby/stdlib -rjruby/vm \
    -e "JRuby::VM.send_message(JRuby::VM_ID, 1); puts JRuby::VM.get_message"
```

- JRuby 9.4:

```sh
docker run --rm \
  -v /home/ll/src/github.com/jruby/jruby:/workspace \
  -w /workspace \
  ghcr.io/datadog/images-rb/engines/jruby:9.4 \
  jruby -I /workspace/lib/ruby/stdlib -rjruby/vm \
    -e "JRuby::VM.send_message(JRuby::VM_ID, 1); puts JRuby::VM.get_message"
```
