### PR TITLE
Fix Thread blocking count drifting across Fiber switches

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -252,6 +252,9 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     private static final AtomicIntegerFieldUpdater<RubyThread> INTERRUPT_FLAG_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(RubyThread.class, "interruptFlag");
 
+    private static final AtomicIntegerFieldUpdater<RubyThread> BLOCKING_COUNT_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(RubyThread.class, "blockingCount");
+
     private static final int TIMER_INTERRUPT_MASK         = 0x01;
     private static final int PENDING_INTERRUPT_MASK       = 0x02;
     private static final int POSTPONED_JOB_INTERRUPT_MASK = 0x04;
@@ -2765,11 +2768,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     public void incrementBlocking() {
-        blockingCount++;
+        BLOCKING_COUNT_UPDATER.incrementAndGet(this);
     }
 
     public void decrementBlocking() {
-        blockingCount--;
+        assert blockingCount > 0 : "blocking count would go negative";
+        BLOCKING_COUNT_UPDATER.decrementAndGet(this);
     }
 
     public boolean isBlocking() {

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -193,10 +193,6 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             data.prev = null;
         }
 
-        if (data.blocking) {
-            context.getFiberCurrentThread().decrementBlocking();
-        }
-
         if (result.type == RequestType.RAISE) {
             throw (RuntimeException) result.data;
         }
@@ -231,6 +227,9 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
     private static final FiberRequest NEVER = new FiberRequest(RubyBasicObject.NEVER, RequestType.DATA);
 
     private static FiberRequest exchangeWithFiber(ThreadContext context, FiberData currentFiberData, FiberData targetFiberData, FiberRequest request) {
+        // MRI: fiber_switch. Must precede the push, which wakes the target fiber's thread
+        if (currentFiberData.blocking) context.getFiberCurrentThread().decrementBlocking();
+
         // push should not block and does not check interrupts
         targetFiberData.queue.push(context, request);
 
@@ -241,8 +240,6 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         // interrupted again and must abandon the fiber.
 
         try {
-            adjustThreadBlocking(context, currentFiberData, targetFiberData);
-
             return currentFiberData.queue.pop(context);
         } catch (RaiseException re) {
             handleExceptionDuringExchange(context, currentFiberData, targetFiberData, re);
@@ -250,19 +247,8 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             // if we get here, we forwarded exception so try once more
             return currentFiberData.queue.pop(context);
         } finally {
-            adjustThreadBlocking(context, targetFiberData, currentFiberData);
-        }
-    }
-
-    private static void adjustThreadBlocking(ThreadContext context, FiberData currentFiberData, FiberData targetFiberData) {
-        // if fiber we are leaving is blocking, decrement thread blocking count
-        if (currentFiberData.blocking) {
-            context.getFiberCurrentThread().decrementBlocking();
-        }
-
-        // if fiber we are entering is blocking, increment thread blocking count
-        if (targetFiberData.blocking) {
-            context.getFiberCurrentThread().incrementBlocking();
+            // MRI: fiber_switch re-reads the current fiber; control can return into a different one
+            if (currentFiberData.blocking) context.getFiberCurrentThread().incrementBlocking();
         }
     }
 
