### PR TITLE
Fix CALL_KEYWORD_EMPTY leaking from (...) forwards to native methods

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -936,8 +936,19 @@ public class IRRuntimeHelpers {
 
     @JIT @Interp
     public static void setCallInfo(ThreadContext context, int flags) {
-        // FIXME: This may propagate empty more than the current call?   empty might need to be stuff elsewhere to prevent this.
-        context.callInfo = (context.callInfo & CALL_KEYWORD_EMPTY) | flags;
+        // CALL_KEYWORD_EMPTY is set dynamically while building this call's arguments (argsPush,
+        // isHashEmpty, irSplat) when a keyword-rest or splat turns out to be empty, and it must
+        // survive into the call so the callee treats the kwargs as explicitly empty. It is only
+        // ever set for a call that passes a keyword-rest or splat, so we carry it forward only
+        // when this call is such a call. Otherwise a leftover CALL_KEYWORD_EMPTY from a previous
+        // call whose (native) callee never reset callInfo would leak into an unrelated call (e.g.
+        // a plain keyword call), causing the keyword argument to be mishandled. See
+        // test/jruby/test_call_info.rb#test_forward_dots_to_native_method_does_not_leak.
+        if ((flags & (CALL_KEYWORD_REST | CALL_SPLATS)) != 0) {
+            context.callInfo = (context.callInfo & CALL_KEYWORD_EMPTY) | flags;
+        } else {
+            context.callInfo = flags;
+        }
     }
 
     public static void checkForExtraUnwantedKeywordArgs(ThreadContext context, final StaticScope scope, RubyHash keywordArgs) {

--- a/test/jruby/test_call_info.rb
+++ b/test/jruby/test_call_info.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 require 'tempfile'
 require 'stringio'
+require 'openssl'
 
 # Tests for ThreadContext#callInfo not leaking between method calls.
 #
@@ -383,6 +384,44 @@ class TestCallInfo < Test::Unit::TestCase
     err = NoMatchingPatternKeyError.new("test")
     assert_equal "test", err.message
 
+    v = KwargsReceiver.new(1, k: 2)
+    assert_equal [1, 2], [v.a, v.k]
+  end
+
+  # ── `(...)` argument forwarding to a native method ─────────────────
+  #
+  # A `(...)` forward (as Forwardable#def_delegator generates on Ruby >= 2.7)
+  # builds the forwarded call with an empty keyword-rest, which sets
+  # CALL_KEYWORD_EMPTY via Helpers#argsPush. When the forward target is a
+  # native method that does not reset callInfo (e.g. jruby-openssl's
+  # OpenSSL::X509::Certificate#to_pem), that flag survives the call and
+  # IRRuntimeHelpers#setCallInfo then preserves it into the NEXT keyword
+  # call, so the next call's keyword hash is treated as a positional arg.
+
+  def self.signed_certificate
+    key = OpenSSL::PKey::RSA.new(2048)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = cert.issuer = OpenSSL::X509::Name.parse("/CN=test")
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 60
+    cert.not_after = Time.now + 60
+    cert.sign(key, OpenSSL::Digest.new("SHA256"))
+    cert
+  end
+
+  def forward_all(o, ...)
+    o.to_pem(...)
+  end
+
+  def test_forward_dots_to_native_method_does_not_leak
+    cert = self.class.signed_certificate
+    forward_all(cert)   # `(...)` forward to a native method; leaks CALL_KEYWORD_EMPTY.
+
+    # The leaked flag is transient (any intervening call resets it), so the
+    # keyword call must come immediately. If callInfo leaked, it raises
+    # ArgumentError: wrong number of arguments (given 2, expected 1).
     v = KwargsReceiver.new(1, k: 2)
     assert_equal [1, 2], [v.a, v.k]
   end


### PR DESCRIPTION
## Problem

A literal keyword argument is silently dropped — passed as a trailing positional Hash — when the immediately-preceding statement is a `(...)` argument-forwarding call to a native method, raising a bogus `ArgumentError: wrong number of arguments (given N, expected N-1)`.

Found via sigstore-ruby on JRuby 10.x: a `bundle.expected_tlog_entry(hashed_input, verifier_pem:)` call raised `ArgumentError` only because the preceding statement forwarded `(...)` to a native method (`OpenSSL::X509::Certificate#to_pem`).

Minimal reproduction (gem-free; `openssl` ships with JRuby):

```ruby
require "openssl"
cert = OpenSSL::X509::Certificate.new   # any signed cert
def forward(o, ...) = o.to_pem(...)     # `(...)` forward to a native method
def kwm(a, k: nil) = [a, k]
v = forward(cert)
kwm("HI", k: v)   # => ArgumentError: wrong number of arguments (given 2, expected 1)
```

Reproduces under `-X-C` as well, so it is an IR-runtime bug, not JIT-specific.

## Root cause

`ThreadContext#callInfo` is transient state passed from a caller's argument build to its callee. `CALL_KEYWORD_EMPTY` (`1<<3`) is set dynamically while building a call's arguments (`Helpers#argsPush`, `IRRuntimeHelpers#isHashEmpty`/`#irSplat`) when a keyword-rest or splat turns out empty, and must survive into the call so the callee treats the kwargs as explicitly empty.

`IRRuntimeHelpers#setCallInfo` carried that bit forward unconditionally:

```java
context.callInfo = (context.callInfo & CALL_KEYWORD_EMPTY) | flags;  // had a FIXME
```

`callInfo` is normally cleared on the callee side in `#receiveKeywords` via `resetCallInfo`, but a native callee (a generated `$INVOKER` with no `recv_kw` step) does not clear it — and the precompiled jruby-openssl invoker predates and bypasses the `InvocationMethodFactory` wipe. So the empty bit set by the `(...)` forward survives, and the next keyword call inherits it and skips keyword processing.

## Fix

A legitimate `CALL_KEYWORD_EMPTY` is only ever produced for a call that itself passes a keyword-rest or splat. So carry it forward only when this call's flags indicate `CALL_KEYWORD_REST` or `CALL_SPLATS`; otherwise a leftover bit from a previous call is stale and is dropped. This preserves correct empty-`**`/splat delegation — which setting `callInfo = flags` outright would regress — while stopping the leak into unrelated keyword calls.

## Commits

1. **Add failing test** — `test_call_info.rb#test_forward_dots_to_native_method_does_not_leak`, documenting the bug (fails on the base).
2. **Fix** — the targeted `setCallInfo` change above.

## Verification

- `test/jruby/test_call_info.rb`: 34/34 pass under both JIT and `-X-C`.
- `spec/ruby/language` keyword/method/block specs: no regressions vs. a rebuilt baseline (notably the empty-`**` delegation specs still pass).
