### PR TITLE
Update jnr dependencies for BSD aliases

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -49,7 +49,7 @@ project 'JRuby Base' do
   jar 'com.github.jnr:jnr-unixsocket:0.39.1', exclusions: ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-posix:3.2.1', exclusions: ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-constants:0.11.0', exclusions: ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-ffi:2.3.0'
+  jar 'com.github.jnr:jnr-ffi:2.3.1-SNAPSHOT'
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -133,7 +133,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.3.0</version>
+      <version>2.3.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
Updates FreeBSD type aliases and adds OpenBSD type aliases.

Fixes jruby/jruby#9553

Draft until verified and jnr-ffi and its downstream JNR dependencies have been released.