@@ -510,6 +496,12 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
                     try {
                         FiberRequest init = data.queue.pop(ctxt);
 
+                        // MRI: rb_fiber_start. A first run does not return through a switch
+                        if (data.blocking) data.parent.incrementBlocking();
+
+                        // Whether we already gave up our blocking-count contribution
+                        boolean handedBack = false;
+
                         try {
                             FiberRequest result;
 
@@ -530,8 +522,15 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
                             ThreadFiber tf = data.fiber.get();
                             if (tf != null) tf.thread = null;
 
+                            // MRI: rb_fiber_terminate, which switches away. Decrement before handing back
+                            if (data.blocking) data.parent.decrementBlocking();
+                            handedBack = true;
+
                             data.prev.data.queue.push(ctxt, result);
                         } finally {
+                            // MRI: rb_fiber_terminate, for raise, kill or flow control
+                            if (!handedBack && data.blocking) data.parent.decrementBlocking();
+
                             // Ensure we do everything for shutdown now
                             data.queue.shutdown();
                             context.runtime.getThreadService().unregisterCurrentThread(ctxt);

--- a/spec/ruby/core/fiber/current_scheduler_spec.rb
+++ b/spec/ruby/core/fiber/current_scheduler_spec.rb
@@ -1,0 +1,85 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/scheduler'
+
+describe "Fiber.current_scheduler" do
+  it "returns nil when no scheduler is set" do
+    Fiber.scheduler.should == nil
+    Fiber.current_scheduler.should == nil
+  end
+
+  describe "when a scheduler is set" do
+    before :each do
+      @scheduler = FiberSpecs::LoggingScheduler.new
+      Fiber.set_scheduler(@scheduler)
+    end
+
+    after :each do
+      Fiber.set_scheduler(nil)
+    end
+
+    it "returns nil on the root Fiber, which is blocking" do
+      Fiber.current_scheduler.should == nil
+    end
+
+    it "returns the scheduler inside a non-blocking Fiber" do
+      seen = nil
+      Fiber.new(blocking: false) { seen = Fiber.current_scheduler }.resume
+      seen.should.equal?(@scheduler)
+    end
+
+    it "returns nil inside a blocking Fiber, where Fiber.scheduler still returns the scheduler" do
+      seen = nil
+      Fiber.new(blocking: true) { seen = [Fiber.scheduler, Fiber.current_scheduler] }.resume
+      seen.should == [@scheduler, nil]
+    end
+
+    it "returns nil inside a blocking Fiber nested in a non-blocking Fiber" do
+      seen = nil
+      Fiber.new(blocking: false) do
+        Fiber.new(blocking: true) { seen = Fiber.current_scheduler }.resume
+      end.resume
+      seen.should == nil
+    end
+
+    it "returns the scheduler inside a non-blocking Fiber nested in a blocking Fiber" do
+      seen = nil
+      Fiber.new(blocking: true) do
+        Fiber.new(blocking: false) { seen = Fiber.current_scheduler }.resume
+      end.resume
+      seen.should.equal?(@scheduler)
+    end
+
+    it "returns nil inside Fiber.blocking in a non-blocking Fiber" do
+      seen = nil
+      Fiber.new(blocking: false) { Fiber.blocking { seen = Fiber.current_scheduler } }.resume
+      seen.should == nil
+    end
+
+    it "returns the scheduler again after Fiber.blocking returns" do
+      seen = nil
+      Fiber.new(blocking: false) do
+        Fiber.blocking { }
+        seen = Fiber.current_scheduler
+      end.resume
+      seen.should.equal?(@scheduler)
+    end
+
+    it "returns nil on the root Fiber after a blocking Fiber has finished" do
+      Fiber.new(blocking: true) { }.resume
+      Fiber.current_scheduler.should == nil
+    end
+
+    it "returns nil on the root Fiber after a blocking Fiber has raised" do
+      fiber = Fiber.new(blocking: true) { raise "from the fiber" }
+      -> { fiber.resume }.should.raise(RuntimeError)
+      Fiber.current_scheduler.should == nil
+    end
+
+    it "returns nil on the root Fiber after a blocking Fiber has been killed" do
+      fiber = Fiber.new(blocking: true) { Fiber.yield }
+      fiber.resume
+      fiber.kill
+      Fiber.current_scheduler.should == nil
+    end
+  end
+end

--- a/spec/tags/ruby/core/fiber/schedule_tags.txt
+++ b/spec/tags/ruby/core/fiber/schedule_tags.txt
@@ -1,1 +1,0 @@
-fails:Fiber.schedule when a scheduler is set runs the block in a Fiber which sees the scheduler as its current scheduler


### PR DESCRIPTION
Fiber.current_scheduler reads the Thread's blocking count, and it drifted both ways: Fiber#resume decremented a target that exchangeWithFiber had already decremented, and the hand-back was counted twice. Account like MRI's fiber_switch instead, where each Fiber adjusts only for itself.

Adds core/fiber/current_scheduler_spec.rb from ruby/spec#1388 and drops the tag added in #9604. Also adds additional root Fiber specs from ruby/spec#1390.

Not as simple a change as https://github.com/jruby/jruby/pull/9604, but this should fix the blocking count drift. 

Of the added tests, 5 of 11 fail on master. Failing ones:
```
returns nil inside a blocking Fiber nested in a non-blocking Fiber
returns nil inside Fiber.blocking in a non-blocking Fiber
returns nil on the root Fiber after a blocking Fiber has finished
returns nil on the root Fiber after a blocking Fiber has raised
returns nil on the root Fiber after a blocking Fiber has been killed
```

Oneliner to test the drift: 
`jruby -e 'require "jruby"; f = org.jruby.RubyThread.java_class.declared_field("blockingCount"); f.accessible = true; c = -> { f.get(JRuby.reference(Thread.current)) }; puts "before: #{c.call}"; 20_000.times { Fiber.new(blocking: true) { }.resume }; puts "after:  #{c.call}"'`

Master: 
before: 1
after:  -19999

This branch: 
before: 1
after:  1