### PR TITLE
Add ruby/spec coverage for the code range of interpolated strings

### DIFF
--- a/spec/ruby/core/string/ascii_only_spec.rb
+++ b/spec/ruby/core/string/ascii_only_spec.rb
@@ -59,6 +59,18 @@ describe "String#ascii_only?" do
     "\x78\x00".dup.force_encoding("UTF-16LE").ascii_only?.should be_false
   end
 
+  it "returns true when interpolating non-String objects into an ASCII only String" do
+    "abc#{1}def".ascii_only?.should be_true
+    "abc#{:sym}def".ascii_only?.should be_true
+    "abc#{1.5}def".ascii_only?.should be_true
+  end
+
+  it "returns false when interpolating a non-String object into a non-ASCII String" do
+    interp = "café#{1}!"
+    interp.ascii_only?.should be_false
+    interp.valid_encoding?.should be_true
+  end
+
   it "returns false when interpolating non ascii strings" do
     base = "EU currency is".dup.force_encoding(Encoding::US_ASCII)
     euro = "\u20AC"

--- a/spec/ruby/core/string/hash_spec.rb
+++ b/spec/ruby/core/string/hash_spec.rb
@@ -6,4 +6,12 @@ describe "String#hash" do
     "abc".hash.should == "abc".hash
     "abc".hash.should_not == "cba".hash
   end
+
+  it "returns the same hash for byte-identical Strings built by interpolation" do
+    interpolated = "abc#{1}def"
+    literal = "abc1def"
+    interpolated.should eql(literal)
+    interpolated.hash.should == literal.hash
+    [interpolated, literal].uniq.size.should == 1
+  end
 end

--- a/spec/ruby/language/heredoc_spec.rb
+++ b/spec/ruby/language/heredoc_spec.rb
@@ -107,6 +107,13 @@ HERE
     SquigglyHeredocSpecs.least_indented_on_the_last_line_single.should == "    a\n  b\nc\n"
   end
 
+  it "returns an ASCII only String for an ASCII only <<~identifier" do
+    value = <<~EOS
+      hello world
+    EOS
+    value.ascii_only?.should be_true
+  end
+
   it "reports line numbers inside HEREDOC with method call" do
     -> {
       <<-HERE.chomp


### PR DESCRIPTION
Follow-up to #9592, per the review note about preferring these tests in the RubySpec suite.

The code range **is** observable from pure Ruby, so specs are possible after all:

- `String#ascii_only?` reads the code range directly.
- `String#hash` disagreeing with `String#eql?` is the user-visible symptom from #9591.

Both are standard methods, and the new specs pass on CRuby, so they are upstreamable to ruby/spec.

### What this adds

- `core/string/ascii_only_spec.rb`: interpolation of a non-String object into an ASCII-only string keeps the string ASCII-only. A second spec checks that real non-ASCII text stays non-ASCII, to guard the opposite error.
- `core/string/hash_spec.rb`: `hash` agrees with `eql?` for byte-identical strings, and `uniq` does not split them.
- `language/heredoc_spec.rb`: an ASCII-only squiggly heredoc is ASCII-only.

### This does not replace the test/jruby test

`test/jruby/test_compound_string_coderange.rb` must stay. The bug only appears in compiled code, and a spec body runs one time, so it stays interpreted. I checked this against a build without the #9592 fix:

| Compile mode | CI target | New specs on an unfixed build |
| --- | --- | --- |
| `compile.mode=JIT`, `jit.threshold=0` | `spec:ruby:fast:jit` | pass, so the bug is missed |
| `compile.mode=FORCE` | none | fail, so the bug is caught |

No CI target runs ruby/spec under FORCE. `spec:precompiled` (`spec:ruby:aot`) is the only FORCE rubyspec task, and it is not in the `ci.yml` matrix. The matrix has `test:jruby:aot`, which runs the `test/jruby` suite.

The `test/jruby` test forces the compiler in a child process, so it stays the guard against a regression. These specs add cross-implementation coverage of the behaviour.

Two of the four specs detect the bug under FORCE: the `String#hash` spec and the `ascii_only?` interpolation spec. The heredoc spec passes on a broken build because the fold does not happen inside a spec block, so treat it as documentation of the expected result.

### Test

Built the branch and ran the three spec files in both JIT and FORCE mode, against a fixed and an unfixed build. On the fixed build the only failures are the two entries already listed in `spec/tags/ruby/language/heredoc_tags.txt`.