### PR TITLE
Report the errno that native exec actually returned

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -1606,7 +1606,10 @@ public class RubyProcess {
         if (!Platform.IS_WINDOWS && Options.NATIVE_EXEC.load() && context.runtime.getPosix().isNative()) {
             int errno = PopenExecutor.exec(context, args, context.nil);
 
-            throw context.runtime.newErrnoFromInt(errno);
+            // exec only returns when it failed; errno 0 means we never reached a syscall (e.g. command not found)
+            throw errno == 0 ?
+                    context.runtime.newErrnoFromLastPOSIXErrno() :
+                    context.runtime.newErrnoFromInt(errno);
         }
 
         return Helpers.execOldCommon(context, null, args[0], null, args);

--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -365,7 +365,9 @@ public class ShellLauncher {
         return false;
     }
 
-    private static File isValidFile(Ruby runtime, String fdir, String fname, boolean isExec) {
+    // With raiseOnNotExecutable false a non-executable match is treated as no match, as MRI's dln_find_1
+    // does while walking PATH, rather than raising EACCES.
+    private static File isValidFile(Ruby runtime, String fdir, String fname, boolean isExec, boolean raiseOnNotExecutable) {
         File validFile = null;
         if (isExec && Platform.IS_WINDOWS) {
             if (withExeSuffix(fname)) {
@@ -386,6 +388,7 @@ public class ShellLauncher {
                     return null;
                 }
                 if (isExec && !runtime.getPosix().stat(validFile.getAbsolutePath()).isExecutable()) {
+                    if (!raiseOnNotExecutable) return null;
                     throw runtime.newErrnoEACCESError(validFile.getAbsolutePath());
                 }
             }
@@ -395,11 +398,14 @@ public class ShellLauncher {
 
     private static File isValidFile(Ruby runtime, String fname, boolean isExec) {
         String fdir = null;
-        return isValidFile(runtime, fdir, fname, isExec);
+        return isValidFile(runtime, fdir, fname, isExec, true);
     }
 
     private static File findPathFile(Ruby runtime, String fname, String[] path, boolean isExec) {
         File pathFile = null;
+        // MRI: dln_find_1 skips non-regular files, so an empty name never resolves (each candidate is a PATH
+        // dir); here the search would instead hit the dir entries themselves and can raise EACCES
+        if (fname.isEmpty()) return null;
         if (Platform.IS_WINDOWS && fname.startsWith("\"") && fname.endsWith("\"")) {
             fname = fname.substring(1, fname.length() - 1); // remove double quotes if present
         }
@@ -410,7 +416,8 @@ public class ShellLauncher {
                 //       MRI's, which can't handle user names after the tilde
                 //       when searching the executable path
                 try {
-                    pathFile = isValidFile(runtime, fdir, fname, isExec);
+                    // MRI: dln_find_1 skips candidates it cannot execute and keeps walking PATH
+                    pathFile = isValidFile(runtime, fdir, fname, isExec, false);
                     if (pathFile != null) {
                         break;
                     }

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -403,12 +403,13 @@ public class PopenExecutor {
         return new BeforeExecState(jmxStopped, cwd);
     }
 
+    // Restore the state saved by beforeExec; only reached when exec failed.
     private static void afterExec(ThreadContext context, BeforeExecState bes) {
+        if (bes == null) return;
+
         if (bes.jmxStopped() && context.runtime.getBeanManager().tryRestartAgent()) context.runtime.registerMBeans();
 
         context.runtime.getPosix().chdir(bes.cwd());
-
-        throw context.runtime.newErrnoFromLastPOSIXErrno();
     }
 
     private static void prepareModifiedEnv(ThreadContext context, ExecArg eargp) {
@@ -438,8 +439,15 @@ public class PopenExecutor {
         }
         else {
             String abspath = null;
-            if (!eargp.command_abspath.isNil())
+            // command_abspath is null (or nil) when the command could not be found in PATH
+            if (eargp.command_abspath != null && !eargp.command_abspath.isNil()) {
                 abspath = eargp.command_abspath.asJavaString();
+            } else {
+                // MRI: dln_find_1 returns names containing a slash as-is, so exec reports the real errno for
+                // them (EACCES for a directory or a file without execute permission, ENOENT if missing).
+                String name = eargp.command_name.asJavaString();
+                if (name.indexOf('/') != -1) abspath = name;
+            }
             err = procExecCmd(context, abspath, eargp.argv_str.argv, eargp.envp_str); /* async-signal-safe */
         }
 

--- a/spec/tags/ruby/core/process/exec_tags.txt
+++ b/spec/tags/ruby/core/process/exec_tags.txt
@@ -1,4 +1,3 @@
-fails:Process.exec raises Errno::EACCES when passed a directory
 fails:Process.exec sets the current directory when given the :chdir option
 fails:Process.exec with a command array uses the first element as the command name and the second as the argv[0] value
 fails:Process.exec with a command array coerces the argument using to_ary

--- a/spec/tags/ruby/core/process/exec_tags.txt
+++ b/spec/tags/ruby/core/process/exec_tags.txt
@@ -1,3 +1,4 @@
+windows:Process.exec raises Errno::EACCES when passed a directory
 fails:Process.exec sets the current directory when given the :chdir option
 fails:Process.exec with a command array uses the first element as the command name and the second as the argv[0] value
 fails:Process.exec with a command array coerces the argument using to_ary

--- a/spec/tags/ruby/core/process/spawn_tags.txt
+++ b/spec/tags/ruby/core/process/spawn_tags.txt
@@ -69,7 +69,6 @@ windows:Process.spawn with a command array calls #to_ary to convert the argument
 fails:Process.spawn sets $? to exit status 127 when the command does not exist
 fails:Process.spawn sets $? to exit status 127 when the file does not exist
 fails:Process.spawn raises an Errno::EACCES when the path is a directory
-fails:Process.spawn raises an Errno::ENOENT when a non-executable file is found in PATH
 fails:Process.spawn when passed :chdir raises an Errno::ENOENT when a given path doesn't exist
 windows:Process.spawn raises an ArgumentError if :unsetenv_others option is not a boolean or nil
 windows:Process.spawn raises an ArgumentError if :close_others option is not a boolean or nil


### PR DESCRIPTION
This should fix flaky openBSD test runs like this one: https://github.com/jruby/jruby/actions/runs/33608150521/job/100176806273#step:5:248

The exec logic threw from a finally block using the last POSIX errno, so a command not found in PATH reported whatever the previous syscall left behind: ENOENT on Linux by accident, EACCES on OpenBSD, NOERROR on macOS.

The PATH search also diverged from `dln_find_1`: an empty name matched the PATH entries themselves, a non-executable candidate aborted the search, and names with a slash were not passed to execv unresolved. Untags two specs.