### PR TITLE
More accurate TTY checking for IO

### DIFF
--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -330,7 +330,7 @@ public class RubyGlobal {
         // If we're the main for the process and native stdio is enabled, use default descriptors
         if (!Platform.IS_WINDOWS && // Windows does not do native IO yet
                 runtime.getPosix().isNative() &&
-                runtime.getInstanceConfig().isHardExit() && // main JRuby only
+                runtime.getInstanceConfig().isMain() && // main JRuby only
                 Options.NATIVE_STDIO.load()) {
             stdin = RubyIO.prepStdio(
                     runtime, runtime.getIn(), new NativeDeviceChannel(0), OpenFile.READABLE, runtime.getIO(), "<STDIN>");

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -66,6 +66,7 @@ import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.transcode.EConvFlags;
 import org.jruby.api.API;
+import org.jruby.api.Convert;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
@@ -89,6 +90,7 @@ import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.runtime.encoding.EncodingService;
 import org.jruby.util.ShellLauncher.POpenProcess;
 import org.jruby.util.*;
+import org.jruby.util.cli.JVMConsole;
 import org.jruby.util.cli.Options;
 import org.jruby.util.io.ChannelFD;
 import org.jruby.util.io.EncodingUtils;
@@ -2240,23 +2242,23 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     public RubyBoolean tty_p(ThreadContext context) {
         Ruby runtime = context.runtime;
         POSIX posix = runtime.getPosix();
-        OpenFile fptr;
-
-        fptr = getOpenFileChecked();
+        OpenFile fptr = getOpenFileChecked();
 
         fptr.lock();
         try {
             if (posix.isNative() && fptr.fd().realFileno != -1) {
-                return posix.libc().isatty(fptr.getFileno()) == 0 ? runtime.getFalse() : runtime.getTrue();
-            } else if (fptr.isStdio()) {
-                // This is a bit of a hack for platforms where we can't do native stdio
-                return runtime.getTrue();
+                // IO is native and we can call isatty
+                return Convert.asBoolean(context, posix.libc().isatty(fptr.getFileno()) == 1);
+            } else if (fptr.isStdio() && runtime.getInstanceConfig().isMain()) {
+                // IO is stdio and JRuby was started through Main, use JVM console status
+                return Convert.asBoolean(context, JVMConsole.isTerminal);
+            } else {
+                // Cannot determine if stdio is a terminal
+                return context.fals;
             }
         } finally {
             fptr.unlock();
         }
-
-        return runtime.getFalse();
     }
 
     // MRI: rb_io_init_copy

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1152,12 +1152,22 @@ public class RubyInstanceConfig {
         this.argvGlobalsOn = argvGlobalsOn;
     }
 
-    public boolean isHardExit() {
-        return hardExit;
+    public boolean isMain() {
+        return main;
     }
 
-    public void setHardExit(boolean hardExit) {
-        this.hardExit = hardExit;
+    public void setMain(boolean main) {
+        this.main = main;
+    }
+
+    @Deprecated(since = "10.0.7.0")
+    public boolean isHardExit() {
+        return main;
+    }
+
+    @Deprecated(since = "10.0.7.0")
+    public void setHardExit(boolean main) {
+        this.main = main;
     }
 
     /**
@@ -1592,7 +1602,7 @@ public class RubyInstanceConfig {
     private boolean managementEnabled = false;
     private String inPlaceBackupExtension = Options.CLI_BACKUP_EXTENSION.load();
     private boolean parserDebug = false;
-    private boolean hardExit = false;
+    private boolean main = false;
     private boolean disableGems = !Options.CLI_RUBYGEMS_ENABLE.load();
     private boolean disableDidYouMean = !Options.CLI_DID_YOU_MEAN_ENABLE.load();
     private boolean disableErrorHighlight = !Options.CLI_ERROR_HIGHLIGHT_ENABLE.load();

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -965,7 +965,8 @@ public class RubyKernel {
         }
 
         if (hard) {
-            if (context.runtime.getInstanceConfig().isHardExit()) {
+            if (context.runtime.getInstanceConfig().isMain()) {
+                // JRuby was started through Main, use a hard exit
                 System.exit(status);
             } else {
                 return new MainExitException(status, true);

--- a/core/src/main/java/org/jruby/main/Main.java
+++ b/core/src/main/java/org/jruby/main/Main.java
@@ -96,16 +96,16 @@ public class Main {
         this(new RubyInstanceConfig());
     }
 
-    private Main(RubyInstanceConfig config, boolean hardExit) {
+    private Main(RubyInstanceConfig config, boolean main) {
         this.config = config;
-        config.setHardExit(hardExit);
+        config.setMain(main);
     }
 
-    private Main(boolean hardExit) {
+    private Main(boolean main) {
         // used only from main(String[]), so we process dotfile here
         processDotfile();
         this.config = new RubyInstanceConfig();
-        config.setHardExit(hardExit);
+        config.setMain(main);
     }
 
     private static List<String> getDotfileDirectories() {

--- a/core/src/main/java/org/jruby/util/cli/JVMConsole.java
+++ b/core/src/main/java/org/jruby/util/cli/JVMConsole.java
@@ -1,0 +1,68 @@
+package org.jruby.util.cli;
+
+import org.jruby.util.SafePropertyAccessor;
+
+import java.io.Console;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Determines whether the JVM process's stdio is connected to a TTY.
+ * </p>
+ * The logic here is based on the {@link System#console()} method with additional checks:
+ * </p>
+ * <li>On Java 21 and lower, we assume a non-null Console indicates a controlling TTY.</li>
+ * <li>On Java 22 and later, we additionally check {@link java.io.Console#isTerminal()}.</li>
+ * <li>If the specification version cannot be determined, or we are on 22+ and cannot call isTerminal, we return false.</li>
+ * </p>
+ * See https://github.com/jruby/jruby/issues/9590 for some discussion on the JRuby side.
+ * </p>
+ * See https://bugs.openjdk.org/browse/JDK-8361911 for an OpenJDK issue describing the changing behavior of System.console().
+ */
+public class JVMConsole {
+    public static final Console console = System.console();
+    public static final boolean isTerminal = isTerminal(console);
+
+    static boolean isTerminal(Console console) {
+        if (console == null) {
+            return false;
+        } else {
+            // There's a bug in JDK 22 where it always returns non-null System.console(), so we have further checks.
+            String specVersion = SafePropertyAccessor.getProperty("java.specification.version");
+
+            if (specVersion == null) {
+                // cannot determine spec, cannot trust console
+                return false;
+            } else {
+                try {
+                    int specVersionInt = Integer.parseInt(specVersion);
+                    if (specVersionInt < 22) {
+                        // Assume JDK 21 and lower return null for non-terminal
+                        return true;
+                    } else {
+                        // double check isTerminal on JDK 22+
+                        return checkConsoleTerminal(console);
+                    }
+                } catch (NumberFormatException e) {
+                    // can't parse spec version, cannot trust console
+                    return false;
+                }
+            }
+        }
+    }
+
+    /**
+     * Reflectively call Console.isTerminal as an additional verification that the Console is a TTY.
+     *
+     * @param console the Console returned by {@link System#console()}
+     * @return the result of isTerminal() if it could be called, false otherwise
+     */
+    private static boolean checkConsoleTerminal(Console console) {
+        try {
+            return (Boolean) Console.class.getMethod("isTerminal").invoke(console);
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException |
+                 InvocationTargetException e) {
+            // can't invoke isTerminal method, return false
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -29,8 +29,6 @@
 
 package org.jruby.util.cli;
 
-import java.io.Console;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,28 +56,7 @@ import static org.jruby.RubyInstanceConfig.CompileMode;
  */
 public class Options {
     private static final List<Option> _loadedOptions = new ArrayList<>(240);
-    private static final boolean COLOR;
-
-    static {
-        boolean isatty;
-        Console console = System.console();
-
-        if (console == null) {
-            isatty = false;
-        } else if (Integer.parseInt(SafePropertyAccessor.getProperty("java.specification.version", "21")) <= 21) {
-            isatty = true;
-        } else {
-            // Java 22 always returns a Console so we have to check for tty with isTerminal()
-            try {
-                isatty = (Boolean) Console.class.getMethod("isTerminal").invoke(console);
-            } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException |
-                     InvocationTargetException e) {
-                isatty = false;
-            }
-        }
-
-        COLOR = isatty;
-    }
+    private static final boolean COLOR = JVMConsole.isTerminal;
 
     public static final String IR_PRINT_PATTERN_NO_PATTERN_STRING = "<NO_PATTERN>";
 

--- a/spec/ruby/core/io/shared/tty.rb
+++ b/spec/ruby/core/io/shared/tty.rb
@@ -21,4 +21,21 @@ describe :io_tty, shared: true do
   it "raises IOError on closed stream" do
     -> { IOSpecs.closed_io.send @method }.should raise_error(IOError)
   end
+
+  it "returns false for stdio streams if they not connected to a terminal" do
+    skip "requires STDOUT and STDERR to be terminal devices" unless STDOUT.tty? && STDERR.tty?
+    begin
+      io = IO.popen(ruby_cmd('print [STDIN.tty?, STDOUT.tty?, STDERR.tty?].inspect'), "r")
+      io.read.should == "[true, false, true]"
+    ensure
+      io&.close
+    end
+
+    begin
+      io = IO.popen(ruby_cmd('print [STDIN.tty?, STDOUT.tty?, STDERR.tty?].inspect'), "r+")
+      io.read.should == "[false, false, true]"
+    ensure
+      io&.close
+    end
+  end
 end


### PR DESCRIPTION
This introduces some cleanup and improvements in how we determine whether an IO is a TTY (`IO#tty?` method):

* If the IO has a proper native file descriptor and we can call `isatty`, use that result.
* Otherwise, if the IO was set up as user-facing stdio AND the current JRuby was started via `Main`, use the JDK's `System.console()` and `Console.isTerminal()`.
* Otherwise, treat the IO as a non-terminal.

This should address situations where JRuby has been embedded as part of a larger application with user-facing stdio streams connected to non-terminal channels, such as in #9590 (deployed in Tomcat using jruby-rack).

Draft until appropriate tests can be added.