### PR TITLE
Don't copy the singleton class in Proc#dup

### DIFF
--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -259,7 +259,7 @@ public class RubyProc extends RubyObject implements DataType {
     }
 
     private RubyProc procDup() {
-        return newProc(getRuntime(), getMetaClass(), block, type, file, line);
+        return newProc(getRuntime(), getMetaClass().getRealClass(), block, type, file, line);
     }
 
     @Override


### PR DESCRIPTION
procDup() passed getMetaClass() to the copy, which is the receiver's singleton class when the proc has singleton methods, so the dup unexpectedly responded to the receiver's singleton methods; MRI drops the singleton class on dup:

    pr = proc { }
    def pr.tag; end
    pr.dup.respond_to?(:tag)  # JRuby: true, MRI: false

Pass the real class instead.  Proc#clone is unaffected because cloneSetup already replaces the copy's metaclass with a clone of the receiver's singleton class, and Proc subclasses are preserved since the real class of a subclass instance is the subclass itself.