### PR TITLE
Invalidate prepended origin module as well as subclasses

### DIFF
--- a/core/src/main/java/org/jruby/PrependedModule.java
+++ b/core/src/main/java/org/jruby/PrependedModule.java
@@ -215,4 +215,16 @@ public class PrependedModule extends RubyClass implements DelegatedModule {
         return origin.getAutoloadMapForWrite();
     }
 
+    /**
+     * If the origin was a module, also invalidate its hierarchies
+     */
+    @Override
+    public void invalidateCacheDescendants(ThreadContext context) {
+        super.invalidateCacheDescendants(context);
+
+        if (origin.isModule()) {
+            origin.invalidateCacheDescendants(context);
+        }
+    }
+
 }

--- a/spec/jruby/language/method_cache_spec.rb
+++ b/spec/jruby/language/method_cache_spec.rb
@@ -1,0 +1,23 @@
+describe "A module with a prepend" do
+  describe "when its method table is modified" do
+    it "invalidates previously cached calls" do
+      module A
+        def foo
+          "foo"
+        end
+      end
+      class X
+        include A
+      end
+      A.prepend(Module.new)
+      call_foo = ->{ X.new.foo }
+      expect(call_foo.()).to eq "foo"
+      module A
+        def foo
+          "foo2"
+        end
+      end
+      expect(call_foo.()).to eq "foo2"
+    end
+  end
+end


### PR DESCRIPTION
When a module is prepended into another module, there's no subclass relationship for normal down-hierarchy invalidation. Instead, we actively invalidate the origin module's including hierarchies as well as classes down the hierarchy.

PrependedModule becomes the new location for the origin's method table, so when it is updated the origin must also be invalidated.

There's probably too much complexity here and this might be fixable by also moving the included hierarchies into the PrependedModule, but I did not validate that all places updating this hierarchy are aware of the `methodLocation`. An audit of this logic should probably happen at some point, and `PrependedModule` might be better renamed to `RelocatedClassGuts` but with a better name, to indicate that it is now the new location for the origin's state. That work is out of scope for this quick fix.

Fixes jruby/jruby#9589

Draft until specs are added.