### PR TITLE
Read unnamed modules of the loaders JRuby loads Java classes from

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -634,11 +634,19 @@ public final class Ruby implements Constantizable {
             else {
                 jrubyClassLoader = new SelfFirstJRubyClassLoader(config.getLoader());
             }
+            addReadsUnnamed(jrubyClassLoader);
+            addReadsUnnamed(config.getLoader());
         }
         else {
             jrubyClassLoader = null; // a NullClassLoader object would be better ...
         }
         return jrubyClassLoader;
+    }
+
+    // An automatic module's read edge to unnamed modules comes from Module.defineModules, which
+    // a CDS/AOT archived boot layer skips, so ask for it rather than assume it (jruby/jruby#9319).
+    private static void addReadsUnnamed(ClassLoader loader) {
+        if (loader != null && JRUBY_MODULE.isNamed()) JRUBY_MODULE.addReads(loader.getUnnamedModule());
     }
 
     private void initDefaultEncodings(ThreadContext context) {

--- a/rakelib/rspec.rake
+++ b/rakelib/rspec.rake
@@ -59,7 +59,7 @@ namespace :spec do
     t.pattern = 'spec/grammar/**/*_spec.rb'
   end
 
-  permute_specs "regression", compile_flags do |t|
+  permute_specs "regression", compile_flags, "test:compile" do |t|
     t.rspec_opts ||= []
     t.rspec_opts << '--color --format documentation '
     t.pattern = 'spec/regression/**/*_spec.rb'

--- a/spec/regression/GH-9319_aot_cache_binds_runtime_loaded_java_classes_spec.rb
+++ b/spec/regression/GH-9319_aot_cache_binds_runtime_loaded_java_classes_spec.rb
@@ -1,0 +1,37 @@
+# -*- encoding: utf-8 -*-
+
+# https://github.com/jruby/jruby/issues/9319
+
+require 'tmpdir'
+
+# An AOT-restored boot layer skips Module.defineModules, dropping org.jruby.dist's read
+# edge to the unnamed module JRubyClassLoader loads gem classes into.
+SRC = <<~RUBY
+  $CLASSPATH << 'test/target/test-classes'
+  obj = Java::Java_integrationFixtures::ClassWithSimpleMethod.new
+  puts obj.foo('bar')
+RUBY
+
+def aot_cache_supported?
+  ENV_JAVA['java.specification.version'].to_i >= 25
+end
+
+describe 'a Java class loaded from the JRuby class loader' do
+  before { skip 'requires a JVM with AOT cache support' unless aot_cache_supported? }
+
+  it 'keeps its bound methods when the boot layer comes from an AOT cache' do
+    # --nocache avoids -XX:SharedArchiveFile, which the JVM rejects alongside AOT cache flags.
+    jruby = "#{ENV_JAVA['jruby.home']}/bin/jruby --nocache"
+
+    Dir.mktmpdir('jruby-9319') do |dir|
+      cache = File.join(dir, 'test.aot')
+      script = File.join(dir, 'probe.rb')
+      File.write(script, SRC)
+
+      expect(`#{jruby} -J-XX:AOTCacheOutput=#{cache} #{script} 2>&1`).to include('foobar')
+      expect(File).to exist(cache)
+
+      expect(`#{jruby} -J-XX:AOTCache=#{cache} #{script} 2>&1`).to include('foobar')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #9319.

org.jruby.dist is an automatic module, and automatic modules get their read edge to unnamed modules from Module.defineModules at boot. An AOT-archived boot layer skips that, and the edge lives in Module.ReflectionData.reads, which isn't archived -- while resolved 
eads sets survive inside the archived Module objects. Hence JDK classes keep binding and gem-jar classes stop. This asks for the edge instead of assuming it.

Verified on JDK 26.0.1+8-34: with -XX:AOTCache, canRead false -> true and the methods come back.