### PR TITLE
Scan the code range when folding a compound string

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/BuildCompoundStringInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BuildCompoundStringInstr.java
@@ -154,9 +154,9 @@ public class BuildCompoundStringInstr extends NOperandResultBaseInstr {
             var newByteList = new ByteList(0);
             newByteList.setEncoding(encoding);
             Operand string = switch (stringStyle) {
-                case Frozen -> new FrozenString(newByteList, CR_VALID, file, line);
-                case Mutable -> new MutableString(newByteList, CR_VALID, file, line);
-                default -> new ChilledString(newByteList, CR_VALID, file, line);
+                case Frozen -> new FrozenString(newByteList, CR_7BIT, file, line);
+                case Mutable -> new MutableString(newByteList, CR_7BIT, file, line);
+                default -> new ChilledString(newByteList, CR_7BIT, file, line);
             };
             return new CopyInstr(getResult(), string);
         } else if (piecesArray.length == 1) { // not sure we can have a compound string with only one piece AND a non-string.
@@ -240,8 +240,8 @@ public class BuildCompoundStringInstr extends NOperandResultBaseInstr {
     private Instr copy(FrozenString string) {
         Operand value = switch (stringStyle) {
             case Frozen -> string;
-            case Mutable -> new MutableString(string.bytelist, CR_VALID, file, line);
-            default -> new ChilledString(string.bytelist, CR_VALID, file, line);
+            case Mutable -> new MutableString(string.bytelist, string.getCodeRange(), file, line);
+            default -> new ChilledString(string.bytelist, string.getCodeRange(), file, line);
         };
 
         return new CopyInstr(result, value);

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -17,6 +17,7 @@ jruby/test_case
 jruby/test_class
 jruby/test_class_subclasses
 jruby/test_comparable
+jruby/test_compound_string_coderange
 jruby/test_core_arities
 jruby/test_coverage
 jruby/test_custom_enumerable

--- a/test/jruby/test_compound_string_coderange.rb
+++ b/test/jruby/test_compound_string_coderange.rb
@@ -1,0 +1,59 @@
+# encoding: UTF-8
+require 'test/unit'
+require 'test/jruby/test_helper'
+
+# GH-9591
+#
+# BuildCompoundStringInstr#simplifyInstr folds a compound string into a single
+# literal. It used to assign CR_VALID without scanning the bytes. An ASCII-only
+# string must be CR_7BIT, otherwise String#hash disagrees with String#eql? and
+# uniq/Hash/Set split byte-identical strings.
+#
+# The interpreter builds these strings at run time and scans them, so the bug
+# only appeared once a method was compiled. Each test therefore runs in a child
+# process with the compiler forced on.
+class TestCompoundStringCodeRange < Test::Unit::TestCase
+  include TestHelper
+
+  FORCE_COMPILE = { "jruby.compile.mode" => "FORCE" }
+
+  def test_folded_integer_interpolation_is_ascii_only
+    assert_equal 'true', run_compiled('print "abc#{1}def".ascii_only?')
+  end
+
+  def test_folded_symbol_interpolation_is_ascii_only
+    assert_equal 'true', run_compiled('print "abc#{:sym}def".ascii_only?')
+  end
+
+  def test_folded_float_interpolation_is_ascii_only
+    assert_equal 'true', run_compiled('print "abc#{1.5}def".ascii_only?')
+  end
+
+  def test_dedented_heredoc_is_ascii_only
+    script = 'value = <<~EOS' "\n" \
+             '  hello world' "\n" \
+             'EOS' "\n" \
+             'print value.ascii_only?'
+    assert_equal 'true', run_compiled(script)
+  end
+
+  def test_folded_string_hash_agrees_with_eql
+    script = 'folded = "abc#{1}def"' "\n" \
+             'plain = "abc1def"' "\n" \
+             'print [folded.eql?(plain), folded.hash == plain.hash, [folded, plain].uniq.size].inspect'
+    assert_equal '[true, true, 1]', run_compiled(script)
+  end
+
+  # The fix must not mark real non-ASCII text as 7-bit.
+  def test_folded_non_ascii_string_is_not_ascii_only
+    script = 'value = "café#{1}!"' "\n" \
+             'print [value.ascii_only?, value.valid_encoding?].inspect'
+    assert_equal '[false, true]', run_compiled(script)
+  end
+
+  private
+
+  def run_compiled(script)
+    with_temp_script(script) { |f| jruby(f.path, FORCE_COMPILE) }
+  end
+end


### PR DESCRIPTION
Fixes #9591.

`BuildCompoundStringInstr#simplifyInstr` folds a compound string into a single
literal. Two places assigned `CR_VALID` without a scan of the bytes. A string
that holds only ASCII must be `CR_7BIT`.

`String#hash` mixes the encoding into the digest when a string is not 7-bit.
Two byte-identical strings with the same encoding therefore compared equal but
hashed differently, and `Array#uniq`, `Hash` and `Set` treated them as two
values.

The interpreter is not affected. `interpret` appends each piece with
`RubyString#cat`, which keeps the code range correct. The two modes disagreed,
so one process could hold both a correct and an incorrect copy of the same
text once the JIT threshold was crossed part way through a run.

## The change

* `copy`: keep the code range of the operand that is folded. The `Frozen`
  branch was already correct, because it reuses the operand and its code range.
* the empty-string branch: use `CR_7BIT`. An empty string is 7-bit.

`asOperand` in the same file already uses `CR_UNKNOWN`, which is safe, because
a later scan computes the true value.

## Which expressions were affected

Code range of the result, with `-Xcompile.mode=FORCE`:

| Expression | before | after |
|---|---|---|
| `"abc#{1}def"` | CR_VALID | CR_7BIT |
| `"abc#{:sym}def"` | CR_VALID | CR_7BIT |
| `"abc#{1.5}def"` | CR_VALID | CR_7BIT |
| `<<~` heredoc with an indented body | CR_VALID | CR_7BIT |
| `"café#{1}!"` | CR_VALID | CR_VALID |

The dedent of a squiggly heredoc makes the parser produce a compound string,
which is why only the indented form was affected. An interpolated String was
not affected, because the parser merges those pieces earlier and rescans.

## Tests

`test/jruby/test_compound_string_coderange.rb` is new. The bug only appears
once a method is compiled, so each case runs in a child process with
`jruby.compile.mode=FORCE`. Without this change 5 of the 6 tests fail. The
sixth checks that real non-ASCII text still gets `CR_VALID`, and it passes
either way.

I also ran `spec/ruby/core/string`, `spec/ruby/core/symbol`,
`spec/ruby/core/encoding`, `spec/ruby/language/string_spec.rb` and
`spec/ruby/language/heredoc_spec.rb` with `-Xcompile.mode=FORCE`. The result is
the same before and after: 4862 examples, 50 failures, 8 errors. Those failures
are already present on master.
