### PR TITLE
Handle nil-or-boolean arguments in popen kwargs

### DIFF
--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -54,6 +54,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.function.BiFunction;
 
+import static org.jruby.api.Check.checkBoolean;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asFloat;
@@ -404,11 +405,10 @@ public class RubyComplex extends RubyNumeric {
         if (maybeKwargs.isNil()) return convertCommon(context, recv, a1, a2, true);
 
         IRubyObject exception = ArgsUtil.extractKeywordArg(context, "exception", (RubyHash) maybeKwargs);
-        if (exception instanceof RubyBoolean) {
-            return a1 instanceof RubyComplex ? a1 : convertCommon(context, recv, a1, null, exception.isTrue());
-        }
 
-        throw argumentError(context, "'Complex': expected true or false as exception: " + exception);
+        boolean exceptionBool = checkBoolean(context,  exception, "exception", true);
+
+        return a1 instanceof RubyComplex ? a1 : convertCommon(context, recv, a1, null, exceptionBool);
     }
 
     /** nucomp_s_convert
@@ -422,11 +422,10 @@ public class RubyComplex extends RubyNumeric {
         if (maybeKwargs.isNil()) throw argumentError(context, 3, 1, 2);
 
         IRubyObject exception = ArgsUtil.extractKeywordArg(context, "exception", (RubyHash) maybeKwargs);
-        if (exception instanceof RubyBoolean) {
-            return convertCommon(context, recv, a1, a2, exception.isTrue());
-        }
 
-        throw argumentError(context, "'Complex': expected true or false as exception: " + exception);
+        boolean exceptionBool = checkBoolean(context,  exception, "exception", true);
+
+        return convertCommon(context, recv, a1, a2, exceptionBool);
     }
 
     // MRI: nucomp_convert

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -71,6 +71,7 @@ import static org.jruby.RubyString.UTF8;
 import static org.jruby.api.Access.dirClass;
 import static org.jruby.api.Access.encodingService;
 import static org.jruby.api.Access.objectClass;
+import static org.jruby.api.Check.checkBoolean;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
@@ -82,7 +83,6 @@ import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.notImplementedError;
 import static org.jruby.api.Error.runtimeError;
 import static org.jruby.api.Warn.warn;
-import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.io.EncodingUtils.newExternalStringWithEncoding;
 
 /**
@@ -246,10 +246,8 @@ public class RubyDir extends RubyObject implements Closeable {
                 if (processFlags && rets[2] != null) options.flags |= toInt(context, rets[2]);
 
                 if (rets[1] != null) {
-                    if (!(rets[1] instanceof RubyBoolean)) {
-                        throw argumentError(context, str(runtime, "expected true or false as sort:", rets[1]));
-                    }
-                    options.sort = !runtime.getFalse().equals(rets[1]); // weirdly only explicit false is honored for sort.
+                    IRubyObject rets1 = rets[1];
+                    options.sort = checkBoolean(context, rets1, "sort", true);
                 }
 
                 if (rets[0] == null || rets[0].isNil()) {

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -79,6 +79,7 @@ import static org.jruby.anno.FrameField.BACKREF;
 import static org.jruby.anno.FrameField.LASTLINE;
 import static org.jruby.api.Access.encodingService;
 import static org.jruby.api.Access.instanceConfig;
+import static org.jruby.api.Check.checkBoolean;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asFloat;
@@ -95,9 +96,7 @@ import static org.jruby.api.Error.indexError;
 import static org.jruby.api.Error.runtimeError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.api.Warn.warn;
-import static org.jruby.api.Warn.warning;
 import static org.jruby.runtime.ThreadContext.hasKeywords;
-import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.StringSupport.CR_7BIT;
 import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
 
@@ -872,7 +871,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         if (arg instanceof RubyBoolean) return arg.isTrue() ? RE_OPTION_IGNORECASE : 0;
         if (arg.isNil()) return 0;
 
-        warning(context, str(context.runtime, "expected true or false as ignorecase: ", arg));
+        checkBoolean(context, arg, "ignorecase", false);
 
         return RE_OPTION_IGNORECASE;
     }

--- a/core/src/main/java/org/jruby/api/Check.java
+++ b/core/src/main/java/org/jruby/api/Check.java
@@ -1,5 +1,6 @@
 package org.jruby.api;
 
+import org.jruby.RubyBoolean;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.runtime.ThreadContext;
@@ -8,6 +9,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 import static org.jruby.api.Access.stringClass;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warning;
+import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.StringSupport.strNullCheck;
 import static org.jruby.util.TypeConverter.convertToTypeWithCheck;
 
@@ -50,5 +53,37 @@ public class Check {
         if (!str.isNil()) return RubySymbol.newHardSymbol(context.runtime, str);
 
         throw typeError(context, obj.callMethod(context, "inspect") + " is not a symbol nor a string");
+    }
+
+    /**
+     * Check that the given value is a Boolean and return its boolean value.
+     * <p>
+     * If the value is not a Boolean, this function will either raise (if the 'raise' parameter is true) or warn and
+     * return true only if the object is non-nil.
+     * <p>
+     * C API: rb_bool_expected
+     *
+     * @param context the current context
+     * @param maybeBool the value that may be a Boolean
+     * @param id the keyword that referred to the value
+     * @param raise whether to raise if the value is not a Boolean
+     * @return the boolean value of the object, after checking if it is a Boolean and raising or warning if not
+     */
+    public static boolean checkBoolean(ThreadContext context, IRubyObject maybeBool, String id, boolean raise) {
+        return switch (maybeBool) {
+            case RubyBoolean.True ignored -> true;
+            case RubyBoolean.False ignored -> false;
+            default -> {
+                String message = "expected true or false as " + id + ": ";
+
+                if (raise) {
+                    throw argumentError(context, str(context.runtime, message, maybeBool));
+                }
+
+                warning(context, message);
+
+                yield !maybeBool.isNil();
+            }
+        };
     }
 }

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -27,6 +27,7 @@ import org.jruby.util.TypeConverter;
 import static java.lang.System.lineSeparator;
 import static org.jruby.api.Access.exceptionClass;
 import static org.jruby.api.Access.instanceConfig;
