### PR TITLE
Fix the Fiber scheduler IO path: negated errno, zero length, buffer size

### DIFF
--- a/core/src/main/java/org/jruby/FiberScheduler.java
+++ b/core/src/main/java/org/jruby/FiberScheduler.java
@@ -218,7 +218,8 @@ public class FiberScheduler {
         return result(runtime.getCurrentContext(), result, error);
     }
 
+    // MRI: rb_fiber_scheduler_io_result
     public static IRubyObject result(ThreadContext context, int result, Errno error) {
-        return asFixnum(context, result == -1 ? error.value(): result);
+        return asFixnum(context, result < 0 ? -error.value() : result);
     }
 }

--- a/core/src/main/java/org/jruby/RubyIOBuffer.java
+++ b/core/src/main/java/org/jruby/RubyIOBuffer.java
@@ -1910,7 +1910,10 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject pread(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
         RubyInteger fromInteger = toInteger(context, _from);
-        RubyInteger lengthInteger = toInteger(context, _length);
+        int offset = 0;
+        int length = toInteger(context, _length).asInt(context);
+        if (length == 0) length = size;
+        RubyInteger lengthInteger = asFixnum(context, length);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPRead(context, scheduler, io, this, fromInteger, lengthInteger, asFixnum(context, 0));
@@ -1918,8 +1921,6 @@ public class RubyIOBuffer extends RubyObject {
         }
 
         int from = toInt(context, fromInteger);
-        int offset = 0;
-        int length = extractLength(context, lengthInteger, offset);
 
         return pread(context, RubyIO.convertToIO(context, io), from, length, offset);
     }
@@ -1943,8 +1944,11 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject pread(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length, IRubyObject _offset) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
         RubyInteger fromInteger = toInteger(context, _from);
-        RubyInteger lengthInteger = toInteger(context, _length);
         RubyInteger offsetInteger = toInteger(context, _offset);
+        int offset = extractOffset(context, offsetInteger);
+        int length = toInteger(context, _length).asInt(context);
+        if (length == 0) length = size - offset;
+        RubyInteger lengthInteger = asFixnum(context, length);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPRead(context, scheduler, io, this, fromInteger, lengthInteger, offsetInteger);
@@ -1952,8 +1956,6 @@ public class RubyIOBuffer extends RubyObject {
         }
 
         int from = toInt(context, fromInteger);
-        int offset = extractOffset(context, offsetInteger);
-        int length = extractLength(context, lengthInteger, offset);
 
         return pread(context, RubyIO.convertToIO(context, io), from, length, offset);
     }
@@ -2122,7 +2124,10 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject pwrite(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
         RubyInteger fromInteger = toInteger(context, _from);
-        RubyInteger lengthInteger = toInteger(context, _length);
+        int offset = 0;
+        int length = toInteger(context, _length).asInt(context);
+        if (length == 0) length = size;
+        RubyInteger lengthInteger = asFixnum(context, length);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPWrite(context, scheduler, io, this, fromInteger, lengthInteger, RubyFixnum.zero(context.runtime));
@@ -2130,8 +2135,6 @@ public class RubyIOBuffer extends RubyObject {
         }
 
         int from = toInt(context, fromInteger);
-        int offset = 0;
-        int length = extractLength(context, lengthInteger, offset);
 
         return pwrite(context, RubyIO.convertToIO(context, io), from, length, offset);
     }
@@ -2155,8 +2158,11 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject pwrite(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length, IRubyObject _offset) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
         RubyInteger fromInteger = toInteger(context, _from);
-        RubyInteger lengthInteger = toInteger(context, _length);
         RubyInteger offsetInteger = toInteger(context, _offset);
+        int offset = extractOffset(context, offsetInteger);
+        int length = toInteger(context, _length).asInt(context);
+        if (length == 0) length = size - offset;
+        RubyInteger lengthInteger = asFixnum(context, length);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPWrite(context, scheduler, io, this, fromInteger, lengthInteger, offsetInteger);
@@ -2164,8 +2170,6 @@ public class RubyIOBuffer extends RubyObject {
         }
 
         int from = toInt(context, fromInteger);
