### PR TITLE
avoid setting $! from RaiseException <init>

### DIFF
--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -132,6 +132,10 @@ public class RubyException extends RubyObject {
         this.setMessage(message == null ? runtime.getNil() : runtime.newString(message));
     }
 
+    public static void raise(ThreadContext context, IRubyObject exception) {
+        RubyKernel.raiseInternal(context, exception, RubyKernel.lastErrorCause(context));
+    }
+
     @JRubyMethod(name = "exception", rest = true, meta = true)
     public static IRubyObject exception(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         return ((RubyClass) recv).newInstance(context, args, block);

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1051,7 +1051,7 @@ public class RubyKernel {
         RubyException exception =
                 lastException instanceof RubyException ex ? ex : newBlankRuntimeException(context);
 
-        return raiseException(context, exception, null);
+        return raiseException(context, exception);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1067,7 +1067,7 @@ public class RubyKernel {
 
     static IRubyObject raiseInternal(ThreadContext context, IRubyObject exception, Cause cause) {
         maybeThrowJavaException(context, exception);
-        return raiseException(context, prepareNewException(context, exception), cause);
+        return raiseWithNewExceptionCause(context, prepareNewException(context, exception), cause);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1083,7 +1083,8 @@ public class RubyKernel {
             default -> prepareNewException(context, arg0, arg1);
         };
 
-        return raiseException(context, exception, cause);
+        setGivenExceptionCause(context, cause, exception);
+        return raiseException(context, exception);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1098,12 +1099,16 @@ public class RubyKernel {
             default -> prepareNewException(context, arg0, arg1, arg2);
         };
 
-        return raiseException(context, exception, cause);
+        return raiseWithNewExceptionCause(context, exception, cause);
     }
 
-    private static IRubyObject raiseException(ThreadContext context, RubyException exception, Cause cause) {
+    private static IRubyObject raiseWithNewExceptionCause(ThreadContext context, RubyException exception, Cause cause) {
+        setNewExceptionCause(context, exception, cause);
+        return raiseException(context, exception);
+    }
+
+    private static IRubyObject raiseException(ThreadContext context, RubyException exception) {
         printDebugException(context, exception);
-        if (cause != null) setNewExceptionCause(context, exception, cause);
 
         context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
         return Helpers.throwExceptionT(exception.toThrowable());
@@ -1121,7 +1126,7 @@ public class RubyKernel {
 
         RubyException exception = prepareNewException(context, arg0, arg1, arg2);
 
-        return raiseException(context, exception, cause);
+        return raiseWithNewExceptionCause(context, exception, cause);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1072,6 +1072,7 @@ public class RubyKernel {
 
         setNewExceptionCause(context, exception, cause);
 
+        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
         return Helpers.throwExceptionT(exception.toThrowable());
     }
 
@@ -1092,6 +1093,7 @@ public class RubyKernel {
 
         setGivenExceptionCause(context, cause, exception);
 
+        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
         return Helpers.throwExceptionT(exception.toThrowable());
     }
 
@@ -1111,6 +1113,7 @@ public class RubyKernel {
 
         setNewExceptionCause(context, exception, cause);
 
+        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
         return Helpers.throwExceptionT(exception.toThrowable());
     }
 
@@ -1130,6 +1133,7 @@ public class RubyKernel {
 
         setNewExceptionCause(context, exception, cause);
 
+        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
         return Helpers.throwExceptionT(exception.toThrowable());
     }
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -955,6 +955,7 @@ public class RubyKernel {
             } else {
                 return new MainExitException(status, true);
             }
+
         }
 
         RaiseException ex = message == null ?

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1232,7 +1232,7 @@ public class RubyKernel {
         IRubyObject maybeException = null;
         switch (argc) {
             case 0:
-                maybeException = globalVariables(context).get("$!");
+                maybeException = context.getErrorInfo();
                 break;
             case 1:
                 if (args.length == 1) maybeException = args[0];
@@ -1259,7 +1259,7 @@ public class RubyKernel {
             if (!(maybeThrowable instanceof Throwable)) throw typeError(context, "can't raise a non-Throwable Java object");
 
             final Throwable ex = (Throwable) maybeThrowable;
-            return ex; // not reached
+            return ex;
         }
         return null;
     }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1107,11 +1107,16 @@ public class RubyKernel {
         return raiseException(context, exception);
     }
 
+    // MRI's rb_longjmp -> setup_exception
     private static IRubyObject raiseException(ThreadContext context, RubyException exception) {
-        printDebugException(context, exception);
+        context.setErrorInfo(exception); // set $! early - wiring below forces toThrowable/preRaise
 
-        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
-        return Helpers.throwExceptionT(exception.toThrowable());
+        RaiseException throwable = exception.toThrowable();
+        printDebugException(context, exception); // debug output ($DEBUG) after $! is set
+        // :raise hook before throwing (MRI: EXEC_EVENT_HOOK(ec, RUBY_EVENT_RAISE, ...))
+        IRRuntimeHelpers.traceRaise(context);
+
+        return Helpers.throwExceptionT(throwable);
     }
 
     public static IRubyObject raise(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -961,8 +961,11 @@ public class RubyKernel {
         RubySystemExit exception = message == null ?
                 RubySystemExit.newInstance(context, status, "exit") :
                 RubySystemExit.newInstance(context, status, message);
-        context.setErrorInfo(exception); // set $! before toThrowable/preRaise fires event hooks
-        return exception.toThrowable();
+        // MRI raises SystemExit through usual rb_longjmp -> setup_exception
+        context.setErrorInfo(exception); // set $!
+        RaiseException throwable = exception.toThrowable();
+        IRRuntimeHelpers.traceRaise(context);
+        return throwable;
     }
 
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1051,9 +1051,7 @@ public class RubyKernel {
         RubyException exception =
                 lastException instanceof RubyException ex ? ex : newBlankRuntimeException(context);
 
-        printDebugException(context, exception);
-
-        return Helpers.throwExceptionT(exception.toThrowable());
+        return raiseException(context, exception, null);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1068,12 +1066,7 @@ public class RubyKernel {
 
         RubyException exception = prepareNewException(context, arg0);
 
-        printDebugException(context, exception);
-
-        setNewExceptionCause(context, exception, cause);
-
-        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
-        return Helpers.throwExceptionT(exception.toThrowable());
+        return raiseException(context, exception, cause);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1089,12 +1082,7 @@ public class RubyKernel {
             default -> prepareNewException(context, arg0, arg1);
         };
 
-        printDebugException(context, exception);
-
-        setGivenExceptionCause(context, cause, exception);
-
-        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
-        return Helpers.throwExceptionT(exception.toThrowable());
+        return raiseException(context, exception, cause);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1109,9 +1097,12 @@ public class RubyKernel {
             default -> prepareNewException(context, arg0, arg1, arg2);
         };
 
-        printDebugException(context, exception);
+        return raiseException(context, exception, cause);
+    }
 
-        setNewExceptionCause(context, exception, cause);
+    private static IRubyObject raiseException(ThreadContext context, RubyException exception, Cause cause) {
+        printDebugException(context, exception);
+        if (cause != null) setNewExceptionCause(context, exception, cause);
 
         context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
         return Helpers.throwExceptionT(exception.toThrowable());
@@ -1129,12 +1120,7 @@ public class RubyKernel {
 
         RubyException exception = prepareNewException(context, arg0, arg1, arg2);
 
-        printDebugException(context, exception);
-
-        setNewExceptionCause(context, exception, cause);
-
-        context.setErrorInfo(exception); // set $! as part of the raise flow (like MRI's setup_exception)
-        return Helpers.throwExceptionT(exception.toThrowable());
+        return raiseException(context, exception, cause);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -958,11 +958,11 @@ public class RubyKernel {
 
         }
 
-        RaiseException ex = message == null ?
-                context.runtime.newSystemExit(status) :
-                context.runtime.newSystemExit(status, message);
-        context.setErrorInfo(ex.getException()); // set $! (in case Kernel.exit called from at_exit)
-        return ex;
+        RubySystemExit exception = message == null ?
+                RubySystemExit.newInstance(context, status, "exit") :
+                RubySystemExit.newInstance(context, status, message);
+        context.setErrorInfo(exception); // set $! before toThrowable/preRaise fires event hooks
+        return exception.toThrowable();
     }
 
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -957,9 +957,11 @@ public class RubyKernel {
             }
         }
 
-        return message == null ?
+        RaiseException ex = message == null ?
                 context.runtime.newSystemExit(status) :
                 context.runtime.newSystemExit(status, message);
+        context.setErrorInfo(ex.getException()); // set $! (in case Kernel.exit called from at_exit)
+        return ex;
     }
 
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1062,11 +1062,12 @@ public class RubyKernel {
 
         if (cause.remainingArgs == 0) throw argumentError(context, "only cause is given with no arguments");
 
-        maybeThrowJavaException(context, arg0);
+        return raiseInternal(context, arg0, cause);
+    }
 
-        RubyException exception = prepareNewException(context, arg0);
-
-        return raiseException(context, exception, cause);
+    static IRubyObject raiseInternal(ThreadContext context, IRubyObject exception, Cause cause) {
+        maybeThrowJavaException(context, exception);
+        return raiseException(context, prepareNewException(context, exception), cause);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1162,6 +1163,10 @@ public class RubyKernel {
         return new Cause(argc, causeGiven, cause);
     }
 
+    static Cause lastErrorCause(ThreadContext context) {
+        return new Cause(0, false, context.getErrorInfo());
+    }
+
     /**
      * Represents an exception cause extracted from a Kernel#raise argument list.
      *
@@ -1169,7 +1174,7 @@ public class RubyKernel {
      * @param provided whether the cause was provided with a cause: keyword
      * @param value the extracted cause
      */
-    private record Cause(int remainingArgs, boolean provided, IRubyObject value) {}
+    record Cause(int remainingArgs, boolean provided, IRubyObject value) {}
 
     /**
      * Set the cause for an exception that was already constructed elsewhere. This is intended to be used to

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -212,8 +212,6 @@ public class RaiseException extends JumpException {
         context.runtime.incrementExceptionCount();
         if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
 
-        doSetLastError(context);
-
         if (backtrace == null) {
             if (capture) { // only false to support legacy RaiseException construction (not setting trace)
                 if (requiresBacktrace(context)) exception.captureBacktrace(context);
@@ -272,12 +270,8 @@ public class RaiseException extends JumpException {
         if (newTrace != curTrace) setStackTrace(newTrace);
     }
 
-    private void doSetLastError(final ThreadContext context) {
-        context.setErrorInfo(exception); // $!
-    }
-
     /**
-     * Sets the exception
+      * Sets the exception
      * @param newException The exception to set
      */
     protected final void setException(RubyException newException) {

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -35,6 +35,8 @@
 
 package org.jruby.exceptions;
 
+import java.util.Arrays;
+
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
@@ -49,9 +51,6 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
-
-import java.lang.reflect.Member;
-import java.util.Arrays;
 
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Error.nameError;
@@ -263,15 +262,8 @@ public class RaiseException extends JumpException {
         return trace;
     }
 
-    private void fillInStackTraceSkipPreRaise() {
-        originalFillInStackTrace(); // (fillInStackTraceSkipPreRaise) originalFillInStackTrace, preRaise
-        StackTraceElement[] curTrace = getStackTrace();
-        StackTraceElement[] newTrace = skipFillInStackTracePart(curTrace);
-        if (newTrace != curTrace) setStackTrace(newTrace);
-    }
-
     /**
-      * Sets the exception
+     * Sets the exception
      * @param newException The exception to set
      */
     protected final void setException(RubyException newException) {

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -223,8 +223,6 @@ public class RaiseException extends JumpException {
             }
             setStackTraceFromException();
         }
-
-        IRRuntimeHelpers.traceRaise(context);
     }
 
     private void setStackTraceFromException() {

--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -119,11 +119,15 @@ public class TracePoint extends RubyObject {
 
                 context.preTrace();
 
+                final IRubyObject errorInfo = context.getErrorInfo();
                 // FIXME: get return value
-                update(event.getName(), file, line, name, type, context.getErrorInfo(), context.nil, binding);
+                update(event.getName(), file, line, name, type, errorInfo, context.nil, binding);
 
+                // MRI clears $! while a hook runs and restores it after (unless the hook raises)
+                context.setErrorInfo(context.nil);
                 try {
                     block.yieldSpecific(context, TracePoint.this);
+                    context.setErrorInfo(errorInfo);
                 } finally {
                     update(null, null, line, null, context.nil, context.nil, context.nil, context.nil);
                     context.postTrace();

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
@@ -31,6 +31,7 @@
 package org.jruby.internal.runtime;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.jruby.Ruby;
 import org.jruby.RubyProc;
@@ -68,13 +69,13 @@ public final class GlobalVariable {
         return scope;
     }
 
-    public ArrayList getTraces() {
+    public List<IRubyObject> getTraces() {
         return traces;
     }
 
     public void addTrace(RubyProc command) {
         if (traces == null) {
-            traces = new ArrayList<IRubyObject>(1);
+            traces = new ArrayList<>(2);
         }
         traces.add(command);
     }

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
@@ -69,7 +69,7 @@ public final class GlobalVariable {
         return scope;
     }
 
-    public List<IRubyObject> getTraces() {
+    public ArrayList getTraces() {
         return traces;
     }
 

--- a/core/src/main/java/org/jruby/ir/builder/EnsureBlockInfo.java
+++ b/core/src/main/java/org/jruby/ir/builder/EnsureBlockInfo.java
@@ -90,7 +90,6 @@ class EnsureBlockInfo {
      * @param builder
      */
     public void emitEnsureBody(IRBuilder builder) {
-        builder.addInstr(new LabelInstr(bodyStart));
         for (Instr i: instrs) {
             builder.addInstr(i);
         }

--- a/core/src/main/java/org/jruby/ir/builder/EnsureBlockInfo.java
+++ b/core/src/main/java/org/jruby/ir/builder/EnsureBlockInfo.java
@@ -6,7 +6,7 @@ import org.jruby.ir.instructions.ExceptionRegionEndMarkerInstr;
 import org.jruby.ir.instructions.ExceptionRegionStartMarkerInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.LabelInstr;
-import org.jruby.ir.instructions.RuntimeHelperCall;
+import org.jruby.ir.instructions.defined.RestoreErrorInfoInstr;
 import org.jruby.ir.operands.Label;
 import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
@@ -16,8 +16,6 @@ import org.jruby.ir.transformations.inlining.SimpleCloneInfo;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.jruby.ir.instructions.RuntimeHelperCall.Methods.RESET_GVAR_UNDERSCORE;
 
 /* -----------------------------------------------------------------------------------
  * Every ensure block has a start label and end label
@@ -103,7 +101,7 @@ class EnsureBlockInfo {
         if (savedGlobalException != null) {
             // We need make sure on all outgoing paths in optimized short-hand rescues we restore the backtrace
             if (!needsBacktrace) builder.addInstr(builder.getManager().needsBacktrace(true));
-            addInstr(new RuntimeHelperCall(builder.temp(), RESET_GVAR_UNDERSCORE, new Operand[] { savedGlobalException }));
+            addInstr(new RestoreErrorInfoInstr(savedGlobalException));
         }
 
         // Sometimes we process a rescue and it hits something like non-local flow like a 'next' and

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -250,7 +250,8 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
 
         // Now emit the ensure body's stashed instructions
         if (ensureNode != null) {
-//            addInstr(new RestoreErrorInfoInstr(exc));
+            addInstr(new RestoreErrorInfoInstr(exc));
+            addInstr(new LabelInstr(ebi.bodyStart));
             ebi.emitEnsureBody(this);
         }
 

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -250,7 +250,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
 
         // Now emit the ensure body's stashed instructions
         if (ensureNode != null) {
-            addInstr(new RestoreErrorInfoInstr(exc));
+//            addInstr(new RestoreErrorInfoInstr(exc));
             ebi.emitEnsureBody(this);
         }
 

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -196,9 +196,8 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         // the ensure code can be cloned at break/next/return sites in the protected body.
         EnsureBlockInfo ebi = new EnsureBlockInfo(scope, getCurrentLoop(), activeRescuers.peek(), currentLine() + 1);
 
-        // Rescue will change $! but we need to restore $! later.  prism: ensure and isRescue means it is both (we
-        // call this method again below to rip those two things apart.
-        if (isRescue && ensureNode == null) ebi.savedGlobalException = savedGlobalException;
+        // $! will be restored from savedGlobalException where required.
+        ebi.savedGlobalException = savedGlobalException;
 
         // Record body of ensure and push to ensure body stack if there is an actual ensure body.
         Operand ensureRetVal = processEnsureBody(ensureNode, ebi);
@@ -250,7 +249,10 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         Variable exc = addResultInstr(new ReceiveJRubyExceptionInstr(temp()));
 
         // Now emit the ensure body's stashed instructions
-        if (ensureNode != null) ebi.emitEnsureBody(this);
+        if (ensureNode != null) {
+            addInstr(new RestoreErrorInfoInstr(exc));
+            ebi.emitEnsureBody(this);
+        }
 
         // 1. Ensure block has no explicit return => the result of the entire ensure expression is the result of the protected body.
         // 2. Ensure block has an explicit return => the result of the protected body is ignored.

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -22,6 +22,8 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.IRScopeType;
 import org.jruby.ir.IRScriptBody;
 import org.jruby.ir.instructions.*;
+import org.jruby.ir.instructions.defined.GetErrorInfoInstr;
+import org.jruby.ir.instructions.defined.RestoreErrorInfoInstr;
 import org.jruby.ir.interpreter.InterpreterContext;
 import org.jruby.ir.operands.*;
 import org.jruby.ir.operands.Boolean;
@@ -188,7 +190,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
      */
     protected Operand buildEnsureInternal(U body, U elseNode, U[] exceptions, U rescueBody, X optRescue,
                                           boolean isModifier, U ensureNode, boolean isRescue, U reference) {
-        var savedGlobalException = addResultInstr(new GetGlobalVariableInstr(temp(), symbol("$!")));
+        var savedGlobalException = addResultInstr(new GetErrorInfoInstr(temp()));
 
         // The ensure code is built first so that when the protected body is being built,
         // the ensure code can be cloned at break/next/return sites in the protected body.

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -196,8 +196,8 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         // the ensure code can be cloned at break/next/return sites in the protected body.
         EnsureBlockInfo ebi = new EnsureBlockInfo(scope, getCurrentLoop(), activeRescuers.peek(), currentLine() + 1);
 
-        // $! will be restored from savedGlobalException where required.
-        ebi.savedGlobalException = savedGlobalException;
+        // Rescue will change $! but we need to restore $! later.
+        if (isRescue) ebi.savedGlobalException = savedGlobalException;
 
         // Record body of ensure and push to ensure body stack if there is an actual ensure body.
         Operand ensureRetVal = processEnsureBody(ensureNode, ebi);

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -2547,7 +2547,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         // Caught exception case -- build rescue body
         addInstr(new LabelInstr(caughtLabel));
         if (reference != null) {
-            Variable exception = addResultInstr(new GetGlobalVariableInstr(temp(), symbol("$!")));
+            Variable exception = addResultInstr(new GetErrorInfoInstr(temp()));
 
             buildAssignment(reference, exception);  // Prism does not desugar
         }

--- a/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
@@ -47,14 +47,14 @@ public class ThrowExceptionInstr extends OneOperandInstr implements FixedArityIn
 
         Object excObj = getException().retrieve(context, self, currScope, currDynScope, temp);
 
-        if (excObj instanceof IRubyObject exc) {
-            RubyKernel.raise(context, kernelModule(context), new IRubyObject[] {exc}, Block.NULL_BLOCK);
-        } else if (excObj instanceof Throwable exc) { // java exception -- avoid having to add 'throws' clause everywhere!
-            Helpers.throwException(exc);
+        if (excObj instanceof Throwable) {
+            excObj = Helpers.wrapJavaException(context.runtime, (Throwable) excObj); // IRubyObject
         }
 
+        RubyKernel.raise(context, kernelModule(context), new IRubyObject[] {(IRubyObject) excObj}, Block.NULL_BLOCK);
+
         // should never get here
-        throw new RuntimeException("Control shouldn't have reached here in ThrowEx");
+        throw new AssertionError("Control shouldn't have reached here in ThrowEx");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
@@ -1,5 +1,6 @@
 package org.jruby.ir.instructions;
 
+import org.jruby.RubyException;
 import org.jruby.RubyKernel;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
@@ -51,7 +52,7 @@ public class ThrowExceptionInstr extends OneOperandInstr implements FixedArityIn
             excObj = Helpers.wrapJavaException(context.runtime, (Throwable) excObj); // IRubyObject
         }
 
-        RubyKernel.raise(context, kernelModule(context), new IRubyObject[] {(IRubyObject) excObj}, Block.NULL_BLOCK);
+        RubyException.raise(context, (IRubyObject) excObj);
 
         // should never get here
         throw new AssertionError("Control shouldn't have reached here in ThrowEx");

--- a/core/src/main/java/org/jruby/ir/instructions/defined/RestoreErrorInfoInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/defined/RestoreErrorInfoInstr.java
@@ -8,6 +8,7 @@ import org.jruby.ir.instructions.OneOperandInstr;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
@@ -40,7 +41,7 @@ public class RestoreErrorInfoInstr extends OneOperandInstr implements FixedArity
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
-        context.setErrorInfo((IRubyObject) getArg().retrieve(context, self, currScope, currDynScope, temp));
+        IRRuntimeHelpers.setErrorInfoGlobalVariable(context, getArg().retrieve(context, self, currScope, currDynScope, temp));
 
         return null;
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -30,6 +30,7 @@ import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.api.Convert;
 import org.jruby.api.Create;
+import org.jruby.exceptions.JumpException;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
 import org.jruby.ext.coverage.CoverageData;
@@ -453,10 +454,15 @@ public class IRRuntimeHelpers {
 
     @JIT
     public static void setErrorInfoGlobalVariable(ThreadContext context, Object exception) {
-        if (exception instanceof Throwable) {
+        if (exception instanceof RaiseException) {
+            exception = ((RaiseException) exception).getException();
+        } else if (exception instanceof Throwable && !(exception instanceof JumpException)) {
             exception = Helpers.wrapJavaException(context.runtime, (Throwable) exception);
         }
-        setErrorInfoGlobalVariable(context, (IRubyObject) exception);
+
+        if (exception instanceof IRubyObject) {
+            setErrorInfoGlobalVariable(context, (IRubyObject) exception);
+        }
     }
 
     public static void setErrorInfoGlobalVariable(ThreadContext context, IRubyObject exception) {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -379,7 +379,7 @@ public class IRRuntimeHelpers {
         if (excType instanceof RubyArray testTypes) {
             for (int i = 0, n = testTypes.getLength(); i < n; i++) {
                 IRubyObject testType = testTypes.eltInternal(i);
-                if (IRRuntimeHelpers.isJavaExceptionHandled(context, testType, ex)) {
+                if (isJavaExceptionHandled(context, testType, ex)) {
                     IRubyObject exception;
                     if (n == 1) {
                         exception = wrapJavaException(context, testType, ex);
@@ -387,7 +387,7 @@ public class IRRuntimeHelpers {
                         exception = Helpers.wrapJavaException(runtime, ex);
                     }
 
-                    context.setErrorInfo(exception);
+                    setErrorInfoGlobalVariable(context, exception);
                     return true;
                 }
             }
@@ -395,7 +395,7 @@ public class IRRuntimeHelpers {
         else {
             IRubyObject exception = wrapJavaException(context, excType, ex);
             if (Helpers.checkJavaException(exception, ex, excType, context)) {
-                context.setErrorInfo(exception);
+                setErrorInfoGlobalVariable(context, exception);
                 return true;
             }
         }
@@ -425,22 +425,34 @@ public class IRRuntimeHelpers {
             RubyArray testTypes = (RubyArray)excType;
             for (int i = 0, n = testTypes.getLength(); i < n; i++) {
                 IRubyObject testType = testTypes.eltInternal(i);
-                if (IRRuntimeHelpers.isRubyExceptionHandled(context, testType, excObj)) {
-                    context.setErrorInfo((IRubyObject) excObj);
+                if (isRubyExceptionHandled(context, testType, excObj)) {
+                    setErrorInfoGlobalVariable(context, (IRubyObject) excObj);
                     return true;
                 }
             }
-        } else if (excObj instanceof IRubyObject) {
-            if (!(excType instanceof RubyModule)) {
-                throw typeError(context, str(context.runtime, "class or module required for rescue clause. Found: ", excType));
-            }
-
-            if (excType.callMethod(context, "===", (IRubyObject)excObj).isTrue()) {
-                context.setErrorInfo((IRubyObject) excObj);
-                return true;
-            }
+            return false;
+        }
+        if (excObj instanceof IRubyObject) {
+            return isRubyExceptionHandled(context, excType, (IRubyObject) excObj);
         }
         return false;
+    }
+
+    private static boolean isRubyExceptionHandled(ThreadContext context, IRubyObject excType, IRubyObject excObj) {
+        // SSS FIXME: Should this check be "runtime.getModule().isInstance(excType)"??
+        if (!(excType instanceof RubyModule)) {
+            throw context.runtime.newTypeError("class or module required for rescue clause. Found: " + excType);
+        }
+
+        if (((RubyModule) excType).callMethod(context, "===", excObj).isTrue()) {
+            setErrorInfoGlobalVariable(context, excObj);
+            return true;
+        }
+        return false;
+    }
+
+    public static void setErrorInfoGlobalVariable(ThreadContext context, IRubyObject exception) {
+        context.runtime.getGlobalVariables().set("$!", exception);
     }
 
     public static IRubyObject isExceptionHandled(ThreadContext context, IRubyObject excType, Object excObj) {
@@ -452,9 +464,7 @@ public class IRRuntimeHelpers {
         // Unwrap Ruby exceptions
         excObj = unwrapRubyException(excObj);
 
-        boolean ret = IRRuntimeHelpers.isRubyExceptionHandled(context, excType, excObj)
-            || IRRuntimeHelpers.isJavaExceptionHandled(context, excType, excObj);
-
+        boolean ret = isRubyExceptionHandled(context, excType, excObj) || isJavaExceptionHandled(context, excType, excObj);
         return asBoolean(context, ret);
     }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -451,6 +451,14 @@ public class IRRuntimeHelpers {
         return false;
     }
 
+    @JIT
+    public static void setErrorInfoGlobalVariable(ThreadContext context, Object exception) {
+        if (exception instanceof Throwable) {
+            exception = Helpers.wrapJavaException(context.runtime, (Throwable) exception);
+        }
+        setErrorInfoGlobalVariable(context, (IRubyObject) exception);
+    }
+
     public static void setErrorInfoGlobalVariable(ThreadContext context, IRubyObject exception) {
         context.runtime.getGlobalVariables().set("$!", exception);
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -466,7 +466,7 @@ public class IRRuntimeHelpers {
     }
 
     public static void setErrorInfoGlobalVariable(ThreadContext context, IRubyObject exception) {
-        context.runtime.getGlobalVariables().set("$!", exception);
+        context.setErrorInfo(exception);
     }
 
     public static IRubyObject isExceptionHandled(ThreadContext context, IRubyObject excType, Object excObj) {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -455,12 +455,11 @@ public class IRRuntimeHelpers {
     @JIT
     public static void setErrorInfoGlobalVariable(ThreadContext context, Object exception) {
         if (exception instanceof RaiseException) {
-            exception = ((RaiseException) exception).getException();
+            setErrorInfoGlobalVariable(context, ((RaiseException) exception).getException());
         } else if (exception instanceof Throwable && !(exception instanceof JumpException)) {
             exception = Helpers.wrapJavaException(context.runtime, (Throwable) exception);
-        }
-
-        if (exception instanceof IRubyObject) {
+            setErrorInfoGlobalVariable(context, (IRubyObject) exception);
+        } else if (exception instanceof IRubyObject) {
             setErrorInfoGlobalVariable(context, (IRubyObject) exception);
         }
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -456,12 +456,13 @@ public class IRRuntimeHelpers {
     public static void setErrorInfoGlobalVariable(ThreadContext context, Object exception) {
         if (exception instanceof RaiseException) {
             setErrorInfoGlobalVariable(context, ((RaiseException) exception).getException());
-        } else if (exception instanceof Throwable && !(exception instanceof JumpException)) {
+        } else if (exception instanceof Throwable && !(exception instanceof Unrescuable)) {
             exception = Helpers.wrapJavaException(context.runtime, (Throwable) exception);
             setErrorInfoGlobalVariable(context, (IRubyObject) exception);
         } else if (exception instanceof IRubyObject) {
             setErrorInfoGlobalVariable(context, (IRubyObject) exception);
         }
+        // un-rescuables e.g. JumpException, ThreadKill do not affect $!
     }
 
     public static void setErrorInfoGlobalVariable(ThreadContext context, IRubyObject exception) {

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2697,9 +2697,7 @@ public class JVMVisitor extends IRVisitor {
     public void RestoreErrorInfoInstr(RestoreErrorInfoInstr restoreerrorinfoinstr) {
         jvmMethod().loadContext();
         visit(restoreerrorinfoinstr.getArg());
-        // jvmAdapter().invokevirtual(p(ThreadContext.class), "setErrorInfo", sig(IRubyObject.class, IRubyObject.class));
         jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "setErrorInfoGlobalVariable", sig(Void.TYPE, ThreadContext.class, Object.class));
-        jvmAdapter().pop();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2697,7 +2697,8 @@ public class JVMVisitor extends IRVisitor {
     public void RestoreErrorInfoInstr(RestoreErrorInfoInstr restoreerrorinfoinstr) {
         jvmMethod().loadContext();
         visit(restoreerrorinfoinstr.getArg());
-        jvmAdapter().invokevirtual(p(ThreadContext.class), "setErrorInfo", sig(IRubyObject.class, IRubyObject.class));
+        // jvmAdapter().invokevirtual(p(ThreadContext.class), "setErrorInfo", sig(IRubyObject.class, IRubyObject.class));
+        jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "setErrorInfoGlobalVariable", sig(Void.TYPE, ThreadContext.class, Object.class));
         jvmAdapter().pop();
     }
 

--- a/core/src/main/java/org/jruby/main/Main.java
+++ b/core/src/main/java/org/jruby/main/Main.java
@@ -289,6 +289,9 @@ public class Main {
                     runtime.runFromMain(in, filename);
                 }
                 status = new Status();
+            } catch (RaiseException ex) {
+                runtime.getCurrentContext().setErrorInfo(ex.getException()); // set $! (accessible in at_exit blocks)
+                throw ex;
             } finally {
                 try {
                     runtime.tearDown();

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -405,6 +405,22 @@ public class TestRaiseException extends Base {
         }
     }
 
+    public void testPreviousRaisedNotConsideredCause() {
+        try {
+            runtime.evalScriptlet("raise 'foo'");
+            fail("expected to throw");
+        } catch (StandardError ex1) {
+            assertNull("ex1 has a cause", ex1.getCause());
+        }
+
+        try {
+            runtime.evalScriptlet("raise 'bar'");
+            fail("expected to throw");
+        } catch (StandardError ex2) {
+            assertNull("ex2 has a cause: " + ex2.getCause(), ex2.getCause());
+        }
+    }
+
     private static String printStackTrace(final Throwable ex) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ex.printStackTrace(new PrintStream(baos));

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -407,14 +407,16 @@ public class TestRaiseException extends Base {
 
     public void testPreviousRaisedNotConsideredCause() {
         try {
-            runtime.evalScriptlet("raise 'foo'");
+            context.runtime.evalScriptlet("raise 'foo'");
             fail("expected to throw");
         } catch (StandardError ex1) {
             assertNull("ex1 has a cause", ex1.getCause());
+            // clear $! like a Ruby rescue block would, so the next raise doesn't pick it up as cause
+            context.setErrorInfo(context.nil);
         }
 
         try {
-            runtime.evalScriptlet("raise 'bar'");
+            context.runtime.evalScriptlet("raise 'bar'");
             fail("expected to throw");
         } catch (StandardError ex2) {
             assertNull("ex2 has a cause: " + ex2.getCause(), ex2.getCause());

--- a/spec/ruby/core/tracepoint/trace_spec.rb
+++ b/spec/ruby/core/tracepoint/trace_spec.rb
@@ -7,4 +7,18 @@ describe 'TracePoint.trace' do
     trace.should.enabled?
     trace.disable
   end
+
+  it 'clears $! when invoking the trace block' do
+    exception_in_trace = nil
+    trace = TracePoint.trace(:raise) do |tp|
+      exception_in_trace = $!
+    end
+    begin
+      raise
+    rescue => e
+      exception_in_trace.should == nil
+      $!.should == e
+    end
+    trace.disable
+  end
 end

--- a/test/jruby/test_exception.rb
+++ b/test/jruby/test_exception.rb
@@ -124,4 +124,36 @@ class TestException < Test::Unit::TestCase
     assert_nil $!
   end
 
+  def test_exception_rescue_java(previous_error = nil)
+    begin
+      raise java.lang.IllegalStateException.new('from java')
+    rescue
+      assert_equal "from java", $!.message
+    ensure
+      assert_same previous_error, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      java.util.ArrayList.new.get(1)
+      raise 'foo'
+    rescue RuntimeError
+      fail 'should not rescue here' if $!
+    rescue java.lang.RuntimeException
+      assert_instance_of java.lang.IndexOutOfBoundsException, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      begin
+        java.util.ArrayList.new.addAll(nil)
+      ensure
+        assert_instance_of java.lang.NullPointerException, $!
+      end
+    rescue java.lang.NullPointerException
+      # pass
+    end
+    assert_same previous_error, $!
+  end if defined? JRUBY_VERSION
+
 end

--- a/test/jruby/test_exception.rb
+++ b/test/jruby/test_exception.rb
@@ -2,8 +2,10 @@ require 'test/unit'
 
 class TestException < Test::Unit::TestCase
 
+  class AnError < RuntimeError; end
+
   def raise_an_error
-    raise "an error"
+    raise AnError
   end
 
   def rescue_an_error
@@ -40,4 +42,86 @@ class TestException < Test::Unit::TestCase
       assert_equal("error 1", e.cause.message)
     end
   end
+
+  def test_exception_no_rescue_ensure
+    begin
+      raise_no_rescue_and_ensure!
+    rescue NotImplementedError
+      # pass
+    end
+    assert_nil $!
+  end
+
+  def raise_no_rescue_and_ensure!
+    begin
+      raise NotImplementedError
+    rescue
+      fail 'not expected'
+    ensure
+      assert_instance_of NotImplementedError, $!
+    end
+    assert_nil $!
+  end
+
+  def test_exception_rescue(previous_error = nil)
+    begin
+      raise TypeError, "duck"
+    rescue
+      assert_equal "duck", $!.message
+    ensure
+      assert_same previous_error, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      raise 'foo'
+    rescue TypeError
+      fail 'should not rescue here' if $!
+    rescue RuntimeError
+      assert_instance_of RuntimeError, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      raise_an_error
+    rescue AnError
+      # pass
+    end
+    assert_same previous_error, $!
+  end
+
+  def test_exception_rescue_nested
+    begin
+      raise_no_rescue_and_ensure!
+    rescue NotImplementedError => e
+      test_exception_rescue(e)
+      assert_instance_of NotImplementedError, $!
+    end
+    assert_nil $!
+
+    begin
+      raise_no_rescue_and_ensure!
+    rescue NotImplementedError
+      test_exception_rescue $!
+      assert_instance_of NotImplementedError, $!
+    ensure
+      assert_nil $!
+    end
+    assert_nil $!
+
+    begin
+      begin
+        raise_no_rescue_and_ensure!
+      ensure
+        prev = $!
+        assert_instance_of NotImplementedError, $!
+        test_exception_rescue(prev)
+        assert_same prev, $!
+      end
+    rescue NotImplementedError
+      # pass
+    end
+    assert_nil $!
+  end
+
 end


### PR DESCRIPTION
The `$!` semantics are handled by IR protocol, specifically the `rescue`/`ensure` parts (and also from `raise` internally), `new RaiseException()`'s filling of `$!` has been in-place for a very long time but is not the right place to set error-info.

Maybe we can get rid of this once and for all... :crossed_fingers: 