### PR TITLE
avoid setting error-info on RaiseException's init

### DIFF
--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -107,7 +107,6 @@ public class RaiseException extends JumpException {
         context.runtime.incrementExceptionCount();
         if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
 
-        doSetLastError(context);
         doCallEventHook(context);
 
         if (backtrace == null) {
@@ -170,10 +169,6 @@ public class RaiseException extends JumpException {
         if (context.runtime.hasEventHooks()) {
             context.runtime.callEventHooks(context, RubyEvent.RAISE, context.getFile(), context.getLine(), context.getFrameName(), context.getFrameKlazz());
         }
-    }
-
-    private void doSetLastError(final ThreadContext context) {
-        context.setErrorInfo(exception); // $!
     }
 
     /**


### PR DESCRIPTION
The `$!` semantics are handled by IR protocol, the  `RaiseException`'s filling of `$!` has been in-place for a very long time but is not the right place to set error-info.