### PR TITLE
Begin deprecating jruby-complete and jruby-core

### DIFF
--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -11,6 +11,11 @@ project 'JRuby Complete' do
   inherit "org.jruby:jruby-artifacts:#{version}"
   packaging 'bundle'
 
+  distribution_management do
+    relocation(groupId: 'org.jruby', artifactId: 'jruby',
+               message: 'The jruby-complete artifact is deprecated in favor of the jruby artifact.')
+  end
+
   extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 
   plugin_repository id: :mavengems, url: 'mavengem:https://rubygems.org'

--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -9,6 +9,11 @@ project 'JRuby Core' do
   inherit 'org.jruby:jruby-parent', version
   id 'org.jruby:jruby-core'
 
+  distribution_management do
+    relocation(groupId: 'org.jruby', artifactId: 'jruby-base',
+               message: 'The jruby-core artifact is deprecated in favor of the jruby-base artifact.')
+  end
+
   properties("polyglot.dump.pom": 'pom.xml',
              "polyglot.dump.readonly": true,
              "jruby.basedir": '${basedir}/..')

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -16,6 +16,13 @@ DO NOT MODIFY - GENERATED CODE
   </parent>
   <artifactId>jruby-core</artifactId>
   <name>JRuby Core</name>
+  <distributionManagement>
+    <relocation>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby-base</artifactId>
+      <message>The jruby-core artifact is deprecated in favor of the jruby-base artifact.</message>
+    </relocation>
+  </distributionManagement>
   <properties>
     <jruby.basedir>${basedir}/..</jruby.basedir>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>


### PR DESCRIPTION
After jruby-dist, which is necessary to release JRuby for Ruby users, jruby-complete is by far the largest artifact published for JRuby, combining all Java dependencies and all Ruby dependencies into a single jar file. This combination can be represented by the org.jruby:jruby artifact, which depends upon jruby-base (itself depending on all Java dependencies) and jruby-stdlib (containing all Ruby dependencies. The only utility of jruby-complete is to publish a single uber-jar.

Similarly, the jruby-core artifact is essentially just a version of jruby-base that shades all Java dependencies. It cannot run on its own due to the missing Ruby dependencies, but it duplicates the logical content of jruby-base.

With Maven Central moving toward publishing limits, we would like to start reducing the number and size of artifacts we push. This commit starts the process of deprecating these two artifacts.

* jruby-complete is deprecated in favor of org.jruby:jruby. Users needing an uber-jar can use other mechanisms to merge all transitive dependencies of that artifact into a single library.
* jruby-core is deprecated in favor of org.jruby:jruby-base, which provides the same logical contents. Users needing a shaded version of jruby-base can use other mechanisms to achieve it.

Removing these two artifacts would reduce the size of a JRuby release to Maven Central by about 71MB based on the 10.1.0.0 release (~30MB for jruby-core and ~41MB for jruby-complete).