### PR TITLE
Add tag for failing spec

### DIFF
--- a/spec/tags/ruby/core/mutex/lock_tags.txt
+++ b/spec/tags/ruby/core/mutex/lock_tags.txt
@@ -1,0 +1,1 @@
+fails:Mutex#lock does not raise deadlock if a fiber's attempt to lock was interrupted


### PR DESCRIPTION
https://github.com/jruby/jruby/actions/runs/33218877185/job/99008508286
```
[3](https://github.com/jruby/jruby/actions/runs/33218877185/job/99008508286#step:7:74)
1)
Mutex#lock does not raise deadlock if a fiber's attempt to lock was interrupted ERROR
ThreadError: deadlock; lock already owned by another fiber belonging to the same thread
org/jruby/ext/thread/Mutex.java:111:in 'lock'
org/jruby/ext/thread/Mutex.java:194:in 'synchronize'
D:/a/jruby/jruby/spec/ruby/core/mutex/lock_spec.rb:70:in 'block in <main>'
org/jruby/RubyKernel.java:1868:in 'loop'
D:/a/jruby/jruby/spec/ruby/core/mutex/lock_spec.rb:70:in 'block in <main>'
```