### PR TITLE
Raise fixes and additional spec permutations

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1086,8 +1086,7 @@ public class RubyKernel {
             default -> prepareNewException(context, arg0, arg1);
         };
 
-        setGivenExceptionCause(context, cause, exception);
-        return raiseException(context, exception);
+        return raiseWithNewExceptionCause(context, exception, cause);
     }
 
     @JRubyMethod(name = {"raise", "fail"}, module = true, visibility = PRIVATE, omit = true, keywords = true)
@@ -1226,7 +1225,13 @@ public class RubyKernel {
      * @param cause the cause
      */
     private static void setNewExceptionCause(ThreadContext context, RubyException exception, Cause cause) {
-        if ((cause.provided || exception.getCause() == null) && cause.value != exception) exception.setCause(context, cause.value);
+        if (cause.value.isNil()) {
+            if (!cause.provided && exception.getCause() == null) {
+                exception.setCause(context, cause.value);
+            }
+        } else if ((cause.provided || exception.getCause() == null) && cause.value != exception) {
+            exception.setCause(context, cause.value);
+        }
     }
 
     /**

--- a/spec/ruby/core/kernel/raise_spec.rb
+++ b/spec/ruby/core/kernel/raise_spec.rb
@@ -38,8 +38,20 @@ describe "Kernel#raise with previously rescued exception" do
     ScratchPad.recorded.should == nil
   end
 
+  new_raisers = [
+    -> { raise "Error" },
+    -> { raise RuntimeError, "Error" },
+    -> { raise RuntimeError, "Error", [] }
+  ]
+
+  re_raisers_with_cause = [
+    -> (e1, e2) {raise e1, cause: e2},
+    -> (e1, e2) {raise e1, "New message", cause: e2},
+    -> (e1, e2) {raise e1, "New message", [], cause: e2}
+  ]
+
   it "re-raises a previously rescued exception without overwriting the cause" do
-    check = -> (&second_raiser) do
+    check = -> (second_raiser) do
       begin
         begin
           begin
@@ -58,64 +70,58 @@ describe "Kernel#raise with previously rescued exception" do
       e.cause.should == e1
     end
 
-    check.() { raise "Error 2" }
-    check.() { raise RuntimeError, "Error 2" }
-    check.() { raise RuntimeError, "Error 2", [] }
+    new_raisers.each(&check)
   end
 
   it "re-raises a previously rescued exception with overwriting the cause when it's explicitly specified with :cause option" do
-    check = -> (&last_raiser) do
+    check = -> ((raiser, re_raiser_with_cause)) do
       e4 = RuntimeError.new("Error 4")
       begin
         begin
           begin
             raise "Error 1"
           rescue => e1
-            raise "Error 2"
+            raiser.call
           end
         rescue => e2
           raise "Error 3"
         end
       rescue
         e2.cause.should == e1
-        last_raiser.call(e2, e4)
+        re_raiser_with_cause.call(e2, e4)
       end
     rescue => e
       e.cause.should == e4
     end
 
-    check.() {|e1, e2| raise e1, cause: e2}
-    check.() {|e1, e2| raise e1, "New message", cause: e2}
-    check.() {|e1, e2| raise e1, "New message", [], cause: e2}
+    new_raisers.product(re_raisers_with_cause).each(&check)
   end
 
   it "re-raises a previously rescued exception without overwriting the cause when it's explicitly specified with a :cause option that has nil value" do
-    check = -> (&last_raiser) do
+    check = -> ((raiser, re_raiser_with_cause)) do
       begin
         begin
           begin
             raise "Error 1"
           rescue => e1
-            raise "Error 2"
+            raiser.call
           end
         rescue => e2
           raise "Error 3"
         end
       rescue
         e2.cause.should == e1
-        last_raiser.call(e2)
+        re_raiser_with_cause.call(e2, nil)
       end
     rescue => e
       e.cause.should == e1
     end
 
-    check.() {|e| raise e, cause: nil }
-    check.() {|e| raise e, "New message", cause: nil }
-    check.() {|e| raise e, "New message", [], cause: nil }
+    new_raisers.product(re_raisers_with_cause).each(&check)
   end
 
   it "re-raises a previously rescued exception without setting a cause implicitly" do
-    check = -> (&raiser) do
+    check = -> (raiser) do
       begin
         raiser.call
       rescue => e1
@@ -126,14 +132,11 @@ describe "Kernel#raise with previously rescued exception" do
       e.cause.should == nil
     end
 
-    check.() { raise "Error 1" }
-    check.() { raise RuntimeError }
-    check.() { raise RuntimeError, "Error 1" }
-    check.() { raise RuntimeError, "Error 1", [] }
+    new_raisers.each(&check)
   end
 
   it "re-raises a previously rescued exception that has a cause without setting a cause implicitly" do
-    check = -> (&raiser) do
+    check = -> (raiser) do
       begin
         raiser.call
       rescue => e1
@@ -148,15 +151,11 @@ describe "Kernel#raise with previously rescued exception" do
       e.cause.should == e1
     end
 
-
-    check.() { raise "Error 1" }
-    check.() { raise RuntimeError }
-    check.() { raise RuntimeError, "Error 1" }
-    check.() { raise RuntimeError, "Error 1", [] }
+    new_raisers.each(&check)
   end
 
-  it "re-raises a previously rescued exception that doesn't have a cause and isn't a cause of any other exception with setting a cause implicitly" do
-    check = -> (&raiser) do
+  it "raises a new exception with two outer rescues while setting the cause implicitly to the innermost rescued exception" do
+    check = -> (raiser) do
       begin
         raiser.call
       rescue => e1
@@ -171,14 +170,11 @@ describe "Kernel#raise with previously rescued exception" do
       e.cause.should == e2
     end
 
-    check.() { raise "Error 1" }
-    check.() { raise RuntimeError }
-    check.() { raise RuntimeError, "Error 1" }
-    check.() { raise RuntimeError, "Error 1", [] }
+    new_raisers.each(&check)
   end
 
   it "re-raises a previously rescued exception that doesn't have a cause and is a cause of other exception without setting a cause implicitly" do
-    check = -> (&raiser) do
+    check = -> (raiser) do
       begin
         raiser.call
       rescue => e1
@@ -195,14 +191,11 @@ describe "Kernel#raise with previously rescued exception" do
       e.cause.should == nil
     end
 
-    check.() { raise "Error 1" }
-    check.() { raise RuntimeError }
-    check.() { raise RuntimeError, "Error 1" }
-    check.() { raise RuntimeError, "Error 1", [] }
+    new_raisers.each(&check)
   end
 
   it "re-raises a previously rescued exception that doesn't have a cause and is a cause of other exception (that wasn't raised explicitly) without setting a cause implicitly" do
-    check = -> (&raiser) do
+    check = -> (raiser) do
       begin
         raiser.call
       rescue => e1
@@ -219,14 +212,11 @@ describe "Kernel#raise with previously rescued exception" do
       e.cause.should == nil
     end
 
-    check.() { raise "Error 1" }
-    check.() { raise RuntimeError }
-    check.() { raise RuntimeError, "Error 1" }
-    check.() { raise RuntimeError, "Error 1", [] }
+    new_raisers.each(&check)
   end
 
   it "re-raises a previously rescued exception that has a cause but isn't a cause of any other exception without setting a cause implicitly" do
-    check = -> (&raiser) do
+    check = -> (raiser) do
       begin
         raiser.call
       rescue => e1
@@ -247,10 +237,7 @@ describe "Kernel#raise with previously rescued exception" do
       e.cause.should == e1
     end
 
-    check.() { raise "Error 1" }
-    check.() { raise RuntimeError }
-    check.() { raise RuntimeError, "Error 1" }
-    check.() { raise RuntimeError, "Error 1", [] }
+    new_raisers.each(&check)
   end
 end
 

--- a/spec/ruby/core/kernel/raise_spec.rb
+++ b/spec/ruby/core/kernel/raise_spec.rb
@@ -39,13 +39,13 @@ describe "Kernel#raise with previously rescued exception" do
   end
 
   it "re-raises a previously rescued exception without overwriting the cause" do
-    begin
+    check = -> (&second_raiser) do
       begin
         begin
           begin
             raise "Error 1"
           rescue => e1
-            raise "Error 2"
+            second_raiser.call
           end
         rescue => e2
           raise "Error 3"
@@ -57,12 +57,15 @@ describe "Kernel#raise with previously rescued exception" do
     rescue => e
       e.cause.should == e1
     end
+
+    check.() { raise "Error 2" }
+    check.() { raise RuntimeError, "Error 2" }
+    check.() { raise RuntimeError, "Error 2", [] }
   end
 
   it "re-raises a previously rescued exception with overwriting the cause when it's explicitly specified with :cause option" do
-    e4 = RuntimeError.new("Error 4")
-
-    begin
+    check = -> (&last_raiser) do
+      e4 = RuntimeError.new("Error 4")
       begin
         begin
           begin
@@ -75,15 +78,19 @@ describe "Kernel#raise with previously rescued exception" do
         end
       rescue
         e2.cause.should == e1
-        raise e2, cause: e4
+        last_raiser.call(e2, e4)
       end
     rescue => e
       e.cause.should == e4
     end
+
+    check.() {|e1, e2| raise e1, cause: e2}
+    check.() {|e1, e2| raise e1, "New message", cause: e2}
+    check.() {|e1, e2| raise e1, "New message", [], cause: e2}
   end
 
-  it "re-raises a previously rescued exception without overwriting the cause when it's explicitly specified with :cause option and has nil value" do
-    begin
+  it "re-raises a previously rescued exception without overwriting the cause when it's explicitly specified with a :cause option that has nil value" do
+    check = -> (&last_raiser) do
       begin
         begin
           begin
@@ -96,17 +103,21 @@ describe "Kernel#raise with previously rescued exception" do
         end
       rescue
         e2.cause.should == e1
-        raise e2, cause: nil
+        last_raiser.call(e2)
       end
     rescue => e
       e.cause.should == e1
     end
+
+    check.() {|e| raise e, cause: nil }
+    check.() {|e| raise e, "New message", cause: nil }
+    check.() {|e| raise e, "New message", [], cause: nil }
   end
 
   it "re-raises a previously rescued exception without setting a cause implicitly" do
-    begin
+    check = -> (&raiser) do
       begin
-        raise "Error 1"
+        raiser.call
       rescue => e1
         raise
       end
@@ -114,12 +125,17 @@ describe "Kernel#raise with previously rescued exception" do
       e.should == e1
       e.cause.should == nil
     end
+
+    check.() { raise "Error 1" }
+    check.() { raise RuntimeError }
+    check.() { raise RuntimeError, "Error 1" }
+    check.() { raise RuntimeError, "Error 1", [] }
   end
 
   it "re-raises a previously rescued exception that has a cause without setting a cause implicitly" do
-    begin
+    check = -> (&raiser) do
       begin
-        raise "Error 1"
+        raiser.call
       rescue => e1
         begin
           raise "Error 2"
@@ -131,12 +147,18 @@ describe "Kernel#raise with previously rescued exception" do
       e.should == e2
       e.cause.should == e1
     end
+
+
+    check.() { raise "Error 1" }
+    check.() { raise RuntimeError }
+    check.() { raise RuntimeError, "Error 1" }
+    check.() { raise RuntimeError, "Error 1", [] }
   end
 
   it "re-raises a previously rescued exception that doesn't have a cause and isn't a cause of any other exception with setting a cause implicitly" do
-    begin
+    check = -> (&raiser) do
       begin
-        raise "Error 1"
+        raiser.call
       rescue => e1
         begin
           raise "Error 2"
@@ -148,12 +170,17 @@ describe "Kernel#raise with previously rescued exception" do
       e.message.should == "Error 3"
       e.cause.should == e2
     end
+
+    check.() { raise "Error 1" }
+    check.() { raise RuntimeError }
+    check.() { raise RuntimeError, "Error 1" }
+    check.() { raise RuntimeError, "Error 1", [] }
   end
 
   it "re-raises a previously rescued exception that doesn't have a cause and is a cause of other exception without setting a cause implicitly" do
-    begin
+    check = -> (&raiser) do
       begin
-        raise "Error 1"
+        raiser.call
       rescue => e1
         begin
           raise "Error 2"
@@ -167,12 +194,17 @@ describe "Kernel#raise with previously rescued exception" do
       e.should == e1
       e.cause.should == nil
     end
+
+    check.() { raise "Error 1" }
+    check.() { raise RuntimeError }
+    check.() { raise RuntimeError, "Error 1" }
+    check.() { raise RuntimeError, "Error 1", [] }
   end
 
   it "re-raises a previously rescued exception that doesn't have a cause and is a cause of other exception (that wasn't raised explicitly) without setting a cause implicitly" do
-    begin
+    check = -> (&raiser) do
       begin
-        raise "Error 1"
+        raiser.call
       rescue => e1
         begin
           foo # raises NameError
@@ -186,12 +218,17 @@ describe "Kernel#raise with previously rescued exception" do
       e.should == e1
       e.cause.should == nil
     end
+
+    check.() { raise "Error 1" }
+    check.() { raise RuntimeError }
+    check.() { raise RuntimeError, "Error 1" }
+    check.() { raise RuntimeError, "Error 1", [] }
   end
 
   it "re-raises a previously rescued exception that has a cause but isn't a cause of any other exception without setting a cause implicitly" do
-    begin
+    check = -> (&raiser) do
       begin
-        raise "Error 1"
+        raiser.call
       rescue => e1
         begin
           raise "Error 2"
@@ -209,6 +246,11 @@ describe "Kernel#raise with previously rescued exception" do
       e.should == e2
       e.cause.should == e1
     end
+
+    check.() { raise "Error 1" }
+    check.() { raise RuntimeError }
+    check.() { raise RuntimeError, "Error 1" }
+    check.() { raise RuntimeError, "Error 1", [] }
   end
 end
 


### PR DESCRIPTION
This PR fixes two issues found while investigating #9551:

* The two-argument form of `raise` did not follow the same cause-setting logic as the other arities when setting cause the first time, failing to initialize it to `nil` when no cause was available. This resulted in a subsequent re-raise incorrectly updating the cause with the current `$!` when no cause should have been set. This was the root cause of #9551.
* None of the paths properly checked if cause was provided as `nil`, which should indicate that the cause not be modified.

This also includes changes to permute the relevant rubyspecs with all valid arities of `raise`, at least when generating the exception under test.