### PR TITLE
Switch to jar-deps based on mima

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -48,7 +48,7 @@ default_gems = [
   # ['io-nonblock', '0.3.2'],
   ['io-wait', '0.4.0'],
   ['ipaddr', '1.2.8'],
-  ['jar-dependencies', '0.5.7'],
+  ['jar-dependencies', '0.6.0.pre2'],
   ['jruby-readline', '1.3.7'],
   ['jruby-openssl', '0.16.0'],
   ['json', '2.18.0'],

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -48,7 +48,7 @@ default_gems = [
   # ['io-nonblock', '0.3.2'],
   ['io-wait', '0.4.0'],
   ['ipaddr', '1.2.8'],
-  ['jar-dependencies', '0.5.7'],
+  ['jar-dependencies', '0.6.0'],
   ['jruby-readline', '1.3.7'],
   ['jruby-openssl', '0.16.2'],
   ['json', '2.18.0'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -255,7 +255,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jar-dependencies</artifactId>
-      <version>0.5.7</version>
+      <version>0.6.0.pre2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1161,7 +1161,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/io-console-0.8.2*</include>
           <include>specifications/io-wait-0.4.0*</include>
           <include>specifications/ipaddr-1.2.8*</include>
-          <include>specifications/jar-dependencies-0.5.7*</include>
+          <include>specifications/jar-dependencies-0.6.0.pre2*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
           <include>specifications/jruby-openssl-0.16.0*</include>
           <include>specifications/json-2.18.0*</include>
@@ -1245,7 +1245,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/io-console-0.8.2*/**/*</include>
           <include>gems/io-wait-0.4.0*/**/*</include>
           <include>gems/ipaddr-1.2.8*/**/*</include>
-          <include>gems/jar-dependencies-0.5.7*/**/*</include>
+          <include>gems/jar-dependencies-0.6.0.pre2*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
           <include>gems/jruby-openssl-0.16.0*/**/*</include>
           <include>gems/json-2.18.0*/**/*</include>
@@ -1329,7 +1329,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/io-console-0.8.2*</include>
           <include>cache/io-wait-0.4.0*</include>
           <include>cache/ipaddr-1.2.8*</include>
-          <include>cache/jar-dependencies-0.5.7*</include>
+          <include>cache/jar-dependencies-0.6.0.pre2*</include>
           <include>cache/jruby-readline-1.3.7*</include>
           <include>cache/jruby-openssl-0.16.0*</include>
           <include>cache/json-2.18.0*</include>
@@ -1413,7 +1413,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>extensions/universal-java/4.0.0/io-console-0.8.2/*</include>
           <include>extensions/universal-java/4.0.0/io-wait-0.4.0/*</include>
           <include>extensions/universal-java/4.0.0/ipaddr-1.2.8/*</include>
-          <include>extensions/universal-java/4.0.0/jar-dependencies-0.5.7/*</include>
+          <include>extensions/universal-java/4.0.0/jar-dependencies-0.6.0.pre2/*</include>
           <include>extensions/universal-java/4.0.0/jruby-readline-1.3.7/*</include>
           <include>extensions/universal-java/4.0.0/jruby-openssl-0.16.0/*</include>
           <include>extensions/universal-java/4.0.0/json-2.18.0/*</include>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -255,7 +255,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jar-dependencies</artifactId>
-      <version>0.5.7</version>
+      <version>0.6.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1161,7 +1161,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/io-console-0.8.2*</include>
           <include>specifications/io-wait-0.4.0*</include>
           <include>specifications/ipaddr-1.2.8*</include>
-          <include>specifications/jar-dependencies-0.5.7*</include>
+          <include>specifications/jar-dependencies-0.6.0*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
           <include>specifications/jruby-openssl-0.16.2*</include>
           <include>specifications/json-2.18.0*</include>
@@ -1245,7 +1245,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/io-console-0.8.2*/**/*</include>
           <include>gems/io-wait-0.4.0*/**/*</include>
           <include>gems/ipaddr-1.2.8*/**/*</include>
-          <include>gems/jar-dependencies-0.5.7*/**/*</include>
+          <include>gems/jar-dependencies-0.6.0*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
           <include>gems/jruby-openssl-0.16.2*/**/*</include>
           <include>gems/json-2.18.0*/**/*</include>
@@ -1329,7 +1329,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/io-console-0.8.2*</include>
           <include>cache/io-wait-0.4.0*</include>
           <include>cache/ipaddr-1.2.8*</include>
-          <include>cache/jar-dependencies-0.5.7*</include>
+          <include>cache/jar-dependencies-0.6.0*</include>
           <include>cache/jruby-readline-1.3.7*</include>
           <include>cache/jruby-openssl-0.16.2*</include>
           <include>cache/json-2.18.0*</include>
@@ -1413,7 +1413,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>extensions/universal-java/4.0.0/io-console-0.8.2/*</include>
           <include>extensions/universal-java/4.0.0/io-wait-0.4.0/*</include>
           <include>extensions/universal-java/4.0.0/ipaddr-1.2.8/*</include>
-          <include>extensions/universal-java/4.0.0/jar-dependencies-0.5.7/*</include>
+          <include>extensions/universal-java/4.0.0/jar-dependencies-0.6.0/*</include>
           <include>extensions/universal-java/4.0.0/jruby-readline-1.3.7/*</include>
           <include>extensions/universal-java/4.0.0/jruby-openssl-0.16.2/*</include>
           <include>extensions/universal-java/4.0.0/json-2.18.0/*</include>

--- a/test/check_versions.sh
+++ b/test/check_versions.sh
@@ -61,15 +61,15 @@ function check {
 
 }
 
-check lib/target/jruby-stdlib-$jar_version.jar 21
-check maven/jruby-jars/pkg/jruby-jars-$gem_version.gem 41
+check lib/target/jruby-stdlib-$jar_version.jar 25
+check maven/jruby-jars/pkg/jruby-jars-$gem_version.gem 45
 check maven/jruby-jars/lib/jruby-core-$jar_version-complete.jar 22
-check maven/jruby-jars/lib/jruby-stdlib-$jar_version.jar 21
-check maven/jruby-complete/target/jruby-complete-$jar_version.jar 42
+check maven/jruby-jars/lib/jruby-stdlib-$jar_version.jar 25
+check maven/jruby-complete/target/jruby-complete-$jar_version.jar 48
 check maven/jruby/target/jruby-$jar_version.jar 9
-check maven/jruby-dist/target/jruby-dist-$jar_version-bin.tar.gz 45 jruby-$jar_version
+check maven/jruby-dist/target/jruby-dist-$jar_version-bin.tar.gz 48 jruby-$jar_version
 check maven/jruby-dist/target/jruby-dist-$jar_version-src.zip 20 jruby-$jar_version
-check maven/jruby-dist/target/jruby-dist-$jar_version-bin.zip 48 jruby-$jar_version
+check maven/jruby-dist/target/jruby-dist-$jar_version-bin.zip 54 jruby-$jar_version
 check core/target/jruby-base-$jar_version.jar 10
 check shaded/target/jruby-core-$jar_version.jar 22
 


### PR DESCRIPTION
We have a working version of jar-dependencies now using the mima stripped-down Maven dependency resolver. This PR will switch us to jar-dependencies 0.6.0 to eliminate issues with post-install hooks trying to install ruby-maven and hitting concurrency challenges.

This is based on finalization changes in https://github.com/jruby/jar-dependencies/pull/107.