### PR TITLE
Defer Kernel#sleep to the Fiber scheduler

### DIFF
--- a/core/src/main/java/org/jruby/FiberScheduler.java
+++ b/core/src/main/java/org/jruby/FiberScheduler.java
@@ -4,6 +4,7 @@ import jnr.constants.platform.Errno;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.cli.Options;
 import org.jruby.util.io.OpenFile;
 
 import java.nio.ByteBuffer;
@@ -13,6 +14,15 @@ import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Error.argumentError;
 
 public class FiberScheduler {
+    // MRI: rb_fiber_scheduler_current, null when there is no scheduler to defer to
+    public static IRubyObject current(ThreadContext context) {
+        if (!Options.FIBER_SCHEDULER.load()) return null;
+
+        IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
+
+        return scheduler.isNil() ? null : scheduler;
+    }
+
     // MRI: rb_fiber_scheduler_kernel_sleep
     public static IRubyObject kernelSleep(ThreadContext context, IRubyObject scheduler, IRubyObject timeout) {
         return scheduler.callMethod(context, "kernel_sleep", timeout);

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3377,6 +3377,9 @@ public final class Ruby implements Constantizable {
             context.pushScope(new ManyVarsDynamicScope(topStaticScope, null));
         }
 
+        // MRI: rb_ec_teardown. Run out this thread's scheduler before any at-exit handler
+        context.getFiberCurrentThread().setFiberScheduler(context, context.nil);
+
         // Run all exit functions from user hooks like at_exit
         while (!exitBlocks.isEmpty()) {
             ExitFunction fun = exitBlocks.remove(0);

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -863,15 +863,23 @@ public class RubyKernel {
         return RubyIO.select(context, recv, args);
     }
 
+    // MRI: rb_f_sleep
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject sleep(ThreadContext context, IRubyObject recv) {
+        IRubyObject scheduler = FiberScheduler.current(context);
+        if (scheduler != null) return schedulerSleep(context, scheduler);
+
         // Zero sleeps forever
         return sleepCommon(context, 0);
     }
 
+    // MRI: rb_f_sleep
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject sleep(ThreadContext context, IRubyObject recv, IRubyObject timeout) {
-        if (timeout.isNil()) return sleep(context, recv);
+        IRubyObject scheduler = FiberScheduler.current(context);
+        if (scheduler != null) return schedulerSleep(context, scheduler, timeout);
+
+        if (timeout.isNil()) return sleepCommon(context, 0);
 
         long nanoseconds = (long) (RubyTime.convertTimeInterval(context, timeout) * 1_000_000_000);
 
@@ -879,6 +887,22 @@ public class RubyKernel {
         if (nanoseconds == 0) return RubyFixnum.zero(context.runtime);
 
         return sleepCommon(context, nanoseconds);
+    }
+
+    private static RubyFixnum schedulerSleep(ThreadContext context, IRubyObject scheduler) {
+        final long startTime = System.nanoTime();
+
+        FiberScheduler.kernelSleep(context, scheduler, IRubyObject.NULL_ARRAY);
+
+        return sleptSeconds(context, startTime);
+    }
+
+    private static RubyFixnum schedulerSleep(ThreadContext context, IRubyObject scheduler, IRubyObject timeout) {
+        final long startTime = System.nanoTime();
+
+        FiberScheduler.kernelSleep(context, scheduler, timeout);
+
+        return sleptSeconds(context, startTime);
     }
 
     private static RubyFixnum sleepCommon(ThreadContext context, long nanoseconds) {
@@ -904,6 +928,10 @@ public class RubyKernel {
             if (interrupted) Thread.currentThread().interrupt();
         }
 
+        return sleptSeconds(context, startTime);
+    }
+
+    private static RubyFixnum sleptSeconds(ThreadContext context, long startTime) {
         return asFixnum(context, Math.round((System.nanoTime() - startTime) / 1_000_000_000.0));
     }
 

--- a/spec/tags/ruby/core/kernel/sleep_tags.txt
+++ b/spec/tags/ruby/core/kernel/sleep_tags.txt
@@ -1,2 +1,0 @@
-critical(hangs):Kernel#sleep Kernel#sleep with Fiber scheduler calls the scheduler without arguments when no duration is given
-fails:Kernel#sleep Kernel#sleep with Fiber scheduler calls the scheduler with the given duration

--- a/test/mri/excludes/TestFiberMutex.rb
+++ b/test/mri/excludes/TestFiberMutex.rb
@@ -1,4 +1,6 @@
 exclude :test_condition_variable, "hangs on macos m1"
 exclude :test_mutex_deadlock, "subprocess times out probably not raising deadlock error"
 exclude :test_mutex_fiber_raise, "hangs on macos m1"
+exclude :test_mutex_interleaved_locking, "Thread::Mutex#lock does not defer to Fiber::Scheduler, so a fiber sleeping under the lock blocks its siblings"
+exclude :test_queue, "Thread::Queue#pop does not defer to Fiber::Scheduler, so it blocks the thread that has to run the scheduler"
 exclude :test_queue_pop_waits, "wonky subprocess launching in test"

--- a/test/mri/excludes/TestFiberScheduler.rb
+++ b/test/mri/excludes/TestFiberScheduler.rb
@@ -1,3 +1,4 @@
+exclude :test_autoload, "autoload holds a Java monitor across Fiber switches, so a sibling fiber hangs instead of deferring to the scheduler"
 exclude :test_condition_variable, "hangs on macos M1"
 exclude :test_current_scheduler, "fails intermittently on Linux CI on GHA"
 exclude :test_io_read_error, "not hooked up to Scheduler yet, https://github.com/jruby/jruby/issues/9275"

--- a/test/mri/excludes/TestFiberSleep.rb
+++ b/test/mri/excludes/TestFiberSleep.rb
@@ -1,2 +1,0 @@
-exclude :test_broken_sleep, ""
-exclude :test_sleep, ""


### PR DESCRIPTION
Kernel#sleep never consulted Fiber.scheduler, so a non-blocking Fiber that slept parked its thread instead of yielding. Follow MRI's rb_f_sleep: look up the current scheduler first and hand it the arguments untouched, nil included, before any interval conversion. FiberScheduler.kernelSleep was already written, this just wires it up.

Closing the scheduler at exit is also fixed. MRI's rb_ec_teardown sets the thread's scheduler to nil before at-exit handlers, which runs out the fibers still waiting on it; JRuby only did that for spawned threads, through RubyThread#dispose. Harmless until now, since nothing parked a fiber on the main thread. But with sleep deferring, a fiber sleeping there would never be resumed, skipping the rest of its body and its ensure blocks.

Passes the tests in https://github.com/ruby/spec/pull/1391, while master fails the new "closes the scheduler at exit" spec. 
Follow-up needed: wire `Thread::Queue#pop` and `Thread::Mutex#lock` to `FiberScheduler.block/unblock` and delete the test exclusions added in this PR.