### PR TITLE
Untag specs fixed by #9441

### DIFF
--- a/spec/tags/ruby/core/method/inspect_tags.txt
+++ b/spec/tags/ruby/core/method/inspect_tags.txt
@@ -1,3 +1,0 @@
-fails:Method#inspect shows the source UnboundMethod's name in parentheses for a define_method'd method
-fails:Method#inspect does not annotate a directly looked-up Kernel method with a shared internal name
-fails:Method#inspect shows the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/ruby/core/method/original_name_tags.txt
+++ b/spec/tags/ruby/core/method/original_name_tags.txt
@@ -1,2 +1,0 @@
-fails:Method#original_name returns the source UnboundMethod's name for Kernel#is_a? and Kernel#kind_of?
-fails:Method#original_name preserves the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/ruby/core/method/to_s_tags.txt
+++ b/spec/tags/ruby/core/method/to_s_tags.txt
@@ -1,3 +1,1 @@
-fails:Method#to_s shows the source UnboundMethod's name in parentheses for a define_method'd method
 fails:Method#to_s does not annotate a directly looked-up Kernel method with a shared internal name
-fails:Method#to_s shows the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/ruby/core/unboundmethod/inspect_tags.txt
+++ b/spec/tags/ruby/core/unboundmethod/inspect_tags.txt
@@ -1,3 +1,0 @@
-fails:UnboundMethod#inspect shows the source UnboundMethod's name in parentheses for a define_method'd method
-fails:UnboundMethod#inspect does not annotate a directly looked-up Kernel method with a shared internal name
-fails:UnboundMethod#inspect shows the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/ruby/core/unboundmethod/original_name_tags.txt
+++ b/spec/tags/ruby/core/unboundmethod/original_name_tags.txt
@@ -1,2 +1,0 @@
-fails:UnboundMethod#original_name returns the source UnboundMethod's name for Kernel#is_a? and Kernel#kind_of?
-fails:UnboundMethod#original_name preserves the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/ruby/core/unboundmethod/to_s_tags.txt
+++ b/spec/tags/ruby/core/unboundmethod/to_s_tags.txt
@@ -1,3 +1,1 @@
-fails:UnboundMethod#to_s shows the source UnboundMethod's name in parentheses for a define_method'd method
 fails:UnboundMethod#to_s does not annotate a directly looked-up Kernel method with a shared internal name
-fails:UnboundMethod#to_s shows the source name when aliasing a define_method'd Kernel method


### PR DESCRIPTION
Removes spec tags that pass now that #9441 is merged:

- `Method#original_name` / `UnboundMethod#original_name`
- `Method#to_s` / `UnboundMethod#to_s`
- `method/inspect_tags.txt` and `unboundmethod/inspect_tags.txt`