### PR TITLE
Do not NPE when a fiber terminates without a resumer

### DIFF
--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -504,6 +504,25 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         return true;
     }
     
+    // MRI: return_fiber. A fiber entered via Fiber#transfer terminates without a resumer, so there is
+    // nobody in prev to hand control back to; fall back to the thread's root fiber. Returns null if the
+    // parent thread is already gone and there is nobody left to notify.
+    private static ThreadFiber returnFiber(FiberData data) {
+        ThreadFiber prev = data.prev;
+        if (prev != null) return prev;
+
+        ThreadContext parentContext = data.parent.getContext();
+        if (parentContext == null) return null;
+
+        return parentContext.getRootFiber();
+    }
+
+    // Hand a result back to the fiber that should regain control, if it is still around.
+    private static void pushToReturnFiber(ThreadContext context, FiberData data, FiberRequest request) {
+        ThreadFiber returnFiber = returnFiber(data);
+        if (returnFiber != null) returnFiber.data.queue.push(context, request);
+    }
+
     static RubyThread createThread(ThreadContext context, final FiberData data, final FiberQueue queue, final Block block) {
         final AtomicReference<RubyThread> fiberThread = new AtomicReference();
 
@@ -547,7 +566,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
                             ThreadFiber tf = data.fiber.get();
                             if (tf != null) tf.thread = null;
 
-                            data.prev.data.queue.push(ctxt, result);
+                            pushToReturnFiber(ctxt, data, result);
                         } finally {
                             // Ensure we do everything for shutdown now
                             data.queue.shutdown();

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -397,6 +397,10 @@ public final class ThreadContext {
         this.symToGuards = context.symToGuards;
     }
 
+    public ThreadFiber getRootFiber() {
+        return rootFiber;
+    }
+
     public void setRootFiber(ThreadFiber rootFiber) {
         this.rootFiber = rootFiber;
     }


### PR DESCRIPTION
A fiber entered via `Fiber#transfer` can reach the end of its block with `FiberData.prev` still null, and the fiber thread body dereferenced it unconditionally when handing the result back:

```java
data.prev.data.queue.push(ctxt, result);
```

Follow-up in a second PR makes `returnFiber()` actually match MRI's semantics, which is what un-excludes `test_terminate_transferred_fiber`.