+import static org.jruby.api.Check.checkBoolean;
 import static org.jruby.api.Check.checkID;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asSymbol;
@@ -394,9 +395,10 @@ public class TraceType {
 
             highlightArg = optHash.fastARef(highlightSym);
 
-            if (highlightArg == null) highlightArg = context.nil;
-            if (!(highlightArg.isNil() || highlightArg == context.tru || highlightArg == context.fals)) {
-                throw argumentError(context, "expected true or false as highlight: " + highlightArg);
+            if (highlightArg == null) {
+                highlightArg = context.nil;
+            } else {
+                checkBoolean(context, highlightArg, "highlight", true);
             }
         }
 

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import static org.jruby.api.Access.hashClass;
 import static org.jruby.api.Access.ioClass;
 import static org.jruby.api.Access.objectClass;
+import static org.jruby.api.Check.checkBoolean;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
@@ -1336,11 +1337,7 @@ public class PopenExecutor {
                         throw argumentError(context, "unsetenv_others option specified twice");
                     }
                     eargp.unsetenvOthersGiven = true;
-                    if (val.isTrue()) {
-                        eargp.unsetenvOthersDo = true;
-                    } else {
-                        eargp.unsetenvOthersDo = false;
-                    }
+                    eargp.unsetenvOthersDo = toBool(context, val, "unsetenv_others");
                 }
                 else if (id.equals("chdir")) {
                     if (eargp.chdirGiven) {
@@ -1363,11 +1360,7 @@ public class PopenExecutor {
                         throw argumentError(context, "close_others option specified twice");
                     }
                     eargp.closeOthersGiven = true;
-                    if (!val.isNil()) {
-                        eargp.closeOthersDo = true;
-                    } else {
-                        eargp.closeOthersDo = false;
-                    }
+                    eargp.closeOthersDo = toBool(context, val, "close_others");
                 } else if (id.equals("in")) {
                     key = RubyFixnum.zero(context.runtime);
                     checkExecRedirect(context, key, val, eargp);
@@ -1410,7 +1403,7 @@ public class PopenExecutor {
                         throw argumentError(context, "exception option specified twice");
                     }
                     eargp.exception_given = true;
-                    eargp.exception = val.isTrue();
+                    eargp.exception = toBool(context, val, "exception");
                 }
                 else {
                     return ST_STOP;
@@ -1432,6 +1425,11 @@ public class PopenExecutor {
         }
 
         return ST_CONTINUE;
+    }
+
+    // MRI: TO_BOOL in process.c
+    private static boolean toBool(ThreadContext context, IRubyObject val, String id) {
+        return val.isNil() ? false : checkBoolean(context, val, id, true);
     }
 
     // MRI: check_exec_redirect


### PR DESCRIPTION
Three popen/spawn kwargs require either nil or Boolean, rejecting other "truthy" values: unsetenv_others, close_others, and exception. Not erroring here led to unexpected exec during specs, sometimes breaking the spec run.

This is part of fixes for jruby/jruby#9609, but that involves Process.exec which is not yet hooked up to this ported logic. A separate PR will be started to make that connection.
