### PR TITLE
Fix __dir__ for eval filenames

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1973,7 +1973,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         String file = "(eval at " + singleBacktrace.getFileName() + ":" +  + singleBacktrace.getLineNumber() + ")";
         int line = 0;
 
-        return evalUnder(context, mod, evalStr, file, line, evalType);
+        return evalUnder(context, mod, evalStr, file, line, evalType, true);
     }
 
     /** specific_eval
@@ -2001,7 +2001,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         String file = arg1.convertToString().asJavaString();
         int line = 0;
 
-        return evalUnder(context, mod, evalStr, file, line, evalType);
+        return evalUnder(context, mod, evalStr, file, line, evalType, false);
     }
 
     /** specific_eval
@@ -2030,7 +2030,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         String file = arg1.convertToString().asJavaString();
         int line = toInt(context, arg2) - 1;
 
-        return evalUnder(context, mod, evalStr, file, line, evalType);
+        return evalUnder(context, mod, evalStr, file, line, evalType, false);
     }
 
     @Deprecated(since = "10.0.0.0")
@@ -2049,7 +2049,11 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * using the module under as the context.
      */
     public IRubyObject evalUnder(final ThreadContext context, RubyModule under, RubyString src, String file, int line, EvalType evalType) {
-        return Interpreter.evalSimple(context, under, this, src, file, line, evalType);
+        return evalUnder(context, under, src, file, line, evalType, false);
+    }
+
+    public IRubyObject evalUnder(final ThreadContext context, RubyModule under, RubyString src, String file, int line, EvalType evalType, boolean syntheticFile) {
+        return Interpreter.evalSimple(context, under, this, src, file, line, evalType, syntheticFile);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -67,6 +67,8 @@ import org.jruby.internal.runtime.GlobalVariables;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.JavaMethod;
 import org.jruby.internal.runtime.methods.JavaMethod.JavaMethodNBlock;
+import org.jruby.ir.IREvalScript;
+import org.jruby.ir.IRScope;
 import org.jruby.ir.interpreter.Interpreter;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.java.proxies.ConcreteJavaProxy;
@@ -1468,7 +1470,7 @@ public class RubyKernel {
                 binding.setLine(0);
             }
         } else {  // no explicit file/line argument given
-            binding.setFile("(eval at " + context.getSingleBacktrace().getFileAndLine() + ")");
+            binding.setFile("(eval at " + context.getSingleBacktrace().getFileAndLine() + ")", true);
             binding.setLine(0);
         }
 
@@ -2295,10 +2297,30 @@ public class RubyKernel {
         // NOTE: not using __FILE__ = context.getFile() since it won't work with JIT
         String __FILE__ = context.getSingleBacktrace().getFileName();
 
+        IREvalScript evalScript = getEvalScript(context);
+
+        if (evalScript != null) {
+            if (evalScript.isFileNameSynthetic()) return context.nil;
+
+            return newString(context, RubyFile.dirname(context, __FILE__));
+        }
+
         __FILE__ = loadService(context).getPathForLocation(__FILE__);
 
         RubyString path = RubyFile.expandPathInternal(context, newString(context, __FILE__), null, false, true);
         return newString(context, RubyFile.dirname(context, path.asJavaString()));
+    }
+
+    private static IREvalScript getEvalScript(ThreadContext context) {
+        if (context.getCurrentStaticScope() == null) return null;
+
+        IRScope scope = context.getCurrentStaticScope().getIRScope();
+
+        for (; scope != null; scope = scope.getLexicalParent()) {
+            if (scope instanceof IREvalScript evalScript) return evalScript;
+        }
+
+        return null;
     }
 
     @Deprecated(since = "10.0.0.0")

