### PR TITLE
Bump the amount of memory for baseline CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: JRuby CI
 on: [push, pull_request]
 
 env:
-  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx1G -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
+  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx2g -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
 
 permissions:
   contents: read

--- a/.github/workflows/dist-verification-ci.yml
+++ b/.github/workflows/dist-verification-ci.yml
@@ -10,7 +10,7 @@ on:
 
 
 env:
-  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx1G -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
+  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx2g -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-snapshot-publish-21.yml
+++ b/.github/workflows/nightly-snapshot-publish-21.yml
@@ -5,7 +5,7 @@ on:
     - cron: '30 6 * * *'
 
 env:
-  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx1G -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
+  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx2g -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-snapshot-publish.yml
+++ b/.github/workflows/nightly-snapshot-publish.yml
@@ -5,7 +5,7 @@ on:
     - cron: '30 6 * * *'
 
 env:
-  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx1G -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
+  JAVA_OPTS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx2g -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M'
 
 permissions:
   contents: read


### PR DESCRIPTION
1GB should be enough for most jobs, but as more dependencies have crept in and test suites have gotten larger, it sometimes fails. Bump the default max heap size up to 1GB.

Note that most test jobs specify their own sizes. This limit has only been noted to affect some larger bundles and third-party suites.