### PR TITLE
Use Maven Central URL to fetch Maven for mvnw

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip


### PR DESCRIPTION
The original URL here, the default provided by the wrapper logic from Apache, uses an Apache URL that apears to have some rate limiting or download issues that sometimes fails in CI. This patch changes to using the Maven Central download URL which should be mirrored and federated and avoid these issues.

Relates to jruby/jruby#9493