### PR TITLE
Fix :core specs run to not execve() in the middle

### DIFF
--- a/spec/ruby/core/process/exec_spec.rb
+++ b/spec/ruby/core/process/exec_spec.rb
@@ -240,20 +240,23 @@ describe "Process.exec" do
   end
 
   describe "options validation" do
+    # Use a non-existent command to prevent unexpected execve() calls and
+    # provide clearer failures if options aren't validated.
+
     it "raises an ArgumentError if :unsetenv_others option is not a boolean or nil" do
-      -> { Process.exec("true", unsetenv_others: 1) }.should.raise(ArgumentError, /expected true or false/)
-      -> { Process.exec("true", unsetenv_others: "true") }.should.raise(ArgumentError, /expected true or false/)
+      -> { Process.exec("should_raise_before_and_not_run", unsetenv_others: 1) }.should.raise(ArgumentError, /expected true or false/)
+      -> { Process.exec("should_raise_before_and_not_run", unsetenv_others: "true") }.should.raise(ArgumentError, /expected true or false/)
     end
 
     it "raises an ArgumentError if :close_others option is not a boolean or nil" do
-      -> { Process.exec("true", close_others: 1) }.should.raise(ArgumentError, /expected true or false/)
-      -> { Process.exec("true", close_others: "true") }.should.raise(ArgumentError, /expected true or false/)
+      -> { Process.exec("should_raise_before_and_not_run", close_others: 1) }.should.raise(ArgumentError, /expected true or false/)
+      -> { Process.exec("should_raise_before_and_not_run", close_others: "true") }.should.raise(ArgumentError, /expected true or false/)
     end
 
     platform_is :windows do
       it "raises an ArgumentError if :new_pgroup option is not a boolean or nil" do
-        -> { Process.exec("true", new_pgroup: 1) }.should.raise(ArgumentError, /expected true or false/)
-        -> { Process.exec("true", new_pgroup: "true") }.should.raise(ArgumentError, /expected true or false/)
+        -> { Process.exec("should_raise_before_and_not_run", new_pgroup: 1) }.should.raise(ArgumentError, /expected true or false/)
+        -> { Process.exec("should_raise_before_and_not_run", new_pgroup: "true") }.should.raise(ArgumentError, /expected true or false/)
       end
     end
   end

--- a/spec/tags/ruby/core/io/getbyte_tags.txt
+++ b/spec/tags/ruby/core/io/getbyte_tags.txt
@@ -1,1 +1,2 @@
 windows:IO#getbyte returns the next byte from the stream
+fails:IO#getbyte reads after ungetc without character conversion

--- a/spec/tags/ruby/core/io/popen_tags.txt
+++ b/spec/tags/ruby/core/io/popen_tags.txt
@@ -19,3 +19,6 @@ windows(hangs):IO.popen does not throw an exception if child exited and has been
 windows:IO.popen raises IOError when writing a read-only pipe
 windows:IO.popen accepts a path using the chdir: keyword argument
 windows:IO.popen accepts a path using the chdir: keyword argument and a coercible path
+fails:IO.popen options validation raises an ArgumentError if :unsetenv_others option is not a boolean or nil
+fails:IO.popen options validation raises an ArgumentError if :close_others option is not a boolean or nil
+fails:IO.popen options validation raises an ArgumentError if :new_pgroup option is not a boolean or nil

--- a/spec/tags/ruby/core/io/read_tags.txt
+++ b/spec/tags/ruby/core/io/read_tags.txt
@@ -15,3 +15,4 @@ windows:IO#read with internal encoding not specified does not transcode the Stri
 windows:IO.read from a pipe warns about deprecation
 
 fails:IO.read from a pipe raises Errno::EINVAL when path starts with a pipe
+fails:IO#read with internal encoding not specified reads after ungetc

--- a/spec/tags/ruby/core/io/readbyte_tags.txt
+++ b/spec/tags/ruby/core/io/readbyte_tags.txt
@@ -1,0 +1,1 @@
+fails:IO#readbyte reads after ungetc without character conversion

