### PR TITLE
Close and unlink to avoid finalization doing anything

### DIFF
--- a/test/jruby/compiler/test_jrubyc.rb
+++ b/test/jruby/compiler/test_jrubyc.rb
@@ -26,8 +26,8 @@ class TestJRubyc < Test::Unit::TestCase
     $stdout.reopen(@old_stdout) if @old_stdout
     $stderr.reopen(@old_stderr) if @old_stderr
 
-    @tempfile_stdout.close rescue nil
-    @tempfile_stderr.close rescue nil
+    @tempfile_stdout.close! rescue nil
+    @tempfile_stderr.close! rescue nil
 
     $compile_test = nil; $encoding = nil
   end


### PR DESCRIPTION
In jruby/jruby#9642 I added closing to this logic, but unless the file is unlinked the Tempfile library will still log it.