### PR TITLE
Consider encoding in ByteList equality

### DIFF
--- a/core/src/main/java/org/jruby/util/ByteList.java
+++ b/core/src/main/java/org/jruby/util/ByteList.java
@@ -959,7 +959,7 @@ public class ByteList implements Comparable, CharSequence, Serializable {
     @Override
     public boolean equals(Object other) {
         if (other == this) return true;
-        if (other instanceof ByteList) return equal((ByteList)other);
+        if (other instanceof ByteList bl) return equal(bl);
         return false;
     }
 
@@ -976,6 +976,8 @@ public class ByteList implements Comparable, CharSequence, Serializable {
         if (hash != 0 && otherHash != 0 && hash != otherHash) return false;
         int realSize = this.realSize;
         if (realSize != other.realSize) return false;
+        Encoding encoding = this.encoding;
+        if (!encoding.equals(other.encoding)) return false;
 
         int first;
         int last = realSize;


### PR DESCRIPTION
Two ByteLists may have exactly the same bytes, but not the same encoding. Such ByteLists have been treated as equals() but we have frequently run into bugs from this behavior. This PR finally adds encoding to the conditions required for ByteList equality.