### PR TITLE
Preserve incoming callInfo when forwarding arguments

### DIFF
--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.jruby.api.Warn.warning;
 import static org.jruby.ir.IRFlags.*;
@@ -67,6 +68,7 @@ import static org.jruby.runtime.CallType.FUNCTIONAL;
 import static org.jruby.runtime.CallType.NORMAL;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD_REST;
+import static org.jruby.runtime.ThreadContext.CALL_FORWARDING;
 import static org.jruby.util.RubyStringBuilder.str;
 
 public abstract class IRBuilder<U, V, W, X, Y, Z> {
@@ -86,6 +88,9 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
     public boolean underscoreVariableSeen = false;
     int lastProcessedLineNum = -1;
     private Variable currentModuleVariable = null;
+
+    // Used for forwarding callInfo in argument-forwarding methods
+    protected Variable forwardingCallInfo;
 
     // FIXME: AST does not use this but Prism does.  AST could put encoding up to RootNode since it is same
     protected Encoding encoding;
@@ -2803,20 +2808,30 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         int[] flags = new int[] { 0 };
         Operand[] args = setupCallArgs(argsNode, flags);
 
+        // propagate callInfo when forwarding arguments
+        if (forwardingCallInfo != null) flags[0] = CALL_FORWARDING;
+
         determineIfWeNeedLineNumber(line, isNewline, false, false); // backtrace needs line of call in case of exception.
         if ((flags[0] & CALL_KEYWORD_REST) != 0) {  // {**k}, {**{}, **k}, etc...
             Variable test = addResultInstr(new RuntimeHelperCall(temp(), IS_HASH_EMPTY, new Operand[] { args[args.length - 1] }));
             if_else(test, tru(),
                     () -> receiveBreakException(block,
-                            determineSuperInstr(result, removeArg(args), block, flags[0], inClassBody, isInstanceMethod)),
+                            determineSuperInstr(result, removeArg(args), block, forwardingCallInfo, flags[0], inClassBody, isInstanceMethod)),
                     () -> receiveBreakException(block,
-                            determineSuperInstr(result, args, block, flags[0], inClassBody, isInstanceMethod)));
+                            determineSuperInstr(result, args, block, forwardingCallInfo, flags[0], inClassBody, isInstanceMethod)));
         } else {
             receiveBreakException(block,
-                    determineSuperInstr(result, args, block, flags[0], inClassBody, isInstanceMethod));
+                    determineSuperInstr(result, args, block, forwardingCallInfo, flags[0], inClassBody, isInstanceMethod));
         }
 
         return result;
+    }
+
+    private CallInstr forwardCallInfo(Operand forwardingCallInfo, Supplier<CallInstr> operandToWrap) {
+        if (forwardingCallInfo != null) {
+            addInstr(new RuntimeHelperCall(temp(), RESTORE_CALL_INFO, new Operand[] { forwardingCallInfo }));
+        }
+        return operandToWrap.get();
     }
 
     protected Operand buildUndef(Operand name) {
@@ -2914,13 +2929,13 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
             Variable test = addResultInstr(new RuntimeHelperCall(temp(), IS_HASH_EMPTY, new Operand[] { keywordRest }));
             if_else(test, tru(),
                     () -> receiveBreakException(block,
-                            determineSuperInstr(zsuperResult, args, block, flags[0], inClassBody, isInstanceMethod)),
+                            determineSuperInstr(zsuperResult, args, block, null, flags[0], inClassBody, isInstanceMethod)),
                     () -> receiveBreakException(block,
-                            determineSuperInstr(zsuperResult, addArg(args, keywordRest), block, flags[0], inClassBody, isInstanceMethod)));
+                            determineSuperInstr(zsuperResult, addArg(args, keywordRest), block, null, flags[0], inClassBody, isInstanceMethod)));
         } else {
             Operand[] args = getZSuperCallOperands(scope, callArgs, keywordArgs, flags);
             receiveBreakException(block,
-                    determineSuperInstr(zsuperResult, args, block, flags[0], inClassBody, isInstanceMethod));
+                    determineSuperInstr(zsuperResult, args, block, null, flags[0], inClassBody, isInstanceMethod));
         }
 
         return zsuperResult;
