### PR TITLE
Expand Kernel#sprintf Hash default to include proc behavior

### DIFF
--- a/spec/ruby/core/kernel/shared/sprintf.rb
+++ b/spec/ruby/core/kernel/shared/sprintf.rb
@@ -1023,7 +1023,11 @@ describe :kernel_sprintf, shared: true do
 
       it "respects Hash#default when there is no set key" do
         @method.call("%{foo}", Hash.new(123)).should == "123"
-        @method.call("%{foo}", Hash.new { 123 }).should == "123"
+        hash_default_proc = Hash.new do |*args|
+          args.should == [hash_default_proc, :foo]
+          123
+        end
+        @method.call("%{foo}", hash_default_proc).should == "123"
       end
 
       it "raises KeyError when Hash#default returns nil" do


### PR DESCRIPTION
Old version checked that the proc was called but not that it was called with appropriate arguments.

See jruby/jruby#9558

Draft until fix merges in from 10.0 and this is green.