-        int offset = extractOffset(context, offsetInteger);
-        int length = extractLength(context, lengthInteger, offset);
 
         return pwrite(context, RubyIO.convertToIO(context, io), from, length, offset);
     }

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1514,7 +1514,7 @@ public class OpenFile implements Finalizable {
         if (fptr.fiberScheduler) {
             IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
             if (!scheduler.isNil()) {
-                IRubyObject result = FiberScheduler.ioReadMemory(context, scheduler, fptr.io, buffer, buf, count);
+                IRubyObject result = FiberScheduler.ioReadMemory(context, scheduler, fptr.io, buffer, count, 0);
 
                 if (result != null) {
                     return FiberScheduler.resultApply(context, result);
@@ -2522,7 +2522,7 @@ public class OpenFile implements Finalizable {
         if (fptr.fiberScheduler) {
             IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
             if (!scheduler.isNil()) {
-                IRubyObject result = FiberScheduler.ioWriteMemory(context, scheduler, fptr.io, bufBytes, buf, count);
+                IRubyObject result = FiberScheduler.ioWriteMemory(context, scheduler, fptr.io, bufBytes, count, 0);
 
                 if (result != null) {
                     return FiberScheduler.resultApply(context, result);

--- a/spec/ruby/core/io/buffer/pread_spec.rb
+++ b/spec/ruby/core/io/buffer/pread_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#pread" do
+  before :each do
+    @path = tmp("io_buffer_pread.txt")
+    touch(@path) { |f| f.write "Hello" }
+
+    @file = File.open(@path, "rb")
+    @buffer = IO::Buffer.new(5)
+  end
+
+  after :each do
+    @file.close
+    rm_r @path
+  end
+
+  it "reads into the whole buffer when no length is given" do
+    @buffer.pread(@file, 0).should == 5
+    @buffer.get_string.should == "Hello"
+  end
+
+  it "reads only the given length, starting at the given offset" do
+    @buffer.pread(@file, 0, 4, 1).should == 4
+    @buffer.get_string(1, 4).should == "Hell"
+  end
+
+  it "treats a length of 0 as the rest of the buffer" do
+    @buffer.pread(@file, 0, 0).should == 5
+    @buffer.get_string.should == "Hello"
+  end
+
+  it "treats a length of 0 as the rest of the buffer after the offset" do
+    @buffer.pread(@file, 0, 0, 1).should == 4
+    @buffer.get_string(1, 4).should == "Hell"
+  end
+end

--- a/spec/ruby/core/io/buffer/pwrite_spec.rb
+++ b/spec/ruby/core/io/buffer/pwrite_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#pwrite" do
+  before :each do
+    @path = tmp("io_buffer_pwrite.txt")
+
+    @file = File.open(@path, "wb+")
+    @buffer = IO::Buffer.new(5)
+    @buffer.set_string("Hello")
+  end
+
+  after :each do
+    @file.close
+    rm_r @path
+  end
+
+  it "writes the whole buffer when no length is given" do
+    @buffer.pwrite(@file, 0).should == 5
+    File.binread(@path).should == "Hello"
+  end
+
+  it "writes only the given length, starting at the given offset" do
+    @buffer.pwrite(@file, 0, 4, 1).should == 4
+    File.binread(@path).should == "ello"
+  end
+
+  it "treats a length of 0 as the rest of the buffer" do
+    @buffer.pwrite(@file, 0, 0).should == 5
+    File.binread(@path).should == "Hello"
+  end
+
+  it "treats a length of 0 as the rest of the buffer after the offset" do
+    @buffer.pwrite(@file, 0, 0, 1).should == 4
+    File.binread(@path).should == "ello"
+  end
+end

--- a/spec/ruby/core/io/buffer/read_spec.rb
+++ b/spec/ruby/core/io/buffer/read_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../../../spec_helper'
+require 'socket'
+require 'io/nonblock'
+
+describe "IO::Buffer#read" do
+  before :each do
+    @path = tmp("io_buffer_read.txt")
+    touch(@path) { |f| f.write "Hello" }
+
+    @file = File.open(@path, "rb")
+    @buffer = IO::Buffer.new(5)
+  end
+
+  after :each do
+    @file.close
+    rm_r @path
+  end
+
+  it "reads into the whole buffer when no length is given" do
+    @buffer.read(@file).should == 5
+    @buffer.get_string.should == "Hello"
+  end
+
+  it "reads only the given length, starting at the given offset" do
+    @buffer.read(@file, 4, 1).should == 4
+    @buffer.get_string(1, 4).should == "Hell"
+  end
+
+  it "treats a length of 0 as the rest of the buffer" do
+    @buffer.read(@file, 0).should == 5
+    @buffer.get_string.should == "Hello"
+  end
+
+  it "treats a length of 0 as the rest of the buffer after the offset" do
+    @buffer.read(@file, 0, 1).should == 4
+    @buffer.get_string(1, 4).should == "Hell"
+  end
+
+  platform_is_not :windows do
+    it "returns the negated errno when the read would block" do
+      r, w = UNIXSocket.pair
+      begin
+        r.nonblock = true
+        @buffer.read(r, 5, 0).should == -Errno::EAGAIN::Errno
+      ensure
+        r.close
+        w.close
+      end
+    end
+  end
+end

--- a/test/mri/excludes/TestFiberIOBuffer.rb
+++ b/test/mri/excludes/TestFiberIOBuffer.rb
@@ -1,5 +1,4 @@
 exclude :test_read_nonblock, "wrong return value, should be :wait_readable"
 exclude :test_read_write_blocking, "hangs on macos m1"
 exclude :test_timeout_after, "hangs on macos m1 probably because timeout is not implemented"
-exclude :test_io_buffer_read_write, "incorrect designation of internal vs readonly buffer"
 exclude :test_io_buffer_pread_pwrite, "uses Tempfile but does not require the library"

--- a/test/mri/excludes/TestFiberIOBuffer.rb
+++ b/test/mri/excludes/TestFiberIOBuffer.rb
@@ -1,4 +1,3 @@
-exclude :test_read_nonblock, "wrong return value, should be :wait_readable"
 exclude :test_read_write_blocking, "hangs on macos m1"
 exclude :test_timeout_after, "hangs on macos m1 probably because timeout is not implemented"
 exclude :test_io_buffer_pread_pwrite, "uses Tempfile but does not require the library"


### PR DESCRIPTION
Three small bug fixes on the Fiber scheduler's IO path:

`FiberScheduler.result` returned a positive errno, so a scheduler comparing against `-Errno::EAGAIN::Errno` read it as a byte count instead of a wait. `IO::Buffer.new(64).read(io, 64, 0)` on a drained non-blocking socket gives `35` on master, `-35` here and on CRuby.

A length of `0` means the remaining capacity, but `IO::Buffer#pread` and `#pwrite` transferred nothing. #9628 fixed `#read` and `#write`.

`OpenFile` passed `ioReadMemory`/`ioWriteMemory` the array offset as the buffer size and the byte count as the minimum transfer length, so `io_read` got a zero-size buffer and a minimum it could never reach.

I added the new specs under `spec/ruby/core/io/buffer/` like #9628. Removes 2 excludes from `test/mri/excludes/TestFiberIOBuffer.rb`. 