@@ -3154,19 +3169,23 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         // check for refinement calls before building any closure
         if (callType == FUNCTIONAL) determineIfMaybeRefined(name, args);
         Operand block = setupCallClosure(argsNode, iter);
+
+        // propagate callInfo when forwarding arguments
+        if (forwardingCallInfo != null) flags[0] = CALL_FORWARDING;
+
         determineIfWeNeedLineNumber(line, isNewline, false, false); // backtrace needs line of call in case of exception.
         if ((flags[0] & CALL_KEYWORD_REST) != 0) {  // {**k}, {**{}, **k}, etc...
             Variable test = addResultInstr(new RuntimeHelperCall(temp(), IS_HASH_EMPTY, new Operand[] { args[args.length - 1] }));
             if_else(test, tru(),
                     () -> receiveBreakException(block,
-                            CallInstr.create(scope, callType, result, name, receiver, removeArg(args), block, flags[0])),
+                            forwardCallInfo(forwardingCallInfo, () -> CallInstr.create(scope, callType, result, name, receiver, removeArg(args), block, flags[0]))),
                     () -> receiveBreakException(block,
-                            CallInstr.create(scope, callType, result, name, receiver, args, block, flags[0])));
+                            forwardCallInfo(forwardingCallInfo, () -> CallInstr.create(scope, callType, result, name, receiver, args, block, flags[0]))));
         } else {
             if (callType == FUNCTIONAL) checkForOptimizableDefineMethod(name, iter, block);
 
             receiveBreakException(block,
-                    CallInstr.create(scope, callType, result, name, receiver, args, block, flags[0]));
+                    forwardCallInfo(forwardingCallInfo, () -> CallInstr.create(scope, callType, result, name, receiver, args, block, flags[0])));
         }
 
         return result;
@@ -3205,18 +3224,19 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         if (refinement) scope.setIsMaybeUsingRefinements();
     }
 
