### PR TITLE
Restore "default" target for several suites

### DIFF
--- a/rakelib/helpers.rb
+++ b/rakelib/helpers.rb
@@ -82,23 +82,22 @@ def permute_specs(base_name, options, *prereqs, &block)
 end
 
 def permute_task(task_desc, task_type, base_name, options, *prereqs, &block)
-  default_task = nil
   all_tasks = nil
 
   # iterate over all flag sets, noting default mapping
   tasks = {}
-  options.each do |name, flags|
-    if name == :default
-      default_task = flags
-      next
-    end
-
-    if name == :all
+  options.uniq.each do |name, flags|
+    case name
+    when :default
+      task_name = base_name
+    when :all
       all_tasks = flags
       next
+    else
+      task_name = "#{base_name}:#{name}"
     end
 
-    test_task = task_type.new("#{base_name}:#{name}", &block).tap do |t|
+    test_task = task_type.new(task_name, &block).tap do |t|
       t.ruby_opts ||= []
       flags.each do |flag|
         t.ruby_opts.unshift flag
@@ -109,12 +108,6 @@ def permute_task(task_desc, task_type, base_name, options, *prereqs, &block)
       t.add_description "#{flags.inspect}"
       t.prerequisites.concat prereqs
     end
-  end
-
-  # set up default, if specified
-  if default_task
-    desc "Run #{task_desc}s for #{default_task}"
-    task base_name => tasks[default_task]
   end
 
   # set up "all", if specified, or make it run everything

--- a/rakelib/rspec.rake
+++ b/rakelib/rspec.rake
@@ -25,7 +25,7 @@ namespace :spec do
   rake_location = File.join(Gem.loaded_specs['rake'].full_gem_path, "lib")
 
   compile_flags = {
-    :default => :int,
+    :default => [],
     :int => ["-X-C"],
     :jit => ["-Xjit.threshold=0"],
     :aot => ["-X+C"],


### PR DESCRIPTION
The default target was not being set up correctly, depending on a task that was never created and terminating without doing anything.

This change restores the default target using the base name of the task group and removes most of the custom logic for setting it up.

Fixes jruby/jruby#9613