### PR TITLE
Ensure uniform keywords flags in native method annotations

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -432,7 +432,7 @@ public class RubyEnumerable {
         return result;
     }
 
-    @JRubyMethod(name = {"to_a", "entries"})
+    @JRubyMethod(name = {"to_a", "entries"}, keywords = true)
     public static IRubyObject to_a(ThreadContext context, IRubyObject self) {
         var result = newArray(context);
         callEach(context, eachSite(context), self, Signature.OPTIONAL, new AppendBlockCallback(result));

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -824,7 +824,7 @@ public class RubyHash extends RubyObject implements Map {
     /** rb_hash_initialize
      *
      */
-    @JRubyMethod(visibility = PRIVATE)
+    @JRubyMethod(visibility = PRIVATE, keywords = true)
     public IRubyObject initialize(ThreadContext context, final Block block) {
         modify();
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1086,12 +1086,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return this;
     }
 
-    @JRubyMethod(name = "initialize", visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", visibility = PRIVATE, keywords = true)
     public IRubyObject initialize(ThreadContext context, IRubyObject fileNumber, Block unused) {
         return initializeCommon(context, toInt(context, fileNumber), null, context.nil);
     }
 
-    @JRubyMethod(name = "initialize", visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", visibility = PRIVATE, keywords = true)
     public IRubyObject initialize(ThreadContext context, IRubyObject fileNumber, IRubyObject second, Block unused) {
         int fileno = toInt(context, fileNumber);
         IRubyObject vmode = null;
@@ -2676,7 +2676,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      */
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE, keywords = true)
     public IRubyObject gets(ThreadContext context) {
         return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context));
     }
@@ -3123,7 +3123,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     /** Read a line.
      *
      */
-    @JRubyMethod(name = "readline", writes = LASTLINE)
+    @JRubyMethod(name = "readline", writes = LASTLINE, keywords = true)
     public IRubyObject readline(ThreadContext context) {
         IRubyObject line = gets(context);
 
@@ -3896,7 +3896,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return this;
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each(final ThreadContext context, final Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each");
 
@@ -3943,7 +3943,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, final Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line");
 
@@ -4000,7 +4000,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
 
-    @JRubyMethod(name = "readlines")
+    @JRubyMethod(name = "readlines", keywords = true)
     public RubyArray readlines(ThreadContext context) {
         return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context));
     }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4214,7 +4214,8 @@ public class RubyModule extends RubyObject {
     // Just relying on annotations will give us: got n expected 0..3 when we want got n expected 1..3.
     @JRubyMethod(name = {"module_eval", "class_eval"}, rest = true,
             reads = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
-            writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE})
+            writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
+            keywords = true)
     public IRubyObject module_eval(ThreadContext context, IRubyObject[] args, Block block) {
         switch(args.length) {
             case 0: return module_eval(context, block);

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -456,7 +456,7 @@ public class RubyProc extends RubyObject implements DataType {
         return context.nil;
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject parameters(ThreadContext context) {
         return parametersCommon(context, isLambda());
     }

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -927,7 +927,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return initialize_m(getCurrentContext(), arg);
     }
 
-    @JRubyMethod(name = "initialize", visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "initialize", visibility = Visibility.PRIVATE, keywords = true)
     public IRubyObject initialize_m(ThreadContext context, IRubyObject arg) {
         return arg instanceof RubyRegexp regexp ?
                 initializeByRegexp(context, regexp, null) :

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -523,7 +523,7 @@ public class RubyStruct extends RubyObject {
         return context.nil;
     }
 
-    @JRubyMethod(visibility = PRIVATE)
+    @JRubyMethod(visibility = PRIVATE, keywords = true)
     @Override
     public IRubyObject initialize(ThreadContext context) {
         IRubyObject nil = context.nil;

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1763,7 +1763,7 @@ public class RubyTime extends RubyObject {
         return time;
     }
 
-    @JRubyMethod(name = "initialize", visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", visibility = PRIVATE, keywords = true)
     public IRubyObject initialize(ThreadContext context) {
         return initializeNow(context, context.nil);
     }

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1578,7 +1578,7 @@ public class RubyTime extends RubyObject {
         return obj;
     }
 
-    @JRubyMethod(meta = true)
+    @JRubyMethod(meta = true, keywords = true)
     public static IRubyObject at(ThreadContext context, IRubyObject recv, IRubyObject arg) {
         return at1(context, recv, arg);
     }
@@ -1601,7 +1601,7 @@ public class RubyTime extends RubyObject {
                 atOpts(context, recv, arg1, arg2, null, arg3);
     }
 
-    @JRubyMethod(required = 1, optional = 3, checkArity = false, meta = true)
+    @JRubyMethod(required = 1, optional = 3, checkArity = false, meta = true, keywords = true)
     public static IRubyObject at(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return switch (args.length) {
             case 1 -> at(context, recv, args[0]);

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1593,5 +1593,17 @@ modes.each do |mode|
         proxy.apply(1)
       RUBY
     end
+
+    # See https://github.com/jruby/jruby/issues/9531
+    it "propagates keywords through multi-dispatch Class#new + #initialize" do
+      looped = 3.times.map { Time.new("2023-05-08 10:21:21", in: "UTC")}
+      nonlooped = [
+        Time.new("2023-05-08 10:21:21", in: "UTC"),
+        Time.new("2023-05-08 10:21:21", in: "UTC"),
+        Time.new("2023-05-08 10:21:21", in: "UTC")
+      ]
+
+      expect(looped).to eq nonlooped
+    end
   end
 end


### PR DESCRIPTION
The keywords flag is used by invokedynamic call sites to determine whether kwarg logic should be added to the bound method handle chain. The flag is accessed by inspecting the one `NativeCall` shipped with the target `DynamicMethod` to see if its annotation has the flag set.

If the one signature propagated as `NativeCall` is not uniform with the other bindings, it will inaccurately reflect the keyword needs of those other signatures. As a short-term workaround for this limitation, we make sure all multi-dispatch native methods set the keywords flag uniformly.

This set of fixes was determined by adding a hard check to the `DescriptorInfo` method, used at binding time to gather method bindings. I'm not comfortable pushing a hard check into JRuby 10.0.x, since this was previously a soft requirement, so only the fixed flags are pushed here. The `DescriptorInfo` hard check will be pushed for JRuby 10.1.

Fixes #9531 and #9543.