### PR TITLE
Don't raise EBADF closing an IO whose channel NIO already closed

### DIFF
--- a/core/src/main/java/org/jruby/util/io/ChannelFD.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelFD.java
@@ -136,12 +136,7 @@ public class ChannelFD implements Closeable {
                 throw new ClosedChannelException();
             }
 
-            // if channel is already closed, we're no longer valid
-            if (!ch.isOpen()) {
-                throw new ClosedChannelException();
-            }
-
-            // otherwise decrement and possibly close as normal
+            // decrement and possibly close as normal
             int count = refs.decrementAndGet();
 
             if (count <= 0) {


### PR DESCRIPTION
This is a fix for the flaky `TestNetHTTP_v1_2#test_s_get_response` and might close #9614.

java.nio closes an `InterruptibleChannel` itself when the thread blocked on it gets interrupted. After a `Thread#kill` lands during a blocking read or write the channel is shut but JRuby's ChannelFD is not, so `IO#close` still walked into `ChannelFD.finish`, found `!ch.isOpen()`, and threw `ClosedChannelException`, which maps to `Errno::EBADF`. 

The throw also skipped refs.decrementAndGet() and the finally that unregisters the fileno, leaving a refcount of 1 and a stale fileno map entry behind until that descriptor number got reused.

Channel.close does nothing on an already closed channel, and a real double close still trips the refs <= 0 check above, so drop the test.

Test script: 

```ruby
require 'socket'
server = TCPServer.new('127.0.0.1', 0)

err = nil
t = Thread.new do
  s = server.accept
  s.write("x"*100_000_000)
rescue
ensure
  puts "PROBE: s = #{s.class}"
  begin
    s&.close
  rescue => e
    err = e
    raise
  end
end

client = TCPSocket.new('127.0.0.1', server.addr[1])
sleep 1
t.kill
puts "t.join   => #{(t.join rescue "RAISED #{$!.class}").inspect}"
puts "captured => #{err ? "#{err.class}: #{err}" : 'nothing'}"
```

Master:
```
PROBE: s = TCPSocket
warning: thread "Ruby-0-Thread-1: (irb):6" terminated with exception (report_on_exception is true):Errno::EBADF: Bad file descriptor - No message available close at org/jruby/RubyIO.java:2352
  evaluate at (irb):13
t.join   => "RAISED Errno::EBADF"
captured => Errno::EBADF: Bad file descriptor - No message available
```

CRuby and patch:
```
PROBE: s = TCPSocket
t.join   => #<Thread:0x0000000122f83338 (irb):5 dead>
captured => nothing
```