### PR TITLE
Fix spawn dup ordering

### DIFF
--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -831,10 +831,10 @@ public class PopenExecutor {
         }
 
         /* sort the table by oldfd: O(n log n) */
-        if (sargp == null)
-            Arrays.sort(pairs, intcmp); /* hopefully async-signal-safe */
-        else
-            Arrays.sort(pairs, intrcmp);
+        // JRuby uses posix_spawn actions for redirects, so they should always be sorted by the input "old"
+        // descriptors to ensure we dup them before they get overwritten by other actions.
+        // See https://github.com/jruby/jruby/issues/9577
+        Arrays.sort(pairs, intcmp);
 
         /* initialize older_index and num_newer: O(n log n) */
         for (i = 0; i < n; i++) {
@@ -2007,13 +2007,6 @@ public class PopenExecutor {
         @Override
         public int compare(run_exec_dup2_fd_pair o1, run_exec_dup2_fd_pair o2) {
             return Integer.compare(o1.oldfd, o2.oldfd);
-        }
-    };
-
-    private static final Comparator<run_exec_dup2_fd_pair> intrcmp = new Comparator<run_exec_dup2_fd_pair>() {
-        @Override
-        public int compare(run_exec_dup2_fd_pair o1, run_exec_dup2_fd_pair o2) {
-            return Integer.compare(o2.oldfd, o1.oldfd);
         }
     };
 

--- a/spec/ruby/core/io/popen_spec.rb
+++ b/spec/ruby/core/io/popen_spec.rb
@@ -29,6 +29,14 @@ describe "IO.popen" do
     @io.read.should == "foo\n"
   end
 
+  platform_is_not :windows do
+    it "redirects the child's STDIN from the parent's STDOUT" do
+      skip "requires STDOUT to be a terminal device" unless STDOUT.tty?
+
+      IO.popen([*ruby_exe, "-e", "print STDIN.tty?", in: STDOUT], &:read).should == "true"
+    end
+  end
+
   it "raises IOError when writing a read-only pipe" do
     @io = IO.popen('echo foo', "r")
     -> { @io.write('bar') }.should raise_error(IOError)


### PR DESCRIPTION
The ordering here was leftover from ported CRuby logic and incorrectly did the redirects in reverse order. For `in: STDOUT`, this caused any redirect to the child's `STDOUT` to get used for the input of the `in:` redirect. Because that child `STDOUT` would be a pipe if not otherwise specified, the `in:` ended up with a non-TTY and broke our `stty`-based io-console logic (https://github.com/ruby/io-console/issues/145).

Fixes https://github.com/jruby/jruby/issues/9577.