### PR TITLE
Fix Fiber.schedule inside a non-blocking Fiber

### DIFF
--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -810,7 +810,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         // MRI: rb_fiber_s_schedule_kw and rb_fiber_s_schedule, kw passes on context
         @JRubyMethod(name = "schedule", meta = true, rest = true, keywords = true)
         public static IRubyObject schedule(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
-            IRubyObject scheduler = context.getThread().getScheduler();
+            IRubyObject scheduler = context.getFiberCurrentThread().getScheduler();
             if (scheduler.isNil()) throw runtimeError(context, "No scheduler is available!");
             return scheduler.callMethod(context, "fiber", args, block);
         }

--- a/spec/ruby/core/fiber/fixtures/scheduler.rb
+++ b/spec/ruby/core/fiber/fixtures/scheduler.rb
@@ -11,6 +11,11 @@ module FiberSpecs
       Fiber.yield
     end
 
+    def fiber(*args, &block)
+      @events << { event: :fiber, fiber: Fiber.current, args: args }
+      Fiber.new(blocking: false, &block).tap(&:resume)
+    end
+
     def io_wait(*args)
       @events << { event: :io_wait, fiber: Fiber.current, args: args }
       Fiber.yield

--- a/spec/ruby/core/fiber/schedule_spec.rb
+++ b/spec/ruby/core/fiber/schedule_spec.rb
@@ -1,0 +1,69 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/scheduler'
+
+describe "Fiber.schedule" do
+  describe "when no scheduler is set" do
+    it "raises a RuntimeError" do
+      Fiber.scheduler.should == nil
+
+      -> {
+        Fiber.schedule { }
+      }.should.raise(RuntimeError)
+    end
+  end
+
+  describe "when a scheduler is set" do
+    before :each do
+      @scheduler = FiberSpecs::LoggingScheduler.new
+      Fiber.set_scheduler(@scheduler)
+    end
+
+    after :each do
+      Fiber.set_scheduler(nil)
+    end
+
+    it "calls the scheduler's #fiber hook" do
+      Fiber.schedule { }
+      @scheduler.events.map { |event| event[:event] }.should == [:fiber]
+    end
+
+    it "returns the Fiber which runs the block" do
+      scheduled = nil
+      fiber = Fiber.schedule { scheduled = Fiber.current }
+      fiber.should.equal?(scheduled)
+    end
+
+    it "can be called from inside a non-blocking Fiber" do
+      inner = nil
+
+      outer = Fiber.new(blocking: false) do
+        inner = Fiber.schedule { }
+      end
+      outer.resume
+
+      inner.should.is_a?(Fiber)
+    end
+
+    it "uses the scheduler of the Thread owning the Fiber it is called from" do
+      seen = nil
+
+      outer = Fiber.new(blocking: false) do
+        Fiber.schedule { seen = Fiber.scheduler }
+      end
+      outer.resume
+
+      seen.should.equal?(@scheduler)
+    end
+
+    it "runs the block in a Fiber which sees the scheduler as its current scheduler" do
+      seen = nil
+
+      outer = Fiber.new(blocking: false) do
+        Fiber.schedule { seen = Fiber.current_scheduler }
+      end
+      outer.resume
+
+      seen.should.equal?(@scheduler)
+    end
+  end
+end

--- a/spec/tags/ruby/core/fiber/schedule_tags.txt
+++ b/spec/tags/ruby/core/fiber/schedule_tags.txt
@@ -1,0 +1,1 @@
+fails:Fiber.schedule when a scheduler is set runs the block in a Fiber which sees the scheduler as its current scheduler


### PR DESCRIPTION
Fiber.schedule looked up the scheduler on the Fiber's carrier thread rather than the Thread that owns it, so calling it from inside a non-blocking Fiber raised "No scheduler is available!". Use getFiberCurrentThread(), like Fiber.scheduler and MRI's rb_fiber_s_schedule.

Specs come from ruby/spec#1388 (merged) and three of the six fail without this. One is tagged for a separate blocking-count bug (passes when run in isolation but fails when run with other fiber tests).

On master the following tests fail with  `RuntimeError: No scheduler is available!`:

- Fiber.schedule when a scheduler is set can be called from inside a non-blocking Fiber
- Fiber.schedule when a scheduler is set uses the scheduler of the Thread owning the Fiber it is called from
- Fiber.schedule when a scheduler is set runs the block in a Fiber which sees the scheduler as its current scheduler

(The last one is the one that fails on this branch too when run with other fiber tests but passes when you just run `spec/ruby/core/fiber/schedule_spec.rb`)