### PR TITLE
[deps] bump jruby-openssl to 0.16.1

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -50,7 +50,7 @@ default_gems = [
   ['ipaddr', '1.2.8'],
   ['jar-dependencies', '0.5.7'],
   ['jruby-readline', '1.3.7'],
-  ['jruby-openssl', '0.16.0'],
+  ['jruby-openssl', '0.16.1'],
   ['json', '2.18.0'],
   ['net-http', '0.9.1'],
   ['net-protocol', '0.2.2'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -281,7 +281,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.16.0</version>
+      <version>0.16.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1163,7 +1163,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/ipaddr-1.2.8*</include>
           <include>specifications/jar-dependencies-0.5.7*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
-          <include>specifications/jruby-openssl-0.16.0*</include>
+          <include>specifications/jruby-openssl-0.16.1*</include>
           <include>specifications/json-2.18.0*</include>
           <include>specifications/net-http-0.9.1*</include>
           <include>specifications/net-protocol-0.2.2*</include>
@@ -1247,7 +1247,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/ipaddr-1.2.8*/**/*</include>
           <include>gems/jar-dependencies-0.5.7*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
-          <include>gems/jruby-openssl-0.16.0*/**/*</include>
+          <include>gems/jruby-openssl-0.16.1*/**/*</include>
           <include>gems/json-2.18.0*/**/*</include>
           <include>gems/net-http-0.9.1*/**/*</include>
           <include>gems/net-protocol-0.2.2*/**/*</include>
@@ -1331,7 +1331,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/ipaddr-1.2.8*</include>
           <include>cache/jar-dependencies-0.5.7*</include>
           <include>cache/jruby-readline-1.3.7*</include>
-          <include>cache/jruby-openssl-0.16.0*</include>
+          <include>cache/jruby-openssl-0.16.1*</include>
           <include>cache/json-2.18.0*</include>
           <include>cache/net-http-0.9.1*</include>
           <include>cache/net-protocol-0.2.2*</include>
@@ -1415,7 +1415,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>extensions/universal-java/4.0.0/ipaddr-1.2.8/*</include>
           <include>extensions/universal-java/4.0.0/jar-dependencies-0.5.7/*</include>
           <include>extensions/universal-java/4.0.0/jruby-readline-1.3.7/*</include>
-          <include>extensions/universal-java/4.0.0/jruby-openssl-0.16.0/*</include>
+          <include>extensions/universal-java/4.0.0/jruby-openssl-0.16.1/*</include>
           <include>extensions/universal-java/4.0.0/json-2.18.0/*</include>
           <include>extensions/universal-java/4.0.0/net-http-0.9.1/*</include>
           <include>extensions/universal-java/4.0.0/net-protocol-0.2.2/*</include>


### PR DESCRIPTION
https://github.com/jruby/jruby-openssl/releases/tag/v0.16.1