### PR TITLE
Mutex Deadlock fix: Track the fiber that owns a Mutex

### DIFF
--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -57,6 +57,8 @@ public class Mutex extends RubyObject implements DataType {
      * thread.
      */
     volatile RubyThread lockingThread;
+    /** The fiber within {@link #lockingThread} that currently holds the lock. */
+    volatile IRubyObject lockingFiber;
 
     @JRubyMethod(name = "new", rest = true, meta = true)
     public static Mutex newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
@@ -94,7 +96,10 @@ public class Mutex extends RubyObject implements DataType {
         }
         boolean locked = context.getThread().tryLock(lock);
 
-        if (locked) this.lockingThread = context.getThread();
+        if (locked) {
+            this.lockingThread = context.getFiberCurrentThread();
+            this.lockingFiber = context.getFiber();
+        }
 
         return locked;
     }
@@ -106,8 +111,7 @@ public class Mutex extends RubyObject implements DataType {
 
         checkRelocking(context);
 
-        RubyThread lockingThread = this.lockingThread;
-        if (lockingThread == parentThread && context.getFiber() != lockingThread.getContext().getFiber()) {
+        if (this.lockingThread == parentThread && this.lockingFiber != context.getFiber()) {
             throw context.runtime.newThreadError("deadlock; lock already owned by another fiber belonging to the same thread");
         }
 
@@ -135,8 +139,9 @@ public class Mutex extends RubyObject implements DataType {
             Helpers.throwException(t);
         }
 
-        // set locking thread once successfully locked with no interrupts
+        // set locking thread and fiber once successfully locked with no interrupts
         this.lockingThread = parentThread;
+        this.lockingFiber = context.getFiber();
 
         return this;
     }
@@ -152,6 +157,7 @@ public class Mutex extends RubyObject implements DataType {
 
         boolean hasQueued = lock.hasQueuedThreads();
         this.lockingThread = null;
+        this.lockingFiber = null;
         context.getThread().unlock(lock);
         return hasQueued ? context.nil : this;
     }

--- a/test/mri/excludes/TestFiberMutex.rb
+++ b/test/mri/excludes/TestFiberMutex.rb
@@ -1,5 +1,4 @@
 exclude :test_condition_variable, "hangs on macos m1"
-exclude :test_mutex_deadlock, "subprocess times out probably not raising deadlock error"
 exclude :test_mutex_fiber_raise, "hangs on macos m1"
 exclude :test_mutex_interleaved_locking, "Thread::Mutex#lock does not defer to Fiber::Scheduler, so a fiber sleeping under the lock blocks its siblings"
 exclude :test_queue, "Thread::Queue#pop does not defer to Fiber::Scheduler, so it blocks the thread that has to run the scheduler"


### PR DESCRIPTION
The `Mutex` deadlock check asked the owning thread's `ThreadContext` which fiber it was currently running. That answer is only right while the root fiber holds the lock. The reverse case is a fiber holding the lock while the root fiber tries to take it. There the check never fires, and `Mutex#lock` blocks forever instead of raising ThreadError. Store the owning fiber on the mutex instead.

Unexcludes `TestFiberMutex#test_mutex_deadlock`.

Sample code: 
```ruby
m = Mutex.new
f = Fiber.new { m.lock; Fiber.yield }
f.resume
m.lock
```
Master: hangs
This branch: `ThreadError: deadlock; lock already owned by another fiber belonging to the same thread`