--- a/spec/tags/ruby/core/io/reopen_tags.txt
+++ b/spec/tags/ruby/core/io/reopen_tags.txt
@@ -19,3 +19,7 @@ windows:IO#reopen with an IO at EOF resets the EOF status to false
 windows:IO#reopen with an IO always resets the close-on-exec flag to true on non-STDIO objects
 windows:IO#reopen with an IO may change the class of the instance
 windows:IO#reopen with an IO sets path equals to the other IO's path if other IO is File
+fails:IO#reopen with a String opens the file in read mode if the IO is read-only
+fails:IO#reopen with a String opens the file in write mode if the IO is write-only
+fails:IO#reopen with a String opens the file in read-write mode if the IO is read-write
+fails:IO#reopen with a String opens the file in append mode if the IO appends

--- a/spec/tags/ruby/core/io/write_tags.txt
+++ b/spec/tags/ruby/core/io/write_tags.txt
@@ -4,3 +4,5 @@ windows:IO#write on Windows normalizes line endings in text mode
 fails:IO#write on STDOUT raises SignalException SIGPIPE if the stream is closed instead of Errno::EPIPE like other IOs
 
 windows:IO#write on a pipe raises Errno::EPIPE if the read end is closed and does not die from SIGPIPE
+fails:IO#write on a file writes binary data with newline conversion if no encoding is given
+fails:IO#write on a file writes binary data with newline conversion if encoding is ASCII-8BIT

--- a/spec/tags/ruby/core/process/exec_tags.txt
+++ b/spec/tags/ruby/core/process/exec_tags.txt
@@ -20,3 +20,6 @@ windows:Process.exec flushes STDERR upon exit when it's not set to sync
 windows:Process.exec with a single argument does not subject the specified command to shell expansion on Windows
 windows:Process.exec with a single argument does not create an argument array with shell parsing semantics for whitespace on Windows
 windows:Process.exec with multiple arguments does not subject the arguments to shell expansion
+fails:Process.exec options validation raises an ArgumentError if :unsetenv_others option is not a boolean or nil
+fails:Process.exec options validation raises an ArgumentError if :close_others option is not a boolean or nil
+fails:Process.exec options validation raises an ArgumentError if :new_pgroup option is not a boolean or nil

--- a/spec/tags/ruby/core/process/kill_tags.txt
+++ b/spec/tags/ruby/core/process/kill_tags.txt
@@ -13,3 +13,5 @@ windows:Process.kill acceps an Integer as a signal value
 windows:Process.kill calls #to_int to coerce the pid to an Integer
 windows:Process.kill signals multiple processes
 windows:Process.kill returns the number of processes signaled
+fails:Process.kill runs a registered signal handler immediately if called with the current process PID on the main Thread
+fails:Process.kill runs a registered signal handler later on the main Thread if called with the current process PID on a non-main Thread

--- a/spec/tags/ruby/core/process/spawn_tags.txt
+++ b/spec/tags/ruby/core/process/spawn_tags.txt
@@ -71,3 +71,6 @@ fails:Process.spawn sets $? to exit status 127 when the file does not exist
 fails:Process.spawn raises an Errno::EACCES when the path is a directory
 fails:Process.spawn raises an Errno::ENOENT when a non-executable file is found in PATH
 fails:Process.spawn when passed :chdir raises an Errno::ENOENT when a given path doesn't exist
+fails:Process.spawn raises an ArgumentError if :unsetenv_others option is not a boolean or nil
+fails:Process.spawn raises an ArgumentError if :close_others option is not a boolean or nil
+fails:Process.spawn raises an ArgumentError if :new_pgroup option is not a boolean or nil

--- a/spec/tags/ruby/core/process/status/wait_tags.txt
+++ b/spec/tags/ruby/core/process/status/wait_tags.txt
@@ -1,2 +1,3 @@
 fails:Process::Status.wait doesn't block if no child is available when WNOHANG is used
 windows:Process::Status.wait returns a status with pid -1 if there are no child processes
+fails:An exception occurred during: before :all


### PR DESCRIPTION
* This avoids the spec process execve()'ing in the middle, as described in https://github.com/jruby/jruby/issues/9609