### PR TITLE
Use CRuby logic for exec

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -74,7 +74,6 @@ import org.jruby.exceptions.EOFError;
 import org.jruby.exceptions.IOError;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.ext.fcntl.FcntlLibrary;
-import org.jruby.internal.runtime.ThreadedRunnable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Arity;
@@ -105,7 +104,6 @@ import org.jruby.util.io.POSIXProcess;
 import org.jruby.util.io.PopenExecutor;
 import org.jruby.util.io.PosixShim;
 import org.jruby.util.io.SelectExecutor;
-import org.jruby.util.io.STDIO;
 
 import static com.headius.backport9.buffer.Buffers.clearBuffer;
 import static com.headius.backport9.buffer.Buffers.flipBuffer;
@@ -116,7 +114,6 @@ import static org.jruby.anno.FrameField.LASTLINE;
 import static org.jruby.api.Access.argsFile;
 import static org.jruby.api.Access.encodingService;
 import static org.jruby.api.Access.fileClass;
-import static org.jruby.api.Access.floatClass;
 import static org.jruby.api.Access.globalVariables;
 import static org.jruby.api.Access.ioClass;
 import static org.jruby.api.Convert.asBoolean;
@@ -4727,7 +4724,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             }
 
             if (options != null) {
-                checkUnsupportedOptions(context, options, UNSUPPORTED_SPAWN_OPTIONS, "unsupported popen option");
+                Helpers.checkUnsupportedPopenOptions(context, options);
             }
 
             io.setupPopen(context, modes, process);
