### PR TITLE
Update SetupAnt to v7

### DIFF
--- a/.github/workflows/dist-verification-ci.yml
+++ b/.github/workflows/dist-verification-ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: build release artifacts
         run: |
           ./mvnw -ntp clean package -Pall
-      - uses: cedx/SetupAnt@v6
+      - uses: cedx/SetupAnt@v7
       - name: install dependencies
         run: bin/jruby -S bundle install
       - name: cache release artifacts


### PR DESCRIPTION
Recent failures in CI were likely due to Apache server issues, but might as well get up to latest SetupAnt anyway.