### PR TITLE
Propagate JRUBY_OPTS from parent env when running mspec

### DIFF
--- a/rakelib/commands.rake
+++ b/rakelib/commands.rake
@@ -79,7 +79,7 @@ def mspec(mspec_options = {}, java_options = {}, &code)
     sysproperty :key => "emma.verbosity.level", :value=> "silent"
 
     env :key => "JAVA_OPTS", :value => "-Demma.verbosity.level=silent"
-    env :key => "JRUBY_OPTS", :value => ms[:jruby_opts] || ""
+    env :key => "JRUBY_OPTS", :value => "#{ENV['JRUBY_OPTS']} #{ms[:jruby_opts]}"
     # launch in the same mode we're testing, since config is loaded by top process
 
     # add . to load path so mspec config is found


### PR DESCRIPTION
We need to be able to manipulate the mspec jobs by setting JRUBY_OPTS, as described in jruby/jruby#9597, but the old logic here overwrote that environment variable while setting up the subprocess launch. This change builds the new JRUBY_OPTS starting with the current environment, so additional flags can be passed through.

This is not ideal; a rogue JRUBY_OPTS in the parent env could cause these jobs to run in ways that break their verification. Unfortunately rake provides few ways to parameterize tasks, so we are forced to permute and generate all tasks we wish to see, and ENV is the cleanest way to pass in additional tweaks.

Fixes jruby/jruby#9597