@@ -5405,59 +5402,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     private static boolean isTrue(IRubyObject val) { return val != null && val.isTrue(); }
-
-    static final Set<String> ALL_SPAWN_OPTIONS;
-    static final String[] UNSUPPORTED_SPAWN_OPTIONS;
-
-    static {
-        String[] SPAWN_OPTIONS = new String[] {
-                "unsetenv_others",
-                "prgroup",
-                "new_pgroup",
-                "rlimit_resourcename",
-                "chdir",
-                "umask",
-                "in",
-                "out",
-                "err",
-                "close_others"
-        };
-        UNSUPPORTED_SPAWN_OPTIONS = new String[] {
-                "unsetenv_others",
-                "prgroup",
-                "new_pgroup",
-                "rlimit_resourcename",
-                "chdir",
-                "umask",
-                "in",
-                "out",
-                "err",
-                "close_others"
-        };
-
-        ALL_SPAWN_OPTIONS = new HashSet<>(Arrays.asList(SPAWN_OPTIONS));
-    }
-
-    static void checkUnsupportedOptions(ThreadContext context, RubyHash opts, String[] unsupported, String error) {
-        for (String key : unsupported) {
-            if (opts.fastARef(asSymbol(context, key)) != null) warn(context, error + ": " + key);
-        }
-    }
-
-    static void checkValidSpawnOptions(ThreadContext context, RubyHash opts) {
-        for (Object opt : opts.directKeySet()) {
-            if (opt instanceof RubySymbol) {
-                if (!ALL_SPAWN_OPTIONS.contains(((RubySymbol) opt).idString())) {
-                    throw argumentError(context, "wrong exec option symbol: " + opt);
-                }
-            }
-            else if (opt instanceof RubyString) {
-                if (!ALL_SPAWN_OPTIONS.contains(((RubyString) opt).toString())) {
-                    throw argumentError(context, "wrong exec option: " + opt);
-                }
-            }
-        }
-    }
 
     /**
      * Try for around 1s to destroy the child process. This is to work around

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -47,11 +47,7 @@ import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import jnr.constants.platform.Errno;
-import jnr.posix.POSIX;
 
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.FrameField;
@@ -61,8 +57,8 @@ import org.jruby.api.Warn;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.RubyWarnings;
 import org.jruby.exceptions.CatchThrow;
-import org.jruby.exceptions.MainExitException;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.ext.jruby.JRubyUtilLibrary;
 import org.jruby.internal.runtime.GlobalVariables;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.JavaMethod;
@@ -89,7 +85,6 @@ import org.jruby.util.ByteList;
 import org.jruby.util.ConvertBytes;
 import org.jruby.util.ShellLauncher;
 import org.jruby.util.TypeConverter;
-import org.jruby.util.cli.Options;
 import org.jruby.util.func.ObjectIntIntFunction;
 import org.jruby.util.io.OpenFile;
 import org.jruby.util.io.PopenExecutor;
@@ -98,9 +93,6 @@ import static org.jruby.RubyEnumerator.SizeFn;
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.RubyFile.fileResource;
 import static org.jruby.anno.FrameField.BACKREF;
-import static org.jruby.RubyIO.checkUnsupportedOptions;
-import static org.jruby.RubyIO.checkValidSpawnOptions;
-import static org.jruby.RubyIO.UNSUPPORTED_SPAWN_OPTIONS;
 import static org.jruby.anno.FrameField.BLOCK;
 import static org.jruby.anno.FrameField.CLASS;
 import static org.jruby.anno.FrameField.FILENAME;
@@ -353,7 +345,7 @@ public class RubyKernel {
             sites(context).puts.call(context, stderr, stderr, message);
         }
 
-        throw exit(context, new IRubyObject[] { context.fals, message }, false);
+        throw Helpers.exit(context, new IRubyObject[] { context.fals, message }, false);
     }
 
     // MRI: rb_f_array
@@ -917,7 +909,7 @@ public class RubyKernel {
     public static IRubyObject exit(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
-        throw exit(context, args, false);
+        throw Helpers.exit(context, args, false);
     }
 
     @Deprecated(since = "10.0.0.0")
@@ -929,44 +921,7 @@ public class RubyKernel {
     public static IRubyObject exit_bang(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
-        throw exit(context, args, true);
-    }
-
-    private static RuntimeException exit(ThreadContext context, IRubyObject[] args, boolean hard) {
-        int status = hard ? 1 : 0;
-        String message = null;
-
-        if (args.length > 0) {
-            RubyObject argument = (RubyObject) args[0];
-            if (argument instanceof RubyBoolean) {
-                status = argument.isFalse() ? 1 : 0;
-            } else {
-                status = toInt(context, argument);
-            }
-        }
-
-        if (args.length == 2 && args[1] instanceof RubyString string) {
-            message = string.toString();
-        }
-
-        if (hard) {
-            if (context.runtime.getInstanceConfig().isMain()) {
-                // JRuby was started through Main, use a hard exit
-                System.exit(status);
-            } else {
-                return new MainExitException(status, true);
-            }
-
-        }
-
-        RubySystemExit exception = message == null ?
-                RubySystemExit.newInstance(context, status, "exit") :
-                RubySystemExit.newInstance(context, status, message);
-        // MRI raises SystemExit through usual rb_longjmp -> setup_exception
-        context.setErrorInfo(exception); // set $!
-        RaiseException throwable = exception.toThrowable();
-        IRRuntimeHelpers.traceRaise(context);
-        return throwable;
+        throw Helpers.exit(context, args, true);
     }
 
 
@@ -2149,121 +2104,19 @@ public class RubyKernel {
         return args;
     }
 
+    @JRubyMethod(name = "exec", module = true, required = 1, rest = true, visibility = PRIVATE)
+    public static IRubyObject execNew(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return RubyProcess.exec(context, recv, args);
+    }
+
+    @Deprecated(since = "10.1.2.0")
     public static IRubyObject exec(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
-        return execCommon(context, null, args[0], null, args);
+        return Helpers.execOldCommon(context, null, args[0], null, args);
     }
 
-    /* Actual exec definition which calls this internal version is specified
-     * in /core/src/main/ruby/jruby/kernel/kernel.rb.
-     */
-    @JRubyMethod(required = 4, visibility = PRIVATE)
+    @Deprecated(since = "10.1.2.0")
     public static IRubyObject _exec_internal(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
-        IRubyObject env = args[0];
-        IRubyObject prog = args[1];
-        IRubyObject options = args[2];
-        var cmdArgs = (RubyArray<?>) args[3];
-
-        if (options instanceof RubyHash) checkExecOptions(context, (RubyHash) options);
-
-        return execCommon(context, env, prog, options, cmdArgs.toJavaArray(context));
-    }
-
-    static void checkExecOptions(ThreadContext context, RubyHash opts) {
-        checkValidSpawnOptions(context, opts);
-        checkUnsupportedOptions(context, opts, UNSUPPORTED_SPAWN_OPTIONS, "unsupported exec option");
-    }
-
-    private static IRubyObject execCommon(ThreadContext context, IRubyObject env, IRubyObject prog, IRubyObject options, IRubyObject[] args) {
-        // This is a fairly specific hack for empty string, but it does the job
-        if (args.length == 1) {
-            RubyString command = args[0].convertToString();
-            if (command.isEmpty()) throw context.runtime.newErrnoENOENTError(command.toString());
-
-            for (byte b : command.getBytes()) {
-                if (b == 0x00) throw argumentError(context, "string contains null byte");
-            }
-        }
-
-        final Ruby runtime = context.runtime;
-
-        if (env != null && env != context.nil) {
-            RubyHash envMap = env.convertToHash();
-            if (envMap != null) {
-                runtime.getENV().merge_bang(context, new IRubyObject[]{envMap}, Block.NULL_BLOCK);
-            }
-        }
-
-        boolean nativeFailed = false;
-        boolean nativeExec = Options.NATIVE_EXEC.load();
-        boolean jmxStopped = false;
-        System.setProperty("user.dir", runtime.getCurrentDirectory());
-
-        if (nativeExec) {
-            IRubyObject oldExc = context.getErrorInfo();
-            try {
-                ShellLauncher.LaunchConfig cfg = new ShellLauncher.LaunchConfig(runtime, args, true);
-
-                // Duplicated in part from ShellLauncher.runExternalAndWait
-                if (cfg.shouldRunInShell()) {
-                    // execute command with sh -c
-                    // this does shell expansion of wildcards
-                    cfg.verifyExecutableForShell();
-                } else {
-                    cfg.verifyExecutableForDirect();
-                }
-                String progStr = cfg.getExecArgs()[0];
-
-                String[] argv = cfg.getExecArgs();
-
-                // attempt to shut down the JMX server
-                jmxStopped = runtime.getBeanManager().tryShutdownAgent();
-
-                final POSIX posix = runtime.getPosix();
-
-                posix.chdir(System.getProperty("user.dir"));
-
-                if (Platform.IS_WINDOWS) {
-                    // Windows exec logic is much more elaborate; exec() in jnr-posix attempts to duplicate it
-                    posix.exec(progStr, argv);
-                } else {
-                    // TODO: other logic surrounding this call? In jnr-posix?
-                    @SuppressWarnings("unchecked")
-                    final Map<String, String> ENV = (Map<String, String>) runtime.getENV();
-                    ArrayList<String> envStrings = new ArrayList<>(ENV.size() + 1);
-                    for ( Map.Entry<String, String> envEntry : ENV.entrySet() ) {
-                        envStrings.add( envEntry.getKey() + '=' + envEntry.getValue() );
-                    }
-                    envStrings.add(null);
-
-                    int status = posix.execve(progStr, argv, envStrings.toArray(new String[envStrings.size()]));
-                    if (Platform.IS_WSL && status == -1) { // work-around a bug in Windows Subsystem for Linux
-                        if (posix.errno() == Errno.ENOMEM.intValue()) {
-                            posix.exec(progStr, argv);
-                        }
-                    }
-                }
-
-                // Only here because native exec could not exec (always -1)
-                nativeFailed = true;
-            } catch (RaiseException e) {
-                context.setErrorInfo(oldExc); // Restore $!
-            } catch (Exception e) {
-                throw runtime.newErrnoENOENTError("cannot execute: " + e.getLocalizedMessage());
-            }
-        }
-
-        // if we get here, either native exec failed or we should try an in-process exec
-        if (nativeFailed) {
-            if (jmxStopped && runtime.getBeanManager().tryRestartAgent()) runtime.registerMBeans();
-
-            throw runtime.newErrnoFromLastPOSIXErrno();
-        }
-
-        // Fall back onto our existing code if native not available
-        // FIXME: Make jnr-posix Pure-Java backend do this as well
-        int resultCode = ShellLauncher.execAndWait(runtime, args);
-
-        throw exit(context, new IRubyObject[] {asFixnum(context, resultCode)}, true);
+        return JRubyUtilLibrary.exec_old(context, recv, args);
     }
 
     @JRubyMethod(name = "fork", module = true, visibility = PRIVATE, notImplemented = true)

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -1602,6 +1602,13 @@ public class RubyProcess {
 
     @JRubyMethod(rest = true, meta = true)
     public static IRubyObject exec(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        // try true native exec based on CRuby logic
+        if (Options.NATIVE_EXEC.load() || context.runtime.getPosix().isNative()) {
+            int errno = PopenExecutor.exec(context, args, context.nil);
+
+            throw context.runtime.newErrnoFromInt(errno);
+        }
+
         return RubyKernel.exec(context, self, args);
     }
 

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -51,6 +51,7 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
 import org.jruby.runtime.CallBlock;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectMarshal;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
@@ -90,7 +91,6 @@ import static org.jruby.api.Create.newStruct;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.notImplementedError;
-import static org.jruby.api.Error.rangeError;
 import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.Helpers.nullToNil;
@@ -1603,13 +1603,13 @@ public class RubyProcess {
     @JRubyMethod(rest = true, meta = true)
     public static IRubyObject exec(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // try true native exec based on CRuby logic
-        if (Options.NATIVE_EXEC.load() || context.runtime.getPosix().isNative()) {
+        if (!Platform.IS_WINDOWS && Options.NATIVE_EXEC.load() && context.runtime.getPosix().isNative()) {
             int errno = PopenExecutor.exec(context, args, context.nil);
 
             throw context.runtime.newErrnoFromInt(errno);
         }
 
-        return RubyKernel.exec(context, self, args);
+        return Helpers.execOldCommon(context, null, args[0], null, args);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -40,13 +40,16 @@ import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.javasupport.Java;
+import org.jruby.platform.Platform;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.BasicLibraryService;
 import org.jruby.runtime.load.Library;
 import org.jruby.util.ClasspathLauncher;
+import org.jruby.util.cli.Options;
 
 import static org.jruby.api.Access.instanceConfig;
 import static org.jruby.api.Convert.*;
@@ -55,7 +58,7 @@ import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Warn.warn;
 import static org.jruby.api.Warn.warnDeprecated;
-import static org.jruby.api.Warn.warningDeprecated;
+import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.URLUtil.getPath;
 
 /**
@@ -110,6 +113,16 @@ public class JRubyUtilLibrary implements Library {
     @JRubyMethod(meta = true, name = "native_posix?")
     public static IRubyObject native_posix_p(ThreadContext context, IRubyObject self) {
         return asBoolean(context, context.runtime.getPosix().isNative());
+    }
+
+    @JRubyMethod(meta = true, name = "windows?")
+    public static IRubyObject windows_p(ThreadContext context, IRubyObject self) {
+        return asBoolean(context, Platform.IS_WINDOWS);
+    }
+
+    @JRubyMethod(meta = true, name = "native_exec?")
+    public static IRubyObject native_exec_p(ThreadContext context, IRubyObject self) {
+        return asBoolean(context, Options.NATIVE_EXEC.load());
     }
 
     /**
@@ -432,4 +445,17 @@ public class JRubyUtilLibrary implements Library {
     public static IRubyObject safe_recurse(ThreadContext context, IRubyObject utilModule, IRubyObject state, IRubyObject obj, IRubyObject name, Block block) {
         return context.safeRecurse(block, state, obj, name.convertToString().toString(), false);
     }
+
+    @JRubyMethod(required = 4, module = true, visibility = PRIVATE)
+    public static IRubyObject exec_old(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        IRubyObject env = args[0];
+        IRubyObject prog = args[1];
+        IRubyObject options = args[2];
+        var cmdArgs = (RubyArray<?>) args[3];
+
+        if (options instanceof RubyHash) Helpers.checkExecOptions(context, (RubyHash) options);
+
+        return Helpers.execOldCommon(context, env, prog, options, cmdArgs.toJavaArray(context));
+    }
+
 }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -2721,8 +2721,16 @@ public class Helpers {
         return null; // not reached
     }
 
+    @SafeVarargs
     public static <T> T[] arrayOf(T... values) {
         return values;
+    }
+
+    public static String[] arrayOf(String first, String... values) {
+        String[] newValues = new String[values.length + 1];
+        newValues[0] = first;
+        System.arraycopy(values, 0, newValues, 1, values.length);
+        return newValues;
     }
 
     public static IRubyObject[] arrayOf(IRubyObject first, IRubyObject... values) {

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -26,8 +26,10 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
@@ -37,6 +39,7 @@ import java.util.stream.Collectors;
 
 import com.headius.invokebinder.Binder;
 import jnr.constants.platform.Errno;
+import jnr.posix.POSIX;
 import org.jruby.*;
 import org.jruby.api.Create;
 import org.jruby.ast.ArgsNode;
@@ -48,9 +51,9 @@ import org.jruby.ast.types.INameNode;
 import org.jruby.ast.RequiredKeywordArgumentValueNode;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.ArgumentError;
+import org.jruby.exceptions.MainExitException;
 import org.jruby.exceptions.NoMethodError;
 import org.jruby.exceptions.RaiseException;
-import org.jruby.exceptions.Unrescuable;
 import org.jruby.internal.runtime.methods.*;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRScopeType;
@@ -63,6 +66,7 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.javasupport.proxy.ReifiedJavaProxy;
 import org.jruby.parser.StaticScope;
 import org.jruby.parser.StaticScopeFactory;
+import org.jruby.platform.Platform;
 import org.jruby.runtime.JavaSites.HelpersSites;
 import org.jruby.runtime.backtrace.BacktraceData;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -73,6 +77,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.CodegenUtils;
 import org.jruby.util.CommonByteLists;
 import org.jruby.util.MurmurHash;
+import org.jruby.util.ShellLauncher;
 import org.jruby.util.TypeConverter;
 
 import org.jcodings.Encoding;
@@ -89,7 +94,9 @@ import static org.jruby.api.Access.kernelModule;
 import static org.jruby.api.Access.moduleClass;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Convert.toInteger;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
@@ -110,6 +117,7 @@ import static org.jruby.util.RubyStringBuilder.ids;
 import static org.jruby.util.RubyStringBuilder.types;
 import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
 
+import org.jruby.util.cli.Options;
 import org.jruby.util.io.EncodingUtils;
 
 /**
@@ -654,6 +662,207 @@ public class Helpers {
         l |= (long) charValues[index + 2] << 32;
         l |= (long) charValues[index + 3] << 48;
         return l;
+    }
+
+    public static IRubyObject execOldCommon(ThreadContext context, IRubyObject env, IRubyObject prog, IRubyObject options, IRubyObject[] args) {
+        // This is a fairly specific hack for empty string, but it does the job
+        if (args.length == 1) {
+            RubyString command = args[0].convertToString();
+            if (command.isEmpty()) throw context.runtime.newErrnoENOENTError(command.toString());
+
+            for (byte b : command.getBytes()) {
+                if (b == 0x00) throw argumentError(context, "string contains null byte");
+            }
+        }
+
+        final Ruby runtime = context.runtime;
+
+        if (env != null && env != context.nil) {
+            RubyHash envMap = env.convertToHash();
+            if (envMap != null) {
+                runtime.getENV().merge_bang(context, new IRubyObject[]{envMap}, Block.NULL_BLOCK);
+            }
+        }
+
+        boolean nativeFailed = false;
+        boolean nativeExec = Options.NATIVE_EXEC.load();
+        boolean jmxStopped = false;
+        System.setProperty("user.dir", runtime.getCurrentDirectory());
+
+        if (nativeExec) {
+            IRubyObject oldExc = context.getErrorInfo();
+            try {
+                ShellLauncher.LaunchConfig cfg = new ShellLauncher.LaunchConfig(runtime, args, true);
+
+                // Duplicated in part from ShellLauncher.runExternalAndWait
+                if (cfg.shouldRunInShell()) {
+                    // execute command with sh -c
+                    // this does shell expansion of wildcards
+                    // this does shell expansion of wildcards
+                    cfg.verifyExecutableForShell();
+                } else {
+                    cfg.verifyExecutableForDirect();
+                }
+                String progStr = cfg.getExecArgs()[0];
+
+                String[] argv = cfg.getExecArgs();
+
+                // attempt to shut down the JMX server
+                jmxStopped = runtime.getBeanManager().tryShutdownAgent();
+
+                final POSIX posix = runtime.getPosix();
+
+                posix.chdir(System.getProperty("user.dir"));
+
+                if (Platform.IS_WINDOWS) {
+                    // Windows exec logic is much more elaborate; exec() in jnr-posix attempts to duplicate it
+                    posix.exec(progStr, argv);
+                } else {
+                    // TODO: other logic surrounding this call? In jnr-posix?
+                    @SuppressWarnings("unchecked")
+                    final Map<String, String> ENV = (Map<String, String>) runtime.getENV();
+                    ArrayList<String> envStrings = new ArrayList<>(ENV.size() + 1);
+                    for ( Map.Entry<String, String> envEntry : ENV.entrySet() ) {
+                        envStrings.add( envEntry.getKey() + '=' + envEntry.getValue() );
+                    }
+                    envStrings.add(null);
+
+                    int status = posix.execve(progStr, argv, envStrings.toArray(new String[envStrings.size()]));
+                    if (Platform.IS_WSL && status == -1) { // work-around a bug in Windows Subsystem for Linux
+                        if (posix.errno() == Errno.ENOMEM.intValue()) {
+                            posix.exec(progStr, argv);
+                        }
+                    }
+                }
+
+                // Only here because native exec could not exec (always -1)
+                nativeFailed = true;
+            } catch (RaiseException e) {
+                context.setErrorInfo(oldExc); // Restore $!
+            } catch (Exception e) {
+                throw runtime.newErrnoENOENTError("cannot execute: " + e.getLocalizedMessage());
+            }
+        }
+
+        // if we get here, either native exec failed or we should try an in-process exec
+        if (nativeFailed) {
+            if (jmxStopped && runtime.getBeanManager().tryRestartAgent()) runtime.registerMBeans();
+
+            throw runtime.newErrnoFromLastPOSIXErrno();
+        }
+
+        // Fall back onto our existing code if native not available
+        // FIXME: Make jnr-posix Pure-Java backend do this as well
+        int resultCode = ShellLauncher.execAndWait(runtime, args);
+
+        throw exit(context, new IRubyObject[] {asFixnum(context, resultCode)}, true);
+    }
+
+    /**
+     * Hard exit the JVM or return a RuntimeException to simulate exiting.
+     *
+     * @param context the current context
+     * @param args the exit arguments, including an exit code and optional message
+     * @param hard whether to use System.exit to terminate immediately
+     * @return a RuntimeException to throw if hard exiting was not requested
+     */
+    public static RuntimeException exit(ThreadContext context, IRubyObject[] args, boolean hard) {
+        int status = hard ? 1 : 0;
+        String message = null;
+
+        if (args.length > 0) {
+            RubyObject argument = (RubyObject) args[0];
+            if (argument instanceof RubyBoolean) {
+                status = argument.isFalse() ? 1 : 0;
+            } else {
+                status = toInt(context, argument);
+            }
+        }
+
+        if (args.length == 2 && args[1] instanceof RubyString string) {
+            message = string.toString();
+        }
+
+        if (hard) {
+            if (context.runtime.getInstanceConfig().isMain()) {
+                // JRuby was started through Main, use a hard exit
+                System.exit(status);
+            } else {
+                return new MainExitException(status, true);
+            }
+
+        }
+
+        RubySystemExit exception = message == null ?
+                RubySystemExit.newInstance(context, status, "exit") :
+                RubySystemExit.newInstance(context, status, message);
+        // MRI raises SystemExit through usual rb_longjmp -> setup_exception
+        context.setErrorInfo(exception); // set $!
+        RaiseException throwable = exception.toThrowable();
+        IRRuntimeHelpers.traceRaise(context);
+        return throwable;
+    }
+
+    public static void checkExecOptions(ThreadContext context, RubyHash opts) {
+        checkValidSpawnOptions(context, opts);
+        checkUnsupportedOptions(context, opts, UNSUPPORTED_SPAWN_OPTIONS, "unsupported exec option");
+    }
+
+    public static void checkUnsupportedPopenOptions(ThreadContext context, RubyHash options) {
+        checkUnsupportedOptions(context, options, UNSUPPORTED_SPAWN_OPTIONS, "unsupported popen option");
+    }
+
+    public static void checkUnsupportedOptions(ThreadContext context, RubyHash opts, String[] unsupported, String error) {
+        for (String key : unsupported) {
+            if (opts.fastARef(asSymbol(context, key)) != null) warn(context, error + ": " + key);
+        }
+    }
+
+    static void checkValidSpawnOptions(ThreadContext context, RubyHash opts) {
+        for (Object opt : opts.directKeySet()) {
+            if (opt instanceof RubySymbol) {
+                if (!ALL_SPAWN_OPTIONS.contains(((RubySymbol) opt).idString())) {
+                    throw argumentError(context, "wrong exec option symbol: " + opt);
+                }
+            }
+            else if (opt instanceof RubyString) {
+                if (!ALL_SPAWN_OPTIONS.contains(((RubyString) opt).toString())) {
+                    throw argumentError(context, "wrong exec option: " + opt);
+                }
+            }
+        }
+    }
+
+    static final Set<String> ALL_SPAWN_OPTIONS;
+    static final String[] UNSUPPORTED_SPAWN_OPTIONS;
+
+    static {
+        String[] SPAWN_OPTIONS = new String[] {
+                "unsetenv_others",
+                "prgroup",
+                "new_pgroup",
+                "rlimit_resourcename",
+                "chdir",
+                "umask",
+                "in",
+                "out",
+                "err",
+                "close_others"
+        };
+        UNSUPPORTED_SPAWN_OPTIONS = new String[] {
+                "unsetenv_others",
+                "prgroup",
+                "new_pgroup",
+                "rlimit_resourcename",
+                "chdir",
+                "umask",
+                "in",
+                "out",
+                "err",
+                "close_others"
+        };
+
+        ALL_SPAWN_OPTIONS = new HashSet<>(Arrays.asList(SPAWN_OPTIONS));
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -5,6 +5,7 @@ import jnr.constants.platform.Fcntl;
 import jnr.constants.platform.OpenFlags;
 import jnr.constants.platform.RLIMIT;
 import jnr.enxio.channels.NativeDeviceChannel;
+import jnr.posix.POSIX;
 import jnr.posix.SpawnAttribute;
 import jnr.posix.SpawnFileAction;
 import org.jcodings.transcode.EConvFlags;
@@ -16,7 +17,6 @@ import org.jruby.RubyFile;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyHash;
 import org.jruby.RubyIO;
-import org.jruby.RubyNumeric;
 import org.jruby.RubyProcess;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
@@ -55,6 +55,7 @@ import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.runtimeError;
+import static org.jruby.runtime.Helpers.arrayOf;
 
 /**
  * Port of MRI's popen+exec logic.
@@ -369,6 +370,82 @@ public class PopenExecutor {
         return RubyIO.ensureYieldClose(context, port, block);
     }
 
+    public static int exec(ThreadContext context, IRubyObject[] argv, IRubyObject opt) {
+        ExecArg eargp;
+
+        eargp = execargNew(context, argv, opt, true, false);
+
+        BeforeExecState bes = null;
+        try {
+            bes = beforeExec(context);
+
+            execargParentStart1(context, eargp);
+
+            return execAsyncSignalSafe(context, eargp, null);
+        } finally {
+            // should only be reached if exec fails
+            afterExec(context, bes);
+        }
+    }
+
+    record BeforeExecState(boolean jmxStopped, String cwd) {}
+
+    private static BeforeExecState beforeExec(ThreadContext context) {
+        boolean jmxStopped;
+        // attempt to shut down the JMX server
+        jmxStopped = context.runtime.getBeanManager().tryShutdownAgent();
+
+        final POSIX posix = context.runtime.getPosix();
+
+        String cwd = posix.getcwd();
+        posix.chdir(context.runtime.getCurrentDirectory());
+
+        return new BeforeExecState(jmxStopped, cwd);
+    }
+
+    private static void afterExec(ThreadContext context, BeforeExecState bes) {
+        if (bes.jmxStopped() && context.runtime.getBeanManager().tryRestartAgent()) context.runtime.registerMBeans();
+
+        context.runtime.getPosix().chdir(bes.cwd());
+
+        throw context.runtime.newErrnoFromLastPOSIXErrno();
+    }
+
+    private static void prepareModifiedEnv(ThreadContext context, ExecArg eargp) {
+        boolean clearEnv = false;
+        if (eargp.unsetenvOthersGiven && eargp.unsetenvOthersDo) {
+            // we handle this elsewhere by starting from a blank env
+            clearEnv = true;
+        }
+
+        RubyArray env = eargp.env_modification;
+        if (env != null) {
+            eargp.envp_str = ShellLauncher.getModifiedEnv(context, env, clearEnv);
+        }
+    }
+
+    static int execAsyncSignalSafe(ThreadContext context, ExecArg eargp, String[] errmsg)
+    {
+        POSIX posix = context.runtime.getPosix();
+        int err;
+
+        if (execargRunOptions(context, eargp, null, errmsg) < 0) { /* hopefully async-signal-safe */
+            return posix.errno();
+        }
+
+        if (eargp.use_shell) {
+            err = procExecSh(context, eargp.command_name.asJavaString(), eargp.envp_str); /* async-signal-safe */
+        }
+        else {
+            String abspath = null;
+            if (!eargp.command_abspath.isNil())
+                abspath = eargp.command_abspath.asJavaString();
+            err = procExecCmd(context, abspath, eargp.argv_str.argv, eargp.envp_str); /* async-signal-safe */
+        }
+
+        return err;
+    }
+
     static void execargSetenv(ThreadContext context, ExecArg eargp, IRubyObject env) {
         eargp.env_modification = !env.isNil() ? checkExecEnv(context, (RubyHash)env, eargp) : null;
     }
@@ -521,6 +598,57 @@ public class PopenExecutor {
             }
 
             return ret;
+        }
+    }
+
+    /* This function should be async-signal-safe.  Actually it is. */
+    static int procExecSh(ThreadContext context, String str, String[] envp)
+    {
+        if (str.matches("^[ \t\n]+$")) return Errno.ENOENT.intValue();
+
+        POSIX posix = context.runtime.getPosix();
+
+        if (envp != null) {
+            posix.execve("/bin/sh", arrayOf("sh", "-c", str), envp);
+        } else {
+            posix.execv("/bin/sh", arrayOf("sh", "-c", str));
+        }
+
+        return posix.errno();
+    }
+
+    static int procExecCmd(ThreadContext context, String prog, String[] argv, String[] envp)
+    {
+        if (prog == null) {
+            return Errno.ENOENT.intValue();
+        }
+
+        POSIX posix = context.runtime.getPosix();
+
+        if (envp != null) {
+            posix.execve(prog, argv, envp);
+        } else {
+            posix.execv(prog, argv);
+        }
+        int err = posix.errno();
+        tryWithSh(context, err, prog, argv, envp); /* try_with_sh() is async-signal-safe. */
+        return err;
+    }
+
+    static void tryWithSh(ThreadContext context, int errno, String prog, String[] argv, String[] envp) {
+        if (errno == Errno.ENOEXEC.intValue()) {
+            execWithSh(context, prog, argv, envp);
+        }
+    }
+
+    static void execWithSh(ThreadContext context, String prog, String[] argv, String[] envp)
+    {
+        argv = arrayOf("sh", argv);
+        POSIX posix = context.runtime.getPosix();
+        if (envp != null) {
+            posix.exec(prog, argv, envp);
+        } else {
+            posix.exec(prog, argv);
         }
     }
 
@@ -998,7 +1126,7 @@ public class PopenExecutor {
         return 0;
     }
 
-    int execargRunOptions(ThreadContext context, ExecArg eargp, ExecArg sargp, String[] errmsg) {
+    static int execargRunOptions(ThreadContext context, ExecArg eargp, ExecArg sargp, String[] errmsg) {
         IRubyObject obj;
 
         if (sargp != null) {
@@ -1016,16 +1144,7 @@ public class PopenExecutor {
             throw context.runtime.newNotImplementedError("setting rlimit in child is unsupported");
         }
 
-        boolean clearEnv = false;
-        if (eargp.unsetenvOthersGiven && eargp.unsetenvOthersDo) {
-            // we handle this elsewhere by starting from a blank env
-            clearEnv = true;
-        }
-
-        RubyArray env = eargp.env_modification;
-        if (env != null) {
-            eargp.envp_str = ShellLauncher.getModifiedEnv(context, env, clearEnv);
-        }
+        prepareModifiedEnv(context, eargp);
 
         if (eargp.umaskGiven) {
             throw context.runtime.newNotImplementedError("setting umask in child is unsupported");

--- a/core/src/main/ruby/jruby/kernel/kernel.rb
+++ b/core/src/main/ruby/jruby/kernel/kernel.rb
@@ -1,6 +1,8 @@
 module Kernel
-  module_function def exec(*args)
-    _exec_internal(*JRuby::ProcessUtil.exec_args(args))
+  if JRuby::Util.windows? || !JRuby::Util.native_exec? || !JRuby::Util.native_posix?
+    module_function def exec(*args)
+      JRuby::Util.exec_old(*JRuby::ProcessUtil.exec_args(args))
+    end
   end
 
   # Replaces Java version for better caching

--- a/spec/tags/ruby/core/io/popen_tags.txt
+++ b/spec/tags/ruby/core/io/popen_tags.txt
@@ -19,6 +19,6 @@ windows(hangs):IO.popen does not throw an exception if child exited and has been
 windows:IO.popen raises IOError when writing a read-only pipe
 windows:IO.popen accepts a path using the chdir: keyword argument
 windows:IO.popen accepts a path using the chdir: keyword argument and a coercible path
-fails:IO.popen options validation raises an ArgumentError if :unsetenv_others option is not a boolean or nil
-fails:IO.popen options validation raises an ArgumentError if :close_others option is not a boolean or nil
+windows:IO.popen options validation raises an ArgumentError if :unsetenv_others option is not a boolean or nil
+windows:IO.popen options validation raises an ArgumentError if :close_others option is not a boolean or nil
 fails:IO.popen options validation raises an ArgumentError if :new_pgroup option is not a boolean or nil

--- a/spec/tags/ruby/core/kernel/system_tags.txt
+++ b/spec/tags/ruby/core/kernel/system_tags.txt
@@ -16,4 +16,4 @@ windows:Kernel.system raises RuntimeError when `exception: true` is given and th
 windows:Kernel.system raises Errno::ENOENT when `exception: true` is given and the specified command does not exist
 windows:Kernel.system does expand shell variables when given multiples arguments
 windows:Kernel.system runs commands starting with any number of @ using shell
-fails:Kernel#system raises an ArgumentError if :exception option is not a boolean or nil
+windows:Kernel#system raises an ArgumentError if :exception option is not a boolean or nil

--- a/spec/tags/ruby/core/process/exec_tags.txt
+++ b/spec/tags/ruby/core/process/exec_tags.txt
@@ -3,7 +3,7 @@ fails:Process.exec sets the current directory when given the :chdir option
 fails:Process.exec with a command array uses the first element as the command name and the second as the argv[0] value
 fails:Process.exec with a command array coerces the argument using to_ary
 fails:Process.exec (environment variables) unsets other environment variables when given a true :unsetenv_others option
-fails:Process.exec with a command array raises an ArgumentError if the Array does not have exactly two elements
+windows:Process.exec with a command array raises an ArgumentError if the Array does not have exactly two elements
 fails:Process.exec with an options Hash with Integer option keys maps the key to a file descriptor in the child that inherits the file descriptor from the parent specified by the value
 windows:Process.exec runs the specified command, replacing current process
 windows:Process.exec with a single argument subjects the specified command to shell expansion
@@ -15,11 +15,10 @@ fails:Process.exec (environment variables) sets environment variables in the chi
 fails:Process.exec (environment variables) unsets environment variables whose value is nil
 fails:Process.exec (environment variables) coerces environment argument using to_hash
 fails:Process.exec with an options Hash with Integer option keys lets the process after exec have specified file descriptor despite close_on_exec
-fails:Process.exec with an options Hash with Integer option keys sets close_on_exec to false on specified fd even when it fails
 windows:Process.exec flushes STDERR upon exit when it's not set to sync
 windows:Process.exec with a single argument does not subject the specified command to shell expansion on Windows
 windows:Process.exec with a single argument does not create an argument array with shell parsing semantics for whitespace on Windows
 windows:Process.exec with multiple arguments does not subject the arguments to shell expansion
-fails:Process.exec options validation raises an ArgumentError if :unsetenv_others option is not a boolean or nil
-fails:Process.exec options validation raises an ArgumentError if :close_others option is not a boolean or nil
+windows:Process.exec options validation raises an ArgumentError if :unsetenv_others option is not a boolean or nil
+windows:Process.exec options validation raises an ArgumentError if :close_others option is not a boolean or nil
 fails:Process.exec options validation raises an ArgumentError if :new_pgroup option is not a boolean or nil

--- a/spec/tags/ruby/core/process/spawn_tags.txt
+++ b/spec/tags/ruby/core/process/spawn_tags.txt
@@ -71,6 +71,6 @@ fails:Process.spawn sets $? to exit status 127 when the file does not exist
 fails:Process.spawn raises an Errno::EACCES when the path is a directory
 fails:Process.spawn raises an Errno::ENOENT when a non-executable file is found in PATH
 fails:Process.spawn when passed :chdir raises an Errno::ENOENT when a given path doesn't exist
-fails:Process.spawn raises an ArgumentError if :unsetenv_others option is not a boolean or nil
-fails:Process.spawn raises an ArgumentError if :close_others option is not a boolean or nil
+windows:Process.spawn raises an ArgumentError if :unsetenv_others option is not a boolean or nil
+windows:Process.spawn raises an ArgumentError if :close_others option is not a boolean or nil
 fails:Process.spawn raises an ArgumentError if :new_pgroup option is not a boolean or nil


### PR DESCRIPTION
This wires up the CRuby process logic to exec, fixing a number of issues and cleaning up some old code.

This is a follow-up to #9626 which fixed the handling of nil-or-boolean flags to `popen` and `spawn` but since `exec` did not use that logic it did not fix the reported issue in #9609.

Fixes #9609