### PR TITLE
Run error-prone on one CI job instead of all of them (reduce 429 errors on Java 21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     name: error-prone (Java 21)
 
     env:
-      JRUBY_ERROR_PRONE: true
+      ERROR_PRONE: true
 
     steps:
       - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,26 @@ jobs:
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
+  error-prone:
+    runs-on: ubuntu-latest
+
+    name: error-prone (Java 21)
+
+    env:
+      JRUBY_ERROR_PRONE: true
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - name: set up java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'maven'
+      - name: bootstrap
+        run: ./mvnw -ntp -Pbootstrap clean package
+
   # This job is a fast-fail all-interp run of test:mri:code to give early indication if the jitted runs will pass.
   rake-test-mri-fast:
     name: rake test:mri:core:int (Java 26, fast fail)

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -313,7 +313,7 @@ project 'JRuby Base' do
       jdk('21')
       # opt-in: one CI job sets this, so the other jobs neither run the check nor resolve the
       # error-prone processor tree from Maven Central
-      property(name: 'env.JRUBY_ERROR_PRONE')
+      property(name: 'env.ERROR_PRONE')
     end
 
     plugin :compiler do

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -311,7 +311,9 @@ project 'JRuby Base' do
   profile 'error-prone' do
     activation do
       jdk('21')
-      property(name: 'env.CI') # for keeping fast development cycle, by default only run on CI
+      # opt-in: one CI job sets this, so the other jobs neither run the check nor resolve the
+      # error-prone processor tree from Maven Central
+      property(name: 'env.JRUBY_ERROR_PRONE')
     end
 
     plugin :compiler do

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -650,7 +650,7 @@ DO NOT MODIFY - GENERATED CODE
       <activation>
         <jdk>21</jdk>
         <property>
-          <name>env.CI</name>
+          <name>env.JRUBY_ERROR_PRONE</name>
         </property>
       </activation>
       <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -650,7 +650,7 @@ DO NOT MODIFY - GENERATED CODE
       <activation>
         <jdk>21</jdk>
         <property>
-          <name>env.JRUBY_ERROR_PRONE</name>
+          <name>env.ERROR_PRONE</name>
         </property>
       </activation>
       <build>


### PR DESCRIPTION
The profile activated on any JDK 21 build with CI set, so all 41 Java 21 jobs resolved error_prone_core from Central and ran the check. Activation now needs JRUBY_ERROR_PRONE, set by one new job.