### PR TITLE
Close tempfiles in teardown

### DIFF
--- a/test/jruby/compiler/test_jrubyc.rb
+++ b/test/jruby/compiler/test_jrubyc.rb
@@ -26,6 +26,9 @@ class TestJRubyc < Test::Unit::TestCase
     $stdout.reopen(@old_stdout) if @old_stdout
     $stderr.reopen(@old_stderr) if @old_stderr
 
+    @tempfile_stdout.close rescue nil
+    @tempfile_stderr.close rescue nil
+
     $compile_test = nil; $encoding = nil
   end
 


### PR DESCRIPTION
Leaving these files open causes them to get cleaned up by Tempfile finalization. If $DEBUG is set when that finalization happens, The tempfile library will output text indicating that the file is being removed. This can cause other tests with stdio output expectations to fail intermittently with errors like this:

```
Failure: test_raise_in_debug_mode(TestKernel)
/home/runner/work/jruby/jruby/test/jruby/test_kernel.rb:289:in 'test_raise_in_debug_mode'
     286:     $stderr = StringIO.new
     287:     raise StandardError rescue nil
     288:     tobe = "Exception 'StandardError' at #{__FILE__}:#{__LINE__ - 1} - StandardError"
  => 289:     assert_equal(tobe, $stderr.string.split("\n")[0])
     290:
     291:     # by String
     292:     $stderr.reopen
org/jruby/RubyKernel.java:1588:in 'catch'
org/jruby/RubyKernel.java:1583:in 'catch'
org/jruby/RubyArrayNative.java:1729:in 'each'
org/jruby/RubyArrayNative.java:1729:in 'each'
org/jruby/RubyKernel.java:1588:in 'catch'
org/jruby/RubyKernel.java:1583:in 'catch'
<"Exception 'StandardError' at /home/runner/work/jruby/jruby/test/jruby/test_kernel.rb:287 - StandardError"> expected but was
<"removing /tmp/test_jrubyc_stderr20260903-3059-3xw8r7...">
```

Closing these tempfiles eagerly should avoid the lazy output.