### PR TITLE
Register the "Hash" symbol when writing identity hash

### DIFF
--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalDumper.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalDumper.java
@@ -131,7 +131,11 @@ public class MarshalDumper {
             writeSymbolLink(out, this, sym);
         } else {
             registerSymbol(sym);
-            dumpSymbol(out, sym.getBytes());
+            ByteList value = sym.getBytes();
+            out.write(':');
+            int len = value.length();
+            writeInt(out, len);
+            out.write(value.getUnsafeBytes(), value.begin(), len);
         }
     }
 
@@ -319,7 +323,7 @@ public class MarshalDumper {
 
                     if (hash.isComparedByIdentity()) {
                         out.write(TYPE_UCLASS);
-                        dumpSymbol(out, HASH_BYTELIST);
+                        writeAndRegisterSymbol(out, context.runtime.newSymbol(HASH_BYTELIST));
                     }
                     if (hash.getIfNone() == RubyBasicObject.UNDEF) {
                         out.write('{');
@@ -577,13 +581,6 @@ public class MarshalDumper {
     }
 
     public void writeString(RubyOutputStream out, ByteList value) {
-        int len = value.length();
-        writeInt(out, len);
-        out.write(value.getUnsafeBytes(), value.begin(), len);
-    }
-
-    public void dumpSymbol(RubyOutputStream out, ByteList value) {
-        out.write(':');
         int len = value.length();
         writeInt(out, len);
         out.write(value.getUnsafeBytes(), value.begin(), len);

--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -610,6 +610,13 @@ describe "Marshal.dump" do
       Marshal.dump(h).should == "\004\bC:\tHash{\x00"
     end
 
+    it "dumps a Hash with compare_by_identity and registers the \"Hash\" symbol in the link table" do
+      h = {}
+      h.compare_by_identity
+
+      Marshal.dump([h, :Hash]).should == "\x04\b[\aC:\tHash{\x00;\x00"
+    end
+
     it "dumps a Hash subclass with compare_by_identity" do
       h = UserHash.new
       h.compare_by_identity


### PR DESCRIPTION
Not registering at this point causes the symbol link table to be off by one for all subsequent symbol links.

Fixes #9585.