### PR TITLE
Implement :fiber_switch trace event

### DIFF
--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -23,6 +23,7 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ExecutionContext;
 import org.jruby.runtime.Helpers;
+import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -259,6 +260,8 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         } finally {
             // MRI: fiber_switch re-reads the current fiber; control can return into a different one
             if (currentFiberData.blocking) context.getFiberCurrentThread().incrementBlocking();
+
+            context.trace(RubyEvent.FIBER_SWITCH, "resume", context.runtime.getFiber());
         }
     }
 
@@ -588,6 +591,8 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
 
                         // Whether we already gave up our blocking-count contribution
                         boolean handedBack = false;
+
+                        ctxt.trace(RubyEvent.FIBER_SWITCH, null, null, null, 0);
 
                         try {
                             FiberRequest result;

--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -107,7 +107,6 @@ public class TracePoint extends RubyObject {
             synchronized (this) {
                 inside = true;
 
-                if (file == null) file = "(ruby)";
                 if (type == null) type = context.fals;
 
                 IRubyObject binding;

--- a/core/src/main/java/org/jruby/runtime/RubyEvent.java
+++ b/core/src/main/java/org/jruby/runtime/RubyEvent.java
@@ -24,6 +24,7 @@ public enum RubyEvent {
     B_RETURN ("b_return"),
     THREAD_BEGIN   ("thread_begin", false),
     THREAD_END ("thread_end", false),
+    FIBER_SWITCH ("fiber_switch", false),
     RAISE    ("raise", false),
     COVERAGE ("coverage"),
     // A_CALL is CALL + B_CALL + C_CALL


### PR DESCRIPTION
This is mostly working, but does not yet pass CRuby's test_fiber_switch in test_setttracefunc.rb for a few reasons:

* The current thread check there is incompatible with JRuby's Thread.current being different for each Fiber.
* Raise events are not being triggered from Fiber.raise or Fiber errors.

As usual, for accurate file and line numbers, it should be run with --debug.

Might be enough for jruby/jruby#9600.