-    protected CallInstr determineSuperInstr(Variable result, Operand[] args, Operand block, int flags,
-                                          boolean inClassBody, boolean isInstanceMethod) {
-        if (result == null) result = temp();
-        return inClassBody ?
-                isInstanceMethod ?
-                        new InstanceSuperInstr(scope, result, getCurrentModuleVariable(), getName(), args, block, flags, scope.maybeUsingRefinements()) :
-                        new ClassSuperInstr(scope, result, getCurrentModuleVariable(), getName(), args, block, flags, scope.maybeUsingRefinements()) :
-                // We dont always know the method name we are going to be invoking if the super occurs in a closure.
-                // This is because the super can be part of a block that will be used by 'define_method' to define
-                // a new method.  In that case, the method called by super will be determined by the 'name' argument
-                // to 'define_method'.
-                new UnresolvedSuperInstr(scope, result, buildSelf(), args, block, flags, scope.maybeUsingRefinements());
+    protected CallInstr determineSuperInstr(Variable result, Operand[] args, Operand block, Operand forwardingCallInfo,
+                                            int flags, boolean inClassBody, boolean isInstanceMethod) {
+        final Variable result2 = result == null ? temp() : result;
+        return forwardCallInfo(forwardingCallInfo, () ->
+                inClassBody ?
+                        isInstanceMethod ?
+                                new InstanceSuperInstr(scope, result2, getCurrentModuleVariable(), getName(), args, block, flags, scope.maybeUsingRefinements()) :
+                                new ClassSuperInstr(scope, result2, getCurrentModuleVariable(), getName(), args, block, flags, scope.maybeUsingRefinements()) :
+                        // We dont always know the method name we are going to be invoking if the super occurs in a closure.
+                        // This is because the super can be part of a block that will be used by 'define_method' to define
+                        // a new method.  In that case, the method called by super will be determined by the 'name' argument
+                        // to 'define_method'.
+                        new UnresolvedSuperInstr(scope, result2, buildSelf(), args, block, flags, scope.maybeUsingRefinements()));
     }
 
     protected Operand findContainerModule() {

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -1973,6 +1973,12 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
     public void receiveArgs(final ArgsNode argsNode) {
         Signature signature = scope.getStaticScope().getSignature();
 
+        // If the method is forwarding arguments, preserve callInfo for later use.
+        if (scope instanceof IRMethod && scope.getStaticScope().exists(CommonByteLists.FWD_ALL.toString()) >= 0) {
+            forwardingCallInfo = temp();
+            addInstr(new RuntimeHelperCall(forwardingCallInfo, CAPTURE_CALL_INFO, Operand.EMPTY_ARRAY));
+        }
+
         Variable keywords = addResultInstr(new ReceiveKeywordsInstr(temp(), signature.hasRest(), argsNode.hasKwargs()));
 
         KeywordRestArgNode keyRest = argsNode.getKeyRest();

--- a/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
+++ b/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
@@ -34,7 +34,7 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
         IS_DEFINED_BACKREF, IS_DEFINED_NTH_REF, IS_DEFINED_GLOBAL,
         IS_DEFINED_CLASS_VAR, IS_DEFINED_SUPER, IS_DEFINED_METHOD, IS_DEFINED_CALL,
         IS_DEFINED_CONSTANT_OR_METHOD, MERGE_KWARGS, IS_HASH_EMPTY, HASH_CHECK, ARRAY_LENGTH,
-        TRACE_RESCUE, RESET_GVAR_UNDERSCORE;
+        TRACE_RESCUE, RESET_GVAR_UNDERSCORE, CAPTURE_CALL_INFO, RESTORE_CALL_INFO;
 
         private static final Methods[] VALUES = values();
 
@@ -108,6 +108,8 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
 
         // These have special operands[0] that we may not want to execute
         switch (helperMethod) {
+            case CAPTURE_CALL_INFO:
+                return IRRuntimeHelpers.captureCallInfo(context);
             case RESET_GVAR_UNDERSCORE:
                 return context.setErrorInfo((IRubyObject) operands[0].retrieve(context, self, currScope, currDynScope, temp));
             case IS_DEFINED_BACKREF:
@@ -127,6 +129,8 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
             case TRACE_RESCUE:
                 IRRuntimeHelpers.traceRescue(context, ((Stringable) operands[0]).getString(), (int) ((Integer) operands[1]).getValue());
                 return context.nil;
+            case RESTORE_CALL_INFO:
+                return IRRuntimeHelpers.restoreCallInfo(context, (IRubyObject) operands[0].retrieve(context, self, currScope, currDynScope, temp));
         }
 
         Object arg1 = operands[0].retrieve(context, self, currScope, currDynScope, temp);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -961,6 +961,10 @@ public class IRRuntimeHelpers {
 
     @JIT @Interp
     public static void setCallInfo(ThreadContext context, int flags) {
+        // Forwarding args set callInfo elsewhere based on the incoming call structure.
+        // We leave them as-is and return.
+        if ((flags & CALL_FORWARDING) != 0) return;
+
         // CALL_KEYWORD_EMPTY is set dynamically while building this call's arguments (argsPush,
         // isHashEmpty, irSplat) when a keyword-rest or splat turns out to be empty, and it must
         // survive into the call so the callee treats the kwargs as explicitly empty. It is only
@@ -974,6 +978,17 @@ public class IRRuntimeHelpers {
         } else {
             context.callInfo = flags;
         }
+    }
+
+    @JIT @Interp
+    public static RubyFixnum captureCallInfo(ThreadContext context) {
+        return context.runtime.newFixnum(context.callInfo);
+    }
+
+    @JIT @Interp
+    public static IRubyObject restoreCallInfo(ThreadContext context, IRubyObject callInfo) {
+        context.callInfo = (int) ((RubyFixnum) callInfo).getValue();
+        return callInfo;
     }
 
     public static void checkForExtraUnwantedKeywordArgs(ThreadContext context, final StaticScope scope, RubyHash keywordArgs) {

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2395,6 +2395,17 @@ public class JVMVisitor extends IRVisitor {
     @Override
     public void RuntimeHelperCall(RuntimeHelperCall runtimehelpercall) {
         switch (runtimehelpercall.getHelperMethod()) {
+            case CAPTURE_CALL_INFO:
+                jvmMethod().loadContext();
+                jvmMethod().invokeIRHelper("captureCallInfo", sig(RubyFixnum.class, ThreadContext.class));
+                jvmStoreLocal(runtimehelpercall.getResult());
+                break;
+            case RESTORE_CALL_INFO:
+                jvmMethod().loadContext();
+                visit(runtimehelpercall.getArgs()[0]);
+                jvmMethod().invokeIRHelper("restoreCallInfo", sig(IRubyObject.class, ThreadContext.class, IRubyObject.class));
+                jvmStoreLocal(runtimehelpercall.getResult());
+                break;
             case RESET_GVAR_UNDERSCORE:
                 jvmMethod().loadContext();
                 visit(runtimehelpercall.getArgs()[0]);

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -142,6 +142,8 @@ public final class ThreadContext {
     // generally live detected info at a callsite that we are passing an empty hash as kwrest.
     // it is also statically determined by literal **{} (which is only found in test suites).
     public final static int CALL_KEYWORD_EMPTY = 1 << 3;
+    // The callInfo for this call has been restored from an enclosing forwarding argument list.
+    public final static int CALL_FORWARDING =    1 << 4;
 
     public int callInfo;
 

--- a/spec/ruby/language/delegation_spec.rb
+++ b/spec/ruby/language/delegation_spec.rb
@@ -73,6 +73,24 @@ describe "delegation with def(...)" do
     h2 = a.new.delegate(h)
     h2.should.equal?(h)
   end
+
+  it "preserves positional arguments when forwarding to super" do
+    forwarding = Module.new
+    forwarding.module_eval(<<-RUBY)
+      def initialize(...)
+        super(...)
+      end
+    RUBY
+
+    prepended = included = nil
+    -> {
+      prepended = Struct.new(:a, :b, :c) { prepend forwarding }.new(1, 2, 3)
+      included = Struct.new(:a, :b, :c) { include forwarding }.new(1, 2, 3)
+    }.should_not complain
+
+    [prepended.a, prepended.b, prepended.c].should == [1, 2, 3]
+    [included.a, included.b, included.c].should == [1, 2, 3]
+  end
 end
 
 describe "delegation with def(x, ...)" do


### PR DESCRIPTION
This is a hack to fix argument forwarding when callInfo must be passed along.

The original callInfo is captured at the top of the method and used to pre-load a callInfo before later calls that forward arguments. A new keyword flag CALL_FORWARDING is added to specify that the already-prepared callInfo should be left as-is. This allows the downstream calls to see the incoming arguments and callInfo metadata largely as they were first received.

It is hacky for a number of reasons:

* The new CALL_FORWARDING argument is just a hack to say "don't set callInfo because I already set it. A better pattern would be to build this intelligence into call/super handling.
* This likely doesn't work properly with the Prism parser and will require additional patches there.
* In both cases, introducing new IR instructions that specifically know how to handle forwarding would mean better optimization and fewer fragile hacks.

This patch works well enough to pass the cases from jruby/jruy#9328 but I'm dubious as to whether the fix is worth the hack.

Generated in part by GPT 5.6 but heavily refactored to remove excess complexity.