### PR TITLE
[fix] re-raising exception with nil backtrace

### DIFF
--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -543,7 +543,7 @@ public class RubyException extends RubyObject {
      *
      * MRI {@code setup_exception} which fills the backtrace only when it is <code>nil</code>
      */
-    void prepareBacktrace(ThreadContext context) {
+    public void prepareBacktrace(ThreadContext context) {
         if (getBacktrace().isNil()) {
             clearBacktraceObject();
             captureBacktrace(context);

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -533,6 +533,23 @@ public class RubyException extends RubyObject {
         backtrace.backtraceData = instanceConfig(context).getTraceType().getBacktrace(context);
     }
 
+    private void clearBacktraceObject() {
+        backtrace.backtraceObject = null;
+        backtrace.backtraceLocations = null;
+    }
+
+    /**
+     * Populate backtrace from the current position when exception is (re-)raised without one.
+     *
+     * MRI {@code setup_exception} which fills the backtrace only when it is <code>nil</code>
+     */
+    void prepareBacktrace(ThreadContext context) {
+        if (getBacktrace().isNil()) {
+            clearBacktraceObject();
+            captureBacktrace(context);
+        }
+    }
+
     public IRubyObject getBacktrace() {
         IRubyObject backtraceObject = backtrace.backtraceObject;
         if (backtraceObject != null) return backtraceObject;

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1058,6 +1058,7 @@ public class RubyKernel {
 
         var exception = raise.getException();
 
+        exception.prepareBacktrace(context);
         if (context.runtime.isDebug()) printExceptionSummary(context, exception);
         if (exception.getCause() == null && cause != exception) exception.setCause(cause);
 
@@ -1121,6 +1122,7 @@ public class RubyKernel {
         }
 
         var exception = raise.getException();
+        exception.prepareBacktrace(context);
         if (context.runtime.isDebug()) printExceptionSummary(context, exception);
         if (forceCause || argc > 0 && exception.getCause() == null && cause != exception) exception.setCause(cause);
 

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -398,7 +398,9 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
 
         if (data.parent != context.getFiberCurrentThread()) fiberCalledAcrossThreads(runtime);
 
-        FiberRequest val = new FiberRequest(((RubyException) exception).toThrowable(), RequestType.RAISE);
+        RubyException rubyException = (RubyException) exception;
+        rubyException.prepareBacktrace(context);
+        FiberRequest val = new FiberRequest(rubyException.toThrowable(), RequestType.RAISE);
 
         data.prev = context.getFiber();
 

--- a/spec/ruby/shared/kernel/raise.rb
+++ b/spec/ruby/shared/kernel/raise.rb
@@ -124,6 +124,28 @@ describe :kernel_raise, shared: true do
     raised_exception.should == exception
   end
 
+  it "re-raises a previously rescued exception with a new backtrace when its backtrace was cleared" do
+    exception = nil
+
+    begin
+      raise "raised"
+    rescue => exception
+      # Ignore.
+    end
+
+    exception.set_backtrace(nil)
+    exception.backtrace.should == nil
+
+    begin
+      raised_exception = @object.raise(exception)
+    rescue => raised_exception
+      # Ignore.
+    end
+
+    raised_exception.should == exception
+    raised_exception.backtrace.should be_kind_of(Array)
+  end
+
   it "allows Exception, message, and backtrace parameters" do
     -> do
       @object.raise(ArgumentError, "message", caller)

--- a/spec/tags/ruby/core/fiber/raise_tags.txt
+++ b/spec/tags/ruby/core/fiber/raise_tags.txt
@@ -1,4 +1,3 @@
-fails:Fiber#raise re-raises a previously rescued exception without overwriting the backtrace
 fails:Fiber#raise raises FiberError if Fiber is not born
 fails:Fiber#raise does not allow message and extra keyword arguments
 fails:Fiber#raise should raise on parent fiber

--- a/spec/tags/ruby/core/thread/raise_tags.txt
+++ b/spec/tags/ruby/core/thread/raise_tags.txt
@@ -1,4 +1,3 @@
 fails:Thread#raise on a running thread raises a RuntimeError when called with no arguments inside rescue
 fails:Thread#raise on same thread raises a RuntimeError when called with no arguments inside rescue
 fails(gh-631):Thread#raise on a sleeping thread raises a RuntimeError when called with no arguments inside rescue
-fails:Thread#raise on same thread re-raises a previously rescued exception without overwriting the backtrace


### PR DESCRIPTION
tried to keep the change-set minimal, will likely cause conflicts when merging over to master (10.1)