### PR TITLE
Pass -1 for max arity when there's rest args

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
@@ -428,7 +428,11 @@ public class InvocationMethodFactory extends MethodFactory implements Opcodes {
                 method.invokevirtual(p(ThreadContext.class), "getRuntime", sig(Ruby.class));
                 method.aload(ARGS_INDEX);
                 method.ldc(jrubyMethod.required());
-                method.ldc(jrubyMethod.required() + jrubyMethod.optional());
+                if (jrubyMethod.rest()) {
+                    method.ldc(-1);
+                } else {
+                    method.ldc(jrubyMethod.required() + jrubyMethod.optional());
+                }
                 method.invokestatic(p(Arity.class), "checkArgumentCount", sig(int.class, Ruby.class, IRubyObject[].class, int.class, int.class));
                 method.pop();
 

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -1666,7 +1666,7 @@ public class PopenExecutor {
 
     // rb_check_argv
     public static RubyString checkArgv(ThreadContext context, IRubyObject[] argv) {
-        Arity.checkArgumentCount(context, argv, 1, Integer.MAX_VALUE);
+        Arity.checkArgumentCount(context, argv, 1, -1);
 
         RubyString prog = null;
 


### PR DESCRIPTION
Arity errors use -1 to indicate "unlimited arguments" and format the arguments' upper bound as "1+". Core methods and one instance in popen logic instead used either Integer.MAX_VALUE or incorrectly just added required plus optional even when rest.

I discovered this while connecting `Kernel.exec` logic up to the CRuby popen logic in #9627. That change moved the implementation of `Kernel.exec` into core, where it was subject to the arity-checking in generated method stubs that incorrectly used "rest + optional" as the max, even when a rest argument was provided. This caused the new `exec` logic to fail an unrelated arity-error message test in `test_message_change_issue_6085` in CRuby's test_arity.rb.