--- a/core/src/main/java/org/jruby/ir/IREvalScript.java
+++ b/core/src/main/java/org/jruby/ir/IREvalScript.java
@@ -7,16 +7,23 @@ import org.jruby.util.ByteList;
 
 public class IREvalScript extends IRClosure {
     private String fileName;
+    private final boolean fileNameSynthetic;
 
     private static final ByteList EVAL = new ByteList(new byte[] {'E', 'V', 'A', 'L'});
 
     public IREvalScript(IRManager manager, IRScope lexicalParent, String fileName,
             int lineNumber, StaticScope staticScope, EvalType evalType) {
+        this(manager, lexicalParent, fileName, lineNumber, staticScope, evalType, false);
+    }
+
+    public IREvalScript(IRManager manager, IRScope lexicalParent, String fileName,
+            int lineNumber, StaticScope staticScope, EvalType evalType, boolean fileNameSynthetic) {
         // ALL eval scopes are not really closures and are always new scopes.  We should not reference an eval
         // by a TemporaryClosureVariable ever.
         super(manager, lexicalParent, lineNumber, staticScope, 0, EVAL);
 
         this.fileName = fileName;
+        this.fileNameSynthetic = fileNameSynthetic;
 
         if (staticScope != null) {
             // SSS FIXME: This is awkward!
@@ -66,5 +73,9 @@ public class IREvalScript extends IRClosure {
     @Override
     public String getFile() {
         return fileName;
+    }
+
+    public boolean isFileNameSynthetic() {
+        return fileNameSynthetic;
     }
 }

--- a/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
@@ -210,6 +210,10 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
      * @return An IRubyObject result from the evaluation
      */
     public static IRubyObject evalSimple(ThreadContext context, RubyModule under, IRubyObject self, RubyString src, String file, int lineNumber, EvalType evalType) {
+        return evalSimple(context, under, self, src, file, lineNumber, evalType, false);
+    }
+
+    public static IRubyObject evalSimple(ThreadContext context, RubyModule under, IRubyObject self, RubyString src, String file, int lineNumber, EvalType evalType, boolean syntheticFile) {
         Ruby runtime = context.runtime;
 
         // no binding, just eval in "current" frame (caller's frame)
@@ -220,7 +224,7 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
         context.pushEvalSimpleFrame(self);
 
         try {
-            return evalCommon(context, evalScope, self, src, file, lineNumber, evalName(file, lineNumber), Block.NULL_BLOCK, evalType, false);
+            return evalCommon(context, evalScope, self, src, file, lineNumber, evalName(file, lineNumber), Block.NULL_BLOCK, evalType, false, syntheticFile);
         } finally {
             context.popFrame();
         }
@@ -232,7 +236,12 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
 
     private static IRubyObject evalCommon(ThreadContext context, DynamicScope evalScope, IRubyObject self, IRubyObject src,
                                           String file, int lineNumber, String name, Block blockArg, EvalType evalType, boolean bindingGiven) {
-        InterpreterContext ic = prepareIC(context, evalScope, src, file, lineNumber, evalType, bindingGiven);
+        return evalCommon(context, evalScope, self, src, file, lineNumber, name, blockArg, evalType, bindingGiven, false);
+    }
+
+    private static IRubyObject evalCommon(ThreadContext context, DynamicScope evalScope, IRubyObject self, IRubyObject src,
+                                          String file, int lineNumber, String name, Block blockArg, EvalType evalType, boolean bindingGiven, boolean syntheticFile) {
+        InterpreterContext ic = prepareIC(context, evalScope, src, file, lineNumber, evalType, bindingGiven, syntheticFile);
 
         evalScope.setEvalType(evalType);
         context.pushScope(evalScope);
@@ -265,7 +274,7 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
         Frame lastFrame = context.preEvalWithBinding(binding);
         try {
             return evalCommon(context, evalScope, self, src, binding.getFile(),
-                    binding.getLine(), binding.getMethod(), binding.getFrame().getBlock(), EvalType.BINDING_EVAL, bindingGiven);
+                    binding.getLine(), binding.getMethod(), binding.getFrame().getBlock(), EvalType.BINDING_EVAL, bindingGiven, binding.isFileNameSynthetic());
         } finally {
             context.postEvalWithBinding(binding, lastFrame);
         }
@@ -273,13 +282,18 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
 
     private static InterpreterContext prepareIC(ThreadContext context, DynamicScope evalScope, IRubyObject src,
                                                         String file, int lineNumber, EvalType evalType, boolean bindingGiven) {
+        return prepareIC(context, evalScope, src, file, lineNumber, evalType, bindingGiven, false);
+    }
+
+    private static InterpreterContext prepareIC(ThreadContext context, DynamicScope evalScope, IRubyObject src,
+                                                        String file, int lineNumber, EvalType evalType, boolean bindingGiven, boolean syntheticFile) {
         Ruby runtime = context.runtime;
         IRScope containingIRScope = evalScope.getStaticScope().getEnclosingScope().getIRScope();
         ParseResult result = runtime.getParserManager().parseEval(file, lineNumber, src.convertToString().getByteList(), evalScope);
         StaticScope staticScope = evalScope.getStaticScope();
 
         // Top-level script!
-        IREvalScript script = new IREvalScript(runtime.getIRManager(), containingIRScope, file, lineNumber, staticScope, evalType);
+        IREvalScript script = new IREvalScript(runtime.getIRManager(), containingIRScope, file, lineNumber, staticScope, evalType, syntheticFile);
 
         // enable refinements if incoming scope already has an overlay active
         if (staticScope.getOverlayModuleForRead() != null || containingIRScope.maybeUsingRefinements()) {

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -51,6 +51,7 @@ public class Binding {
 
     public String method;
     public String filename;
+    private boolean filenameSynthetic;
     public int line;
 
     private Visibility visibility;
@@ -148,6 +149,7 @@ public class Binding {
     
     private Binding(Binding other) {
         this(other.self, other.frame, other.visibility, other.dynamicScope, other.method, other.filename, other.line, other.dummyScope);
+        this.filenameSynthetic = other.filenameSynthetic;
     }
 
     /**
@@ -221,7 +223,16 @@ public class Binding {
     }
 
     public void setFile(String filename) {
+        setFile(filename, false);
+    }
+
+    public void setFile(String filename, boolean synthetic) {
         this.filename = filename;
+        this.filenameSynthetic = synthetic;
+    }
+
+    public boolean isFileNameSynthetic() {
+        return filenameSynthetic;
     }
 
     public int getLine() {

--- a/spec/ruby/core/kernel/__dir___spec.rb
+++ b/spec/ruby/core/kernel/__dir___spec.rb
@@ -17,6 +17,17 @@ describe "Kernel#__dir__" do
       eval("__dir__", nil, "foo.rb").should == "."
       eval("__dir__", nil, "foo/bar.rb").should == "foo"
     end
+
+    it "returns File.dirname(filename) when used in instance_eval" do
+      Object.new.instance_eval("__dir__", "foo/bar.rb").should == "foo"
+    end
+
+    it "returns File.dirname(filename) in methods defined by eval" do
+      klass = Class.new
+      klass.class_eval("def evaluated_dir; __dir__; end", "foo/bar.rb")
+
+      klass.new.evaluated_dir.should == "foo"
+    end
   end
 
   context "when used in eval with top level binding" do

--- a/spec/tags/ruby/core/kernel/__dir___tags.txt
+++ b/spec/tags/ruby/core/kernel/__dir___tags.txt
@@ -1,2 +1,0 @@
-fails:Kernel#__dir__ when used in eval with a given filename returns File.dirname(filename)
-fails:Kernel#__dir__ when used in eval with top level binding returns nil


### PR DESCRIPTION
Fix `Kernel#__dir__` for code evaluated with explicit filenames so relative eval filenames stay relative, matching CRuby.

# Context
JRuby currently expands `__dir__` for eval filenames through the normal file path handling. This differs from CRuby for code like:

```ruby
instance_eval(File.read("print.rb"), "foo/bar/print.rb")
```

CRuby reports `__FILE__` as `"foo/bar/print.rb"` and `__dir__` as `"foo/bar"`. JRuby already reports `__FILE__` correctly, but `__dir__` was expanded to an absolute path. For evals without an explicit filename, CRuby returns `nil` for `__dir__`.

# Changes
- Track whether an eval filename was synthesized by JRuby when eval is invoked without an explicit filename.
- Carry that metadata through `Binding` and `IREvalScript`, including methods defined inside eval.
- Update `Kernel#__dir__` to use eval source metadata:
  - explicit eval filename: return `File.dirname(filename)` without expansion
  - synthetic eval filename: return `nil`
  - normal loaded files: keep the existing expansion behavior
- Remove the now-passing `__dir__` spec tags.
- Add coverage for `instance_eval` with an explicit filename and a method defined inside eval.

# Tophatting
Ran locally with JDK 25:

```sh
JAVA_HOME=/opt/homebrew/opt/java PATH=/opt/homebrew/opt/java/bin:$PATH ./mvnw -Dcore
JAVA_HOME=/opt/homebrew/opt/java PATH=/opt/homebrew/opt/java/bin:$PATH ./bin/jruby spec/mspec/bin/mspec ci spec/ruby/core/kernel/__dir___spec.rb
JAVA_HOME=/opt/homebrew/opt/java PATH=/opt/homebrew/opt/java/bin:$PATH ./bin/jruby -e 'p Object.new.instance_eval("[__FILE__, __dir__]", "foo/bar/print.rb")'
JAVA_HOME=/opt/homebrew/opt/java PATH=/opt/homebrew/opt/java/bin:$PATH ./bin/jruby -e 'p eval("[__FILE__, __dir__]", binding); p eval("[__FILE__, __dir__]", nil, "(eval at explicit/foo.rb)")'
```
