### PR TITLE
Preserve ruby2_keywords hash passed as positional argument

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -739,7 +739,7 @@ public class IRRuntimeHelpers {
             // This complicates check_arity but empty ** is special case.
             RubyHash hash = (RubyHash) last;
             return hash;
-        } else if (isKwarg || ((RubyHash) last).isRuby2KeywordHash()) {
+        } else if (isKwarg || ((callInfo & CALL_SPLATS) != 0 && ((RubyHash) last).isRuby2KeywordHash())) {
             RubyHash hash = (RubyHash) last;
             return hash.dupFast(context);
         } else {

--- a/spec/regression/ruby2_keywords_hash_passed_as_positional_argument_spec.rb
+++ b/spec/regression/ruby2_keywords_hash_passed_as_positional_argument_spec.rb
@@ -1,0 +1,29 @@
+# A ruby2_keywords-flagged Hash passed as an ordinary positional argument
+# (no splat, no keywords at the call site) must arrive in the callee as the
+# same object with its flag intact. In 9.4.15.0 the JIT specific-arity
+# receive path dup'ed and unflagged it, which corrupted Rails ActiveJob
+# argument serialization (Hash.ruby2_keywords_hash? returned false inside
+# ActiveJob::Arguments.serialize_argument, so kwargs were persisted without
+# the _aj_ruby2_keywords marker).
+describe "A ruby2_keywords-flagged Hash passed as a positional argument" do
+  def probe(hash)
+    [hash, Hash.ruby2_keywords_hash?(hash)]
+  end
+
+  it "is passed through without being copied or unflagged" do
+    flagged = Hash.ruby2_keywords_hash({ a: 1 })
+    failure = nil
+
+    # Loop enough for the method to be JIT compiled; the interpreter was
+    # never affected.
+    10_000.times do |i|
+      received, marked = probe(flagged)
+      unless received.equal?(flagged) && marked
+        failure = "iteration #{i}: same_object=#{received.equal?(flagged)}, flagged=#{marked}"
+        break
+      end
+    end
+
+    expect(failure).to be_nil
+  end
+end


### PR DESCRIPTION
### Problem

Since 9.4.15.0, a `ruby2_keywords`-flagged Hash passed as a plain positional argument (no splat, no keywords at the call site) to a JIT-compiled method arrives as a dup'ed, **unflagged** copy. CRuby 3.1.7, JRuby 9.4.14.0, and JRuby 10.x all pass the same object through with the flag intact:

```ruby
def probe(hash)
  { object_id: hash.object_id, flagged: Hash.ruby2_keywords_hash?(hash) }
end

h = Hash.ruby2_keywords_hash({ every: 60 })
puts "caller: object_id=#{h.object_id} flagged=#{Hash.ruby2_keywords_hash?(h)}"
puts "callee: #{probe(h)}"
```

CRuby 3.1.7 / JRuby 9.4.14.0 / JRuby 10.1.0.0:

```
caller: object_id=4000 flagged=true
callee: {:object_id=>4000, :flagged=>true}
```

JRuby 9.4.15.0:

```
caller: object_id=4000 flagged=true
callee: {:object_id=>4004, :flagged=>false}
```

The practical fallout is severe for Rails apps: `ActiveJob::Arguments.serialize` (Rails 7.1) passes each job argument into `serialize_argument(argument)` and checks `Hash.ruby2_keywords_hash?(argument)` there to decide between the `_aj_ruby2_keywords` and `_aj_symbol_keys` markers. With this bug the check is always false once the serializer is JIT-compiled, so every job enqueued with keyword arguments (including every ActionMailer `deliver_later`, whose `MailDeliveryJob#perform` has a required `args:` keyword) is persisted with the wrong marker and fails at execution with `ArgumentError: wrong number of arguments (given N+1, expected N)`. Because the corruption happens at enqueue time, the bad rows keep failing even after downgrading JRuby.

ActiveJob 7.1.5.2 round trip (serialize → JSON → execute, 5000 iterations): 0 failures on 9.4.14.0; 4986 failures on 9.4.15.0 (first at iteration 14, once the JIT threshold is crossed). The bug does not reproduce with `-Xcompile.mode=OFF`.

### Cause

#9001 backported the #8922 indy fix and additionally backported "kwargs tweaks from 10" (185d62ec). On 10.x, `kwargsActionJIT` only dups a flagged hash when it arrived **through a splat**:

```java
if ((callInfo & CALL_SPLATS) != 0 && ((RubyHash) last).isRuby2KeywordHash()) {
    return KwargsAction.RETURN_DUP;
}
```

The 9.4 translation in `IRRuntimeHelpers.receiverSpecificArityKwargsCommon` dropped the `CALL_SPLATS` guard:

```java
} else if (isKwarg || ((RubyHash) last).isRuby2KeywordHash()) {
```

so any flagged trailing hash gets dup'ed (and thereby unflagged) on the specific-arity receive path, even for a direct positional pass. This is presumably why 10.x does not exhibit the bug.

### Fix

Restore the `CALL_SPLATS` guard to match 10.x, and add a regression spec.

### Verification

All cases looped so the JIT path is exercised:

| Case | CRuby 3.1.7 | 9.4.14.0 | 9.4.15.0 | this PR |
|---|---|---|---|---|
| flagged hash passed directly as positional arg keeps identity+flag | pass | pass | **fail** | pass |
| splatted flagged hash into `(arg)` method is copied+unmarked (#8920) | pass | **fail** | pass | pass |
| ruby2_keywords forwarding chain (#8922 spec) | pass | pass | pass | pass |
| kwargs passed to method without keyword params | pass | pass | pass | pass |

Also verified on this branch's build: green with `-Xjit.threshold=0` (the #9000 trigger, i.e. this does not reintroduce what #9001 fixed), and the ActiveJob 7.1.5.2 round trip above runs 5000/5000 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
