### PR TITLE
[ji] resolve Java super <init> through included modules

### DIFF
--- a/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
+++ b/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jruby.Ruby;
+import org.jruby.RubyArray;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyClass.ConcreteJavaReifier;
@@ -971,8 +972,11 @@ public abstract class RealClassGenerator {
                 m.ldc("super.<init>");
                 m.swap();
                 m.getfield(p(SplitCtorData.class), "rbarguments", ci(IRubyObject[].class));
+                m.getstatic(cjr.javaPath, cjr.RUBY_FIELD, ci(Ruby.class));
+                m.swap();
+                m.invokestatic(p(RubyArray.class), "newArrayMayCopy", sig(RubyArray.class, Ruby.class, IRubyObject[].class));
                 m.invokevirtual(p(Ruby.class), "newNoMethodError",
-                        sig(RaiseException.class, String.class, String.class, IRubyObject[].class));
+                        sig(RaiseException.class, String.class, String.class, IRubyObject.class));
                 m.athrow();
 
                 // case n:

--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -546,7 +546,7 @@ public class ConcreteJavaProxy extends JavaProxy {
         }
 
         // jcreate is for nested ruby classes from a java class
-        if (shouldSplitJavaConstructorInitialize(plan.isLateral, fromRubySuper, plan.methodSource) && air != null) {
+        if (shouldSplitJavaConstructorInitialize(plan, fromRubySuper) && air != null) {
             if (plan.canSkipDirectSuper(args)) {
                 return splitSuperInitialized(plan, args, block, jcc);
             }
@@ -589,25 +589,32 @@ public class ConcreteJavaProxy extends JavaProxy {
     }
 
     private SplitCtorData splitSuperInitialized(final SplitCtorPlan plan, final IRubyObject[] args,
-                                               final Block block, final ConstructorCache jcc) {
-        RubyClass next = nextRubyConstructorSource(plan.effectiveSource, jcc);
+                                                final Block block, final ConstructorCache cache) {
+        RubyClass next = nextRubyConstructorSource(plan, cache);
 
-        if (next == null) return new SplitCtorData(getRuntime(), args, jcc);
-        if (!next.getDelegate().getJavaProxy()) return new SplitCtorData(getRuntime(), args, null);
+        if (next == null) return new SplitCtorData(getRuntime(), args, cache);
+        if (!next.getDelegate().getJavaProxy() && !next.isIncluded() && !next.isPrepended()) {
+            // an intermediate Ruby class: bubble the forwarded args up to its reified parent
+            return new SplitCtorData(getRuntime(), args, null);
+        }
 
-        return splitInitialized(plan.superPlan(next), args, block, jcc, true);
+        return splitInitialized(plan.superPlan(next), args, block, cache, true);
     }
 
-    private static RubyClass nextRubyConstructorSource(final RubyModule methodSource, final ConstructorCache jcc) {
-        if (jcc == null || methodSource.getDelegate().getJavaProxy()) return null;
+    private static RubyClass nextRubyConstructorSource(final SplitCtorPlan plan, final ConstructorCache cache) {
+        if (cache == null || plan.effectiveSource.getDelegate().getJavaProxy()) return null;
 
-        return methodSource.getMethodLocation().getSuperClass();
+        RubyClass superClass = plan.effectiveSource.getMethodLocation().getSuperClass();
+        // skip over included/prepended modules that don't define the constructor method
+        while (superClass != null && !superClass.getDelegate().getJavaProxy() && superClass.getMethods().get(plan.name) == null) {
+            superClass = superClass.getSuperClass();
+        }
+        return superClass;
     }
 
-    private static boolean shouldSplitJavaConstructorInitialize(final boolean isLateral,
-                                                               final boolean fromRubySuper,
-                                                               final RubyModule methodSource) {
-        return isLateral || (fromRubySuper && methodSource.getDelegate().getJavaProxy());
+    private static boolean shouldSplitJavaConstructorInitialize(final SplitCtorPlan plan,
+                                                                final boolean fromRubySuper) {
+        return plan.isLateral || (fromRubySuper && plan.methodSource.getDelegate().getJavaProxy());
     }
 
     private static boolean isPrependedJavaCtorWrapper(final RubyClass methodSource, final RubyClass klass) {

--- a/spec/java_integration/methods/inheritance_variants_spec.rb
+++ b/spec/java_integration/methods/inheritance_variants_spec.rb
@@ -288,6 +288,71 @@ describe "Java subclassing - constructor argument variants" do
     end
   end
 
+  describe "module inclusion (Ruby subclass includes a module)" do
+    it "constructs when an included module does not define initialize (GH-9655)" do
+      cls = Class.new(MultiCtorBase) do
+        include Enumerable
+        def initialize; super(7); end
+      end
+      obj = cls.new
+      expect(obj.ctor).to eq("(int)")
+      expect(obj.trace.to_a).to eq(["Java (int) ctor with 7"])
+    end
+
+    it "constructs with a no-arg super through an included module without initialize" do
+      mod = Module.new { def size; 42; end }
+      cls = Class.new(MultiCtorBase) do
+        include mod
+        def initialize; super(); end
+      end
+      expect(cls.new.ctor).to eq("()")
+    end
+
+    # NOTE: older JRuby silently skipped an included module's initialize here
+    it "runs an included module's initialize between the class and the Java ctor" do
+      mod = Module.new do
+        attr_reader :mod_marker
+        def initialize(s)
+          super(s)
+          @mod_marker = "mod-#{s}"
+        end
+      end
+      cls = Class.new(MultiCtorBase) do
+        include mod
+        attr_reader :cls_marker
+        def initialize(s)
+          super(s)
+          @cls_marker = "cls-#{s}"
+        end
+      end
+
+      obj = cls.new("x")
+      expect(obj.ctor).to eq("(String)")
+      expect(obj.mod_marker).to eq("mod-x")
+      expect(obj.cls_marker).to eq("cls-x")
+      expect(obj.trace.to_a).to eq(["Java (String) ctor with x"])
+    end
+
+    it "forwards args through an included module's direct super" do
+      mod = Module.new { def initialize(*args); super(*args); end }
+      cls = Class.new(MultiCtorBase) do
+        include mod
+        def initialize(*args); super(*args); end
+      end
+      expect(cls.new("hi").ctor).to eq("(String)")
+      expect(cls.new(7).ctor).to eq("(int)")
+    end
+
+    it "constructs when a module without initialize is prepended" do
+      mod = Module.new { def size; 42; end }
+      cls = Class.new(MultiCtorBase) do
+        prepend mod
+        def initialize; super(); end
+      end
+      expect(cls.new.ctor).to eq("()")
+    end
+  end
+
   describe "blocks (terminal super shouldn't break when a block is passed)" do
     it "ignores a passed block (no Java ctor accepts one)" do
       cls = Class.new(MultiCtorBase) { def initialize; super("blockless"); end }


### PR DESCRIPTION

the second commit - fallback branch in the generated code is hard to test, since it's being handled up to stack. just poked manually (revering the first commit) and got:

```
NoMethodError: No available java superconstructors match that type signature
  <main> at repro.rb:9
```