### PR TITLE
Run pager commands through the platform shell

### DIFF
--- a/core/src/main/java/org/jruby/main/Main.java
+++ b/core/src/main/java/org/jruby/main/Main.java
@@ -471,12 +471,12 @@ public class Main {
             // non-null only if both STDIN and STDOUT are tty.
             boolean tty = System.console() != null;
 
-            if (rubyPager == null) {
+            if (!tty || rubyPager == null) {
                 config.getOutput().print(OutputStrings.getBasicUsageHelp(tty));
                 config.getOutput().print(OutputStrings.getFeaturesHelp(tty));
             } else {
                 try {
-                    ProcessBuilder builder = new ProcessBuilder(rubyPager);
+                    ProcessBuilder builder = new ProcessBuilder(pagerCommand(rubyPager));
                     builder.environment().put("LESS", "-R");
 
                     builder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
@@ -504,6 +504,12 @@ public class Main {
             rubyPager = System.getenv("PAGER");
 
         return rubyPager;
+    }
+
+    static String[] pagerCommand(String pager) {
+        if (Platform.IS_WINDOWS) return new String[] { "cmd.exe", "/c", pager };
+
+        return new String[] { "/bin/sh", "-c", pager };
     }
 
     private void doShowCopyright() {
@@ -586,4 +592,3 @@ public class Main {
 
     private final RubyInstanceConfig config;
 }
-

--- a/core/src/test/java/org/jruby/main/MainTest.java
+++ b/core/src/test/java/org/jruby/main/MainTest.java
@@ -1,0 +1,25 @@
+package org.jruby.main;
+
+import java.util.Arrays;
+
+import junit.framework.TestCase;
+
+import org.jruby.platform.Platform;
+
+public class MainTest extends TestCase {
+    public void testPagerCommandPreservesOptions() {
+        String pager = "less -RSs";
+
+        if (Platform.IS_WINDOWS) {
+            assertEquals(Arrays.asList("cmd.exe", "/c", pager), Arrays.asList(Main.pagerCommand(pager)));
+        } else {
+            assertEquals(Arrays.asList("/bin/sh", "-c", pager), Arrays.asList(Main.pagerCommand(pager)));
+        }
+    }
+
+    public void testPagerCommandPreservesQuotedExecutable() {
+        String pager = "'/path with spaces/less' -R";
+
+        assertEquals(pager, Main.pagerCommand(pager)[2]);
+    }
+}


### PR DESCRIPTION
Pager environment variables may contain options or quoted executable paths, so execute them through the platform shell.

Fixes #9026