### PR TITLE
Also set up the current module when in a for body

### DIFF
--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -1619,7 +1619,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         // can be U_NIL if the node is an if node with returns in both branches.
         if (closureRetVal != U_NIL) addInstr(new ReturnInstr(closureRetVal));
 
-        prependUsedClosureImplicitState(forNode);
+        prependUsedClosureImplicitState();
 
         // Add break/return handling in case it is a lambda (we cannot know at parse time what it is).
         // SSS FIXME: At a later time, see if we can optimize this and do this on demand.
@@ -1655,7 +1655,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         // can be U_NIL if the node is an if node with returns in both branches.
         if (closureRetVal != U_NIL) addInstr(new ReturnInstr(closureRetVal));
 
-        prependUsedClosureImplicitState(false);
+        prependUsedClosureImplicitState();
 
         handleBreakAndReturnsInLambdas();
 
@@ -3067,14 +3067,13 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         if (numberOfInstrs > 0) afterPrologueIndex += numberOfInstrs;
     }
 
-    private void prependUsedClosureImplicitState(boolean forLoop) {
+    private void prependUsedClosureImplicitState() {
         int numberOfInstrs = 0;
         if (needsYieldBlock) {
             numberOfInstrs++;
             addInstrAtBeginning(new LoadBlockImplicitClosureInstr(getYieldClosureVariable()));
         }
-        // for loops refer to previous module scope and not its own so we do not make one.
-        if (!forLoop && currentModuleUsed) {
+        if (currentModuleUsed) {
             numberOfInstrs++;
             addInstrAtBeginning(new CopyInstr(getCurrentModuleVariable(), SCOPE_MODULE[0]));
         }

--- a/spec/regression/fixtures/for_in_evaluated_lambda_used_for_define_method.rb
+++ b/spec/regression/fixtures/for_in_evaluated_lambda_used_for_define_method.rb
@@ -1,0 +1,14 @@
+class ForInLambdaInEvalInDefineMethod
+  def initialize
+    code = eval(<<~RUBY)
+          -> {
+              for _ in [1]
+                value = defined?(Array)
+              end
+              value
+            }
+          RUBY
+
+    self.define_singleton_method( :bar, &code )
+  end
+end

--- a/spec/regression/language/GH-9491_defined_constant_inside_for_inside_lambda_inside_eval_spec.rb
+++ b/spec/regression/language/GH-9491_defined_constant_inside_for_inside_lambda_inside_eval_spec.rb
@@ -1,0 +1,13 @@
+require 'rspec'
+require_relative '../fixtures/for_in_evaluated_lambda_used_for_define_method'
+
+# The case here only triggers if a for loop inside an eval is wrapped in a lambda and
+# converted into a method with define_method.
+#
+# This is a complex combination of states, so we have a regression spec rather than try to
+# force it into ruby/spec somewhere weird.
+describe 'defined?(Array) inside a for loop inside an evaluated lambda used for define_method' do
+  it "returns 'constant'" do
+    expect(ForInLambdaInEvalInDefineMethod.new.bar) == 'constant'
+  end
+end


### PR DESCRIPTION
Regardless of where the current module comes from, we need this setup to ensure that the temp variable %current_module has been initialized, or else we may end up in a situation like #9491 where we expect it to be available and it is not.

It's not clear to me why this logic was gated on being a for loop body.

Fixes #9491