### PR TITLE
Fix identity hash dumping and loading

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2537,8 +2537,10 @@ public class RubyHash extends RubyObject implements Map {
         }
     };
 
-    public static RubyHash unmarshalFrom(UnmarshalStream input, boolean defaultValue) throws IOException {
-        RubyHash result = (RubyHash) input.entry(newHash(input.getRuntime()));
+    public static RubyHash unmarshalFrom(UnmarshalStream input, boolean defaultValue, boolean identity) throws IOException {
+        RubyHash result = newHash(input.getRuntime());
+        if (identity) result.setComparedByIdentity(true);
+        result = (RubyHash) input.entry(result);
         int size = input.unmarshalInt();
 
         for (int i = 0; i < size; i++) {

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
@@ -38,6 +38,7 @@ package org.jruby.runtime.marshal;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.jcodings.Encoding;
 import org.jcodings.specific.USASCIIEncoding;
@@ -76,6 +77,8 @@ import static org.jruby.util.RubyStringBuilder.types;
  * @author Anders
  */
 public class MarshalStream extends FilterOutputStream {
+    private static final ByteList HASH_BYTELIST = new ByteList("Hash".getBytes(StandardCharsets.US_ASCII), false);
+
     private final Ruby runtime;
     private final MarshalCache cache;
     private final int depthLimit;
@@ -278,6 +281,10 @@ public class MarshalStream extends FilterOutputStream {
             case HASH: {
                 RubyHash hash = (RubyHash)value;
 
+                if (hash.isComparedByIdentity()) {
+                    out.write(TYPE_UCLASS);
+                    writeAndRegisterSymbol(HASH_BYTELIST);
+                }
                 if(hash.getIfNone() == RubyBasicObject.UNDEF){
                     write('{');
                 } else if (hash.hasDefaultProc()) {

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
@@ -275,10 +275,10 @@ public class UnmarshalStream extends InputStream {
                 obj = objectForArray(partial);
                 break;
             case TYPE_HASH:
-                obj = objectForHash(partial);
+                obj = objectForHash(partial, false);
                 break;
             case TYPE_HASH_DEF:
-                obj = objectForHashDefault(partial);
+                obj = objectForHashDefault(partial, false);
                 break;
             case TYPE_STRUCT:
                 obj = objectForStruct(partial);
@@ -385,12 +385,12 @@ public class UnmarshalStream extends InputStream {
         return leave(RubyStruct.unmarshalFrom(this), partial);
     }
 
-    private IRubyObject objectForHashDefault(boolean partial) throws IOException {
-        return leave(RubyHash.unmarshalFrom(this, true), partial);
+    private IRubyObject objectForHashDefault(boolean partial, boolean identity) throws IOException {
+        return leave(RubyHash.unmarshalFrom(this, true, identity), partial);
     }
 
-    private IRubyObject objectForHash(boolean partial) throws IOException {
-        return leave(RubyHash.unmarshalFrom(this, false), partial);
+    private IRubyObject objectForHash(boolean partial, boolean identity) throws IOException {
+        return leave(RubyHash.unmarshalFrom(this, false, identity), partial);
     }
 
     private IRubyObject objectForArray(boolean partial) throws IOException {
@@ -436,8 +436,9 @@ public class UnmarshalStream extends InputStream {
 
         int type = r_byte();
         if (c == runtime.getHash() && (type == TYPE_HASH || type == TYPE_HASH_DEF)) {
-            // FIXME: Missing logic to make the following methods use compare_by_identity (and construction of that)
-            return type == TYPE_HASH ? objectForHash(partial) : objectForHashDefault(partial);
+            return type == TYPE_HASH ?
+                    objectForHash(partial, true) :
+                    objectForHashDefault(partial, true);
         }
 
         IRubyObject obj = objectFor(type, null, partial, extendedModules);

--- a/spec/tags/ruby/core/marshal/dump_tags.txt
+++ b/spec/tags/ruby/core/marshal/dump_tags.txt
@@ -12,8 +12,6 @@ fails:Marshal.dump with an object responding to #_dump dumps the String in multi
 fails:Marshal.dump with an object responding to #_dump raises TypeError if an Object is an instance of an anonymous class
 fails:Marshal.dump with a Class dumps a class with multibyte characters in name
 fails:Marshal.dump with a Module dumps a module with multibyte characters in name
-fails:Marshal.dump with a Hash dumps a Hash with compare_by_identity
-fails:Marshal.dump with a Hash dumps a Hash subclass with compare_by_identity
 fails:Marshal.dump with an Object raises TypeError if an Object extends an anonymous module
 fails:Marshal.dump with a Time dumps a Time subclass with multibyte characters in name
 fails:Marshal.dump with a Time raises TypeError with an anonymous Time subclass

--- a/spec/tags/ruby/core/marshal/load_tags.txt
+++ b/spec/tags/ruby/core/marshal/load_tags.txt
@@ -8,7 +8,5 @@ fails:Marshal.load when called with freeze: true returns frozen object having #_
 fails:Marshal.load when called with freeze: true returns frozen object responding to #marshal_dump and #marshal_load
 fails:Marshal.load when called with freeze: true returns frozen object extended by a module
 fails:Marshal.load when called on objects with custom _dump methods loads the String in multibyte encoding
-fails:Marshal.load for a Hash preserves compare_by_identity behaviour
-fails:Marshal.load for a Hash preserves compare_by_identity behaviour for a Hash subclass
 fails:Marshal.load for a Rational loads
 fails:Marshal.load for a Complex loads

--- a/spec/tags/ruby/core/marshal/restore_tags.txt
+++ b/spec/tags/ruby/core/marshal/restore_tags.txt
@@ -8,7 +8,5 @@ fails:Marshal.restore when called with freeze: true returns frozen object having
 fails:Marshal.restore when called with freeze: true returns frozen object responding to #marshal_dump and #marshal_load
 fails:Marshal.restore when called with freeze: true returns frozen object extended by a module
 fails:Marshal.restore when called on objects with custom _dump methods loads the String in multibyte encoding
-fails:Marshal.restore for a Hash preserves compare_by_identity behaviour
-fails:Marshal.restore for a Hash preserves compare_by_identity behaviour for a Hash subclass
 fails:Marshal.restore for a Rational loads
 fails:Marshal.restore for a Complex loads


### PR DESCRIPTION
This was fixed for 10.0+ in jruby/jruby#9065 but never backported.

This also includes a fix for jruby/jruby#9525 to properly register the "Hash" symbol.