### PR TITLE
Return Fiber's parent thread for Thread.current

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -977,7 +977,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(meta = true)
     public static RubyThread current(IRubyObject recv) {
-        return recv.getRuntime().getCurrentContext().getThread();
+        return recv.getRuntime().getCurrentContext().getFiberCurrentThread();
     }
 
     @JRubyMethod(meta = true)


### PR DESCRIPTION
A few step toward getting Thread.current in general to behave like CRuby, returning the same Thread for all Fiber instances that it owns.

Behind the scenes, each Fiber is still backed by a VirtualThread with an associated ThreadContext and RubyThread, but user code should generally not see those.

Additional fixes will follow for internal code that has expectations about the current thread of a fiber.

See other attempts to do this and issues related:

* My attempt: https://github.com/jruby/jruby/pull/5827
* Community attempt: https://github.com/jruby/jruby/pull/1225
* An early issue: https://github.com/jruby/jruby/issues/1806

Relates to test failures mentioned in jruby/jruby#9603 and workarounds from users in jruby